### PR TITLE
Add grammar to FSA conversion workflow

### DIFF
--- a/lib/core/algorithms.dart
+++ b/lib/core/algorithms.dart
@@ -6,6 +6,7 @@ export 'algorithms/fa_to_regex_converter.dart';
 export 'algorithms/nfa_to_dfa_converter.dart';
 export 'algorithms/regex_to_nfa_converter.dart';
 export 'algorithms/grammar_to_pda_converter.dart';
+export 'algorithms/grammar_to_fsa_converter.dart';
 export 'algorithms/grammar_parser.dart';
 export 'algorithms/pda_simulator.dart';
 export 'algorithms/pumping_lemma_game.dart';

--- a/lib/core/algorithms/grammar_to_fsa_converter.dart
+++ b/lib/core/algorithms/grammar_to_fsa_converter.dart
@@ -1,0 +1,251 @@
+import 'dart:math' as math;
+
+import 'package:vector_math/vector_math_64.dart';
+
+import '../models/fsa.dart';
+import '../models/fsa_transition.dart';
+import '../models/grammar.dart';
+import '../models/state.dart';
+import '../result.dart';
+
+/// Converter that builds a finite automaton from a right-linear grammar.
+class GrammarToFSAConverter {
+  /// Converts a right-linear grammar into an equivalent FSA.
+  ///
+  /// The converter supports productions of the form A → aB, A → a and
+  /// A → ε. It validates that the grammar respects these constraints and
+  /// emits a descriptive error otherwise.
+  static Result<FSA> convert(Grammar grammar) {
+    final validationError = _validateGrammar(grammar);
+    if (validationError != null) {
+      return ResultFactory.failure(validationError);
+    }
+
+    final nonTerminalList = grammar.nonterminals.toList();
+    final statePositions = _computeStatePositions(
+      nonTerminalList.length + (_needsFinalState(grammar) ? 1 : 0),
+    );
+
+    final stateMap = <String, State>{};
+    final states = <State>{};
+
+    for (var i = 0; i < nonTerminalList.length; i++) {
+      final symbol = nonTerminalList[i];
+      final isStart = symbol == grammar.startSymbol;
+      final state = State(
+        id: symbol,
+        label: symbol,
+        position: statePositions[i],
+        isInitial: isStart,
+        isAccepting: false,
+      );
+      stateMap[symbol] = state;
+      states.add(state);
+    }
+
+    final transitions = <FSATransition>{};
+    final requiresFinalState = _needsFinalState(grammar);
+    State? finalState;
+    if (requiresFinalState) {
+      final finalPosition = statePositions.isEmpty
+          ? Vector2.zero()
+          : statePositions.last;
+      finalState = State(
+        id: '${grammar.id}_ACCEPT',
+        label: 'F',
+        position: finalPosition,
+        isAccepting: true,
+      );
+      states.add(finalState);
+    }
+
+    var transitionCounter = 0;
+
+    for (final production in grammar.productions) {
+      final fromSymbol = production.leftSide.first;
+      final originalFromState = stateMap[fromSymbol];
+      if (originalFromState == null) {
+        continue;
+      }
+
+      // Handle lambda/epsilon productions by marking the source state as
+      // accepting.
+      if (production.isLambda || production.rightSide.isEmpty) {
+        final acceptingState = originalFromState.copyWith(isAccepting: true);
+        states
+          ..remove(originalFromState)
+          ..add(acceptingState);
+        stateMap[fromSymbol] = acceptingState;
+        continue;
+      }
+
+      final rightSide = production.rightSide;
+      final inputSymbol = rightSide.first;
+      if (_isLambdaSymbol(inputSymbol)) {
+        final acceptingState = originalFromState.copyWith(isAccepting: true);
+        states
+          ..remove(originalFromState)
+          ..add(acceptingState);
+        stateMap[fromSymbol] = acceptingState;
+        continue;
+      }
+
+      State targetState;
+      if (rightSide.length == 1) {
+        if (finalState != null) {
+          targetState = finalState;
+        } else {
+          final acceptingState = originalFromState.copyWith(isAccepting: true);
+          states
+            ..remove(originalFromState)
+            ..add(acceptingState);
+          stateMap[fromSymbol] = acceptingState;
+          targetState = acceptingState;
+        }
+      } else {
+        final nextSymbol = rightSide.last;
+        final mappedTarget = stateMap[nextSymbol];
+        if (mappedTarget == null) {
+          return ResultFactory.failure(
+            'Production ${production.id} references undefined non-terminal $nextSymbol.',
+          );
+        }
+        targetState = mappedTarget;
+      }
+
+      final updatedFromState = stateMap[fromSymbol]!;
+      transitionCounter += 1;
+      transitions.add(
+        FSATransition(
+          id: 't$transitionCounter',
+          fromState: updatedFromState,
+          toState: targetState,
+          label: inputSymbol,
+          inputSymbols: {inputSymbol},
+        ),
+      );
+    }
+
+    final acceptingStates = states.where((s) => s.isAccepting).toSet();
+    final alphabet = grammar.terminals
+        .where((symbol) => !_isLambdaSymbol(symbol))
+        .toSet();
+
+    final now = DateTime.now();
+    final automaton = FSA(
+      id: 'fsa_from_${grammar.id}',
+      name: '${grammar.name} (Automaton)',
+      states: states,
+      transitions: transitions,
+      alphabet: alphabet,
+      initialState: stateMap[grammar.startSymbol],
+      acceptingStates: acceptingStates,
+      created: now,
+      modified: now,
+      bounds: const math.Rectangle(0, 0, 800, 600),
+    );
+
+    return ResultFactory.success(automaton);
+  }
+
+  static String? _validateGrammar(Grammar grammar) {
+    if (grammar.productions.isEmpty) {
+      return 'Grammar must contain at least one production rule.';
+    }
+
+    for (final production in grammar.productions) {
+      if (production.leftSide.length != 1) {
+        return 'Production ${production.id} must have exactly one non-terminal on the left side.';
+      }
+
+      final leftSymbol = production.leftSide.first;
+      if (!grammar.nonterminals.contains(leftSymbol)) {
+        return 'Production ${production.id} uses unknown non-terminal $leftSymbol.';
+      }
+
+      if (production.isLambda || production.rightSide.isEmpty) {
+        continue;
+      }
+
+      if (production.rightSide.length > 2) {
+        return 'Production ${production.id} is not right-linear (too many symbols on the right side).';
+      }
+
+      final firstSymbol = production.rightSide.first;
+      if (_isLambdaSymbol(firstSymbol)) {
+        continue;
+      }
+
+      if (!_isTerminalSymbol(firstSymbol, grammar)) {
+        return 'Production ${production.id} must start with a terminal symbol.';
+      }
+
+      if (production.rightSide.length == 2) {
+        final secondSymbol = production.rightSide.last;
+        if (!grammar.nonterminals.contains(secondSymbol)) {
+          return 'Production ${production.id} must end with a non-terminal symbol.';
+        }
+      } else if (grammar.nonterminals.contains(firstSymbol)) {
+        return 'Production ${production.id} cannot produce only a non-terminal in a right-linear grammar.';
+      }
+    }
+
+    return null;
+  }
+
+  static bool _needsFinalState(Grammar grammar) {
+    return grammar.productions.any((production) {
+      if (production.isLambda || production.rightSide.isEmpty) {
+        return false;
+      }
+      if (production.rightSide.length == 1) {
+        final symbol = production.rightSide.first;
+        return !_isLambdaSymbol(symbol) && !grammar.nonterminals.contains(symbol);
+      }
+      return false;
+    });
+  }
+
+  static bool _isLambdaSymbol(String symbol) {
+    return symbol == 'ε' || symbol == 'λ' || symbol.toLowerCase() == 'lambda';
+  }
+
+  static bool _isTerminalSymbol(String symbol, Grammar grammar) {
+    if (_isLambdaSymbol(symbol)) {
+      return false;
+    }
+    if (grammar.terminals.contains(symbol)) {
+      return true;
+    }
+    // Fallback heuristic: uppercase denotes non-terminals.
+    final uppercaseRegex = RegExp(r'^[A-Z]$');
+    return !uppercaseRegex.hasMatch(symbol);
+  }
+
+  static List<Vector2> _computeStatePositions(int count) {
+    if (count <= 0) {
+      return const [];
+    }
+
+    if (count == 1) {
+      return [Vector2(400, 300)];
+    }
+
+    final positions = <Vector2>[];
+    const radius = 180.0;
+    const centerX = 400.0;
+    const centerY = 300.0;
+
+    for (var i = 0; i < count; i++) {
+      final angle = (2 * math.pi * i) / count;
+      positions.add(
+        Vector2(
+          centerX + radius * math.cos(angle),
+          centerY + radius * math.sin(angle),
+        ),
+      );
+    }
+
+    return positions;
+  }
+}

--- a/lib/data/services/conversion_service.dart
+++ b/lib/data/services/conversion_service.dart
@@ -6,6 +6,7 @@ import '../../core/algorithms/dfa_minimizer.dart';
 import '../../core/algorithms/regex_to_nfa_converter.dart';
 import '../../core/algorithms/fa_to_regex_converter.dart';
 import '../../core/algorithms/grammar_to_pda_converter.dart';
+import '../../core/algorithms/grammar_to_fsa_converter.dart';
 
 /// Service for automaton conversion operations
 class ConversionService {
@@ -148,6 +149,26 @@ class ConversionService {
       return ResultFactory.failure('Error converting grammar to PDA (Greibach): $e');
     }
   }
+
+  /// Converts a right-linear grammar to a finite automaton
+  Result<FSA> convertGrammarToFsa(ConversionRequest request) {
+    try {
+      if (request.grammar == null) {
+        return ResultFactory.failure('Grammar is required');
+      }
+
+      if (request.conversionType != ConversionType.grammarToFsa) {
+        return ResultFactory.failure(
+          'Invalid conversion type for grammar to automaton conversion',
+        );
+      }
+
+      final result = GrammarToFSAConverter.convert(request.grammar!);
+      return result;
+    } catch (e) {
+      return ResultFactory.failure('Error converting grammar to automaton: $e');
+    }
+  }
 }
 
 /// Request for conversion operations
@@ -219,6 +240,14 @@ class ConversionRequest {
       conversionType: ConversionType.grammarToPdaGreibach,
     );
   }
+
+  /// Creates a conversion request for grammar to FSA
+  factory ConversionRequest.grammarToFsa({required Grammar grammar}) {
+    return ConversionRequest(
+      grammar: grammar,
+      conversionType: ConversionType.grammarToFsa,
+    );
+  }
 }
 
 /// Types of conversions supported
@@ -230,6 +259,7 @@ enum ConversionType {
   grammarToPda,
   grammarToPdaStandard,
   grammarToPdaGreibach,
+  grammarToFsa,
 }
 
 /// Extension on ConversionType for better usability
@@ -250,6 +280,8 @@ extension ConversionTypeExtension on ConversionType {
         return 'Grammar to PDA (Standard)';
       case ConversionType.grammarToPdaGreibach:
         return 'Grammar to PDA (Greibach)';
+      case ConversionType.grammarToFsa:
+        return 'Grammar to FSA';
     }
   }
 }

--- a/lib/presentation/providers/grammar_provider.dart
+++ b/lib/presentation/providers/grammar_provider.dart
@@ -1,0 +1,230 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/fsa.dart';
+import '../../core/models/grammar.dart';
+import '../../core/models/production.dart';
+import '../../core/result.dart';
+import '../../data/services/conversion_service.dart';
+
+/// State for managing grammar editing and conversions.
+class GrammarState {
+  final String name;
+  final String startSymbol;
+  final List<Production> productions;
+  final GrammarType type;
+  final bool isConverting;
+  final String? error;
+  final int nextProductionId;
+
+  const GrammarState({
+    required this.name,
+    required this.startSymbol,
+    required this.productions,
+    required this.type,
+    required this.isConverting,
+    required this.nextProductionId,
+    this.error,
+  });
+
+  factory GrammarState.initial() {
+    return const GrammarState(
+      name: 'My Grammar',
+      startSymbol: 'S',
+      productions: [],
+      type: GrammarType.regular,
+      isConverting: false,
+      nextProductionId: 1,
+    );
+  }
+
+  GrammarState copyWith({
+    String? name,
+    String? startSymbol,
+    List<Production>? productions,
+    GrammarType? type,
+    bool? isConverting,
+    Object? error = _noErrorUpdate,
+    int? nextProductionId,
+  }) {
+    return GrammarState(
+      name: name ?? this.name,
+      startSymbol: startSymbol ?? this.startSymbol,
+      productions: productions ?? this.productions,
+      type: type ?? this.type,
+      isConverting: isConverting ?? this.isConverting,
+      error: error == _noErrorUpdate ? this.error : error as String?,
+      nextProductionId: nextProductionId ?? this.nextProductionId,
+    );
+  }
+}
+
+const _noErrorUpdate = Object();
+
+/// Provider notifier responsible for updating grammar state and running conversions.
+class GrammarProvider extends StateNotifier<GrammarState> {
+  GrammarProvider({ConversionService? conversionService})
+      : _conversionService = conversionService ?? ConversionService(),
+        super(GrammarState.initial());
+
+  final ConversionService _conversionService;
+
+  void updateName(String value) {
+    state = state.copyWith(name: value, error: null);
+  }
+
+  void updateStartSymbol(String value) {
+    if (value.isEmpty) {
+      return;
+    }
+    state = state.copyWith(startSymbol: value, error: null);
+  }
+
+  void addProduction({
+    required List<String> leftSide,
+    required List<String> rightSide,
+    bool isLambda = false,
+  }) {
+    final production = Production(
+      id: 'p${state.nextProductionId}',
+      leftSide: leftSide,
+      rightSide: rightSide,
+      isLambda: isLambda,
+      order: state.productions.length,
+    );
+
+    state = state.copyWith(
+      productions: [...state.productions, production],
+      nextProductionId: state.nextProductionId + 1,
+      error: null,
+    );
+  }
+
+  void updateProduction(
+    String id, {
+    required List<String> leftSide,
+    required List<String> rightSide,
+    bool isLambda = false,
+  }) {
+    final index = state.productions.indexWhere((p) => p.id == id);
+    if (index == -1) {
+      return;
+    }
+
+    final updated = state.productions[index].copyWith(
+      leftSide: leftSide,
+      rightSide: rightSide,
+      isLambda: isLambda,
+    );
+
+    final productions = [...state.productions];
+    productions[index] = updated;
+
+    state = state.copyWith(
+      productions: productions,
+      error: null,
+    );
+  }
+
+  void deleteProduction(String id) {
+    state = state.copyWith(
+      productions: state.productions.where((p) => p.id != id).toList(),
+      error: null,
+    );
+  }
+
+  void clearProductions() {
+    state = state.copyWith(
+      productions: const <Production>[],
+      nextProductionId: 1,
+      error: null,
+    );
+  }
+
+  void clearError() {
+    if (state.error != null) {
+      state = state.copyWith(error: null);
+    }
+  }
+
+  Grammar buildGrammar() {
+    final now = DateTime.now();
+    final nonTerminals = <String>{state.startSymbol};
+    final terminals = <String>{};
+
+    for (final production in state.productions) {
+      if (production.leftSide.isNotEmpty) {
+        nonTerminals.add(production.leftSide.first);
+      }
+    }
+
+    for (final production in state.productions) {
+      if (production.isLambda) {
+        continue;
+      }
+
+      for (final symbol in production.rightSide) {
+        if (_isLambda(symbol)) {
+          continue;
+        }
+
+        if (nonTerminals.contains(symbol) || _looksLikeNonTerminal(symbol)) {
+          nonTerminals.add(symbol);
+        } else {
+          terminals.add(symbol);
+        }
+      }
+    }
+
+    terminals.removeWhere(_isLambda);
+
+    return Grammar(
+      id: 'grammar_${now.microsecondsSinceEpoch}',
+      name: state.name,
+      terminals: terminals,
+      nonterminals: nonTerminals,
+      startSymbol: state.startSymbol,
+      productions: state.productions.toSet(),
+      type: state.type,
+      created: now,
+      modified: now,
+    );
+  }
+
+  Future<Result<FSA>> convertToAutomaton() async {
+    if (state.productions.isEmpty) {
+      return ResultFactory.failure('Add at least one production before converting.');
+    }
+
+    final grammar = buildGrammar();
+    state = state.copyWith(isConverting: true, error: null);
+
+    final result = _conversionService.convertGrammarToFsa(
+      ConversionRequest.grammarToFsa(grammar: grammar),
+    );
+
+    if (result.isSuccess) {
+      state = state.copyWith(isConverting: false, error: null);
+    } else {
+      state = state.copyWith(
+        isConverting: false,
+        error: result.error,
+      );
+    }
+
+    return result;
+  }
+
+  bool _isLambda(String symbol) =>
+      symbol == 'ε' || symbol == 'λ' || symbol.toLowerCase() == 'lambda';
+
+  bool _looksLikeNonTerminal(String symbol) {
+    final uppercaseRegex = RegExp(r'^[A-Z]$');
+    return uppercaseRegex.hasMatch(symbol);
+  }
+}
+
+/// Global grammar provider instance.
+final grammarProvider =
+    StateNotifierProvider<GrammarProvider, GrammarState>((ref) {
+  return GrammarProvider();
+});

--- a/lib/presentation/providers/home_navigation_provider.dart
+++ b/lib/presentation/providers/home_navigation_provider.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Controls navigation between the major workspaces displayed on the home page.
+class HomeNavigationNotifier extends StateNotifier<int> {
+  HomeNavigationNotifier() : super(fsaIndex);
+
+  /// Index for the Finite State Automaton workspace.
+  static const int fsaIndex = 0;
+
+  /// Index for the Grammar workspace.
+  static const int grammarIndex = 1;
+
+  /// Index for the Pushdown Automaton workspace.
+  static const int pdaIndex = 2;
+
+  /// Index for the Turing Machine workspace.
+  static const int tmIndex = 3;
+
+  /// Index for the Regular Expression workspace.
+  static const int regexIndex = 4;
+
+  /// Index for the Pumping Lemma workspace.
+  static const int pumpingLemmaIndex = 5;
+
+  /// Updates the currently visible workspace.
+  void setIndex(int index) {
+    if (index == state) {
+      return;
+    }
+    state = index;
+  }
+
+  /// Convenience method that switches to the FSA workspace.
+  void goToFsa() => setIndex(fsaIndex);
+}
+
+/// Provides the current navigation index for the home page.
+final homeNavigationProvider =
+    StateNotifierProvider<HomeNavigationNotifier, int>(
+  (ref) => HomeNavigationNotifier(),
+);


### PR DESCRIPTION
## Summary
- implement a right-linear grammar to FSA converter and expose it through the shared conversion service
- introduce a grammar state notifier so the editor can persist productions and build Grammar models correctly
- update the grammar editor and algorithm panel to drive conversion, surface errors, and open the FSA workspace with the generated automaton

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cc43043cc8832e857990069dd039a9