### PR TITLE
Implement PDA editor state and analysis tooling

### DIFF
--- a/lib/core/algorithms/pda_to_cfg_converter.dart
+++ b/lib/core/algorithms/pda_to_cfg_converter.dart
@@ -1,0 +1,83 @@
+import '../models/pda.dart';
+import '../models/pda_transition.dart';
+import '../result.dart';
+
+/// Converts a PDA into a textual description of an equivalent CFG using
+/// the standard state/stack variable construction.
+class PDAtoCFGConverter {
+  /// Converts the provided [pda] into a CFG description.
+  static Result<String> convert(PDA pda) {
+    if (pda.states.isEmpty) {
+      return Failure('Cannot convert an empty PDA to a grammar.');
+    }
+
+    if (pda.initialState == null) {
+      return Failure('PDA must define an initial state before conversion.');
+    }
+
+    if (pda.acceptingStates.isEmpty) {
+      return Failure('PDA must have at least one accepting state for conversion.');
+    }
+
+    final buffer = StringBuffer();
+    buffer.writeln('Generated CFG from PDA');
+    buffer.writeln('Non-terminals of the form [p,A,q] indicate moving from state p');
+    buffer.writeln('with stack symbol A on top to state q after consuming a string.');
+    buffer.writeln('');
+
+    // Start productions
+    buffer.writeln('Start productions:');
+    for (final accept in pda.acceptingStates) {
+      buffer.writeln(
+        '  S → [${pda.initialState!.label}, ${pda.initialStackSymbol}, ${accept.label}]',
+      );
+    }
+
+    buffer.writeln('');
+    buffer.writeln('Transition productions:');
+
+    for (final transition in pda.pdaTransitions) {
+      buffer.write(_formatTransitionProductions(pda, transition));
+    }
+
+    if (buffer.isEmpty) {
+      return Failure('No productions could be generated for this PDA.');
+    }
+
+    return Success(buffer.toString());
+  }
+
+  static String _formatTransitionProductions(
+    PDA pda,
+    PDATransition transition,
+  ) {
+    final input = transition.isLambdaInput || transition.inputSymbol.isEmpty
+        ? 'λ'
+        : transition.inputSymbol;
+    final pop = transition.isLambdaPop || transition.popSymbol.isEmpty
+        ? 'λ'
+        : transition.popSymbol;
+    final push = transition.isLambdaPush || transition.pushSymbol.isEmpty
+        ? 'λ'
+        : transition.pushSymbol;
+
+    final from = transition.fromState.label;
+    final to = transition.toState.label;
+    final buffer = StringBuffer();
+
+    if (push == 'λ') {
+      // When nothing new is pushed onto the stack we can stay in the target state
+      buffer.writeln(
+        '  [${from}, $pop, ${to}] → $input',
+      );
+    } else {
+      for (final target in pda.states) {
+        buffer.writeln(
+          '  [${from}, $pop, ${target.label}] → $input [${to}, $push, ${target.label}]',
+        );
+      }
+    }
+
+    return buffer.toString();
+  }
+}

--- a/lib/presentation/providers/pda_editor_provider.dart
+++ b/lib/presentation/providers/pda_editor_provider.dart
@@ -1,0 +1,146 @@
+import 'dart:math' as math;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../core/models/pda.dart';
+import '../../core/models/pda_transition.dart';
+import '../../core/models/state.dart';
+import '../../core/models/transition.dart';
+
+/// Holds the current PDA being edited in the canvas together with
+/// metadata used by other widgets (e.g. highlighting information).
+class PDAEditorState {
+  /// The PDA built from the canvas contents.
+  final PDA? pda;
+
+  /// Identifiers of transitions that participate in nondeterministic choices.
+  final Set<String> nondeterministicTransitionIds;
+
+  /// Identifiers of transitions that involve at least one lambda operation.
+  final Set<String> lambdaTransitionIds;
+
+  const PDAEditorState({
+    this.pda,
+    this.nondeterministicTransitionIds = const {},
+    this.lambdaTransitionIds = const {},
+  });
+
+  PDAEditorState copyWith({
+    PDA? pda,
+    Set<String>? nondeterministicTransitionIds,
+    Set<String>? lambdaTransitionIds,
+  }) {
+    return PDAEditorState(
+      pda: pda ?? this.pda,
+      nondeterministicTransitionIds:
+          nondeterministicTransitionIds ?? this.nondeterministicTransitionIds,
+      lambdaTransitionIds: lambdaTransitionIds ?? this.lambdaTransitionIds,
+    );
+  }
+}
+
+/// Riverpod notifier responsible for maintaining the PDA that is edited by
+/// the PDA canvas.
+class PDAEditorNotifier extends StateNotifier<PDAEditorState> {
+  PDAEditorNotifier() : super(const PDAEditorState());
+
+  /// Updates the notifier using the raw state and transition collections
+  /// maintained by the canvas.
+  void updateFromCanvas({
+    required List<State> states,
+    required List<PDATransition> transitions,
+  }) {
+    if (states.isEmpty) {
+      state = const PDAEditorState(pda: null);
+      return;
+    }
+
+    final stateSet = states.toSet();
+    final transitionSet = transitions.toSet();
+
+    final initialState = states.firstWhere(
+      (s) => s.isInitial,
+      orElse: () => states.first,
+    );
+
+    final acceptingStates = states.where((s) => s.isAccepting).toSet();
+
+    final alphabet = <String>{};
+    final stackAlphabet = <String>{'Z'};
+
+    for (final transition in transitionSet) {
+      if (!transition.isLambdaInput && transition.inputSymbol.isNotEmpty) {
+        alphabet.add(transition.inputSymbol);
+      }
+
+      if (!transition.isLambdaPop && transition.popSymbol.isNotEmpty) {
+        stackAlphabet.add(transition.popSymbol);
+      }
+
+      if (!transition.isLambdaPush && transition.pushSymbol.isNotEmpty) {
+        stackAlphabet.add(transition.pushSymbol);
+      }
+    }
+
+    if (stackAlphabet.isEmpty) {
+      stackAlphabet.add('Z');
+    }
+
+    final now = DateTime.now();
+
+    final pda = PDA(
+      id: 'editor-pda',
+      name: 'Canvas PDA',
+      states: stateSet,
+      transitions: transitionSet.map<Transition>((t) => t).toSet(),
+      alphabet: alphabet,
+      initialState: initialState,
+      acceptingStates: acceptingStates.isEmpty ? {states.last} : acceptingStates,
+      created: now,
+      modified: now,
+      bounds: const math.Rectangle(0, 0, 800, 600),
+      stackAlphabet: stackAlphabet,
+      initialStackSymbol: stackAlphabet.first,
+      zoomLevel: 1,
+      panOffset: Vector2.zero(),
+    );
+
+    final nondeterministicTransitionIds = _findNondeterministicTransitions(transitionSet);
+    final lambdaTransitionIds = transitionSet
+        .where((t) => t.isLambdaInput || t.isLambdaPop || t.isLambdaPush)
+        .map((t) => t.id)
+        .toSet();
+
+    state = state.copyWith(
+      pda: pda,
+      nondeterministicTransitionIds: nondeterministicTransitionIds,
+      lambdaTransitionIds: lambdaTransitionIds,
+    );
+  }
+
+  Set<String> _findNondeterministicTransitions(Set<PDATransition> transitions) {
+    final grouped = <String, List<PDATransition>>{};
+
+    for (final transition in transitions) {
+      final key = [
+        transition.fromState.id,
+        transition.isLambdaInput ? 'λ' : transition.inputSymbol,
+        transition.isLambdaPop ? 'λ' : transition.popSymbol,
+      ].join('|');
+
+      grouped.putIfAbsent(key, () => []).add(transition);
+    }
+
+    return grouped.values
+        .where((list) => list.length > 1)
+        .expand((list) => list.map((transition) => transition.id))
+        .toSet();
+  }
+}
+
+/// Provider exposing the current PDA editor state.
+final pdaEditorProvider =
+    StateNotifierProvider<PDAEditorNotifier, PDAEditorState>(
+  (ref) => PDAEditorNotifier(),
+);

--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -267,10 +267,12 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
               _addState(position);
             },
             onTransitionAdded: (transition) {
-              setState(() {
-                _transitions.add(transition);
-              });
-              _notifyAutomatonChanged();
+              if (transition is FSATransition) {
+                setState(() {
+                  _transitions.add(transition);
+                });
+                _notifyAutomatonChanged();
+              }
             },
             onStateEdited: (state) {
               _editState(state);

--- a/lib/presentation/widgets/tm_canvas.dart
+++ b/lib/presentation/widgets/tm_canvas.dart
@@ -5,6 +5,7 @@ import '../../core/models/tm.dart';
 import '../../core/models/state.dart' as automaton_state;
 import '../../core/models/tm_transition.dart';
 import '../../core/models/fsa_transition.dart';
+import '../../core/models/transition.dart';
 import 'touch_gesture_handler.dart';
 
 /// Interactive canvas for drawing and editing Turing Machines
@@ -177,7 +178,10 @@ class _TMCanvasState extends State<TMCanvas> {
     });
   }
 
-  void _addTransition(FSATransition transition) {
+  void _addTransition(Transition transition) {
+    if (transition is! FSATransition) {
+      return;
+    }
     // Convert FSA transition to TM transition
     final tmTransition = TMTransition(
       id: transition.id,
@@ -209,9 +213,9 @@ class _TMCanvasState extends State<TMCanvas> {
     });
   }
 
-  void _deleteTransition(FSATransition transition) {
+  void _deleteTransition(Transition transition) {
     setState(() {
-      _transitions.remove(transition);
+      _transitions.removeWhere((t) => t.id == transition.id);
     });
   }
 

--- a/lib/presentation/widgets/touch_gesture_handler.dart
+++ b/lib/presentation/widgets/touch_gesture_handler.dart
@@ -3,20 +3,20 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart';
 import '../../core/models/state.dart' as automaton_state;
-import '../../core/models/fsa_transition.dart';
+import '../../core/models/transition.dart';
 
 /// Comprehensive touch gesture handler for mobile automaton editing
 class TouchGestureHandler extends StatefulWidget {
   final List<automaton_state.State> states;
-  final List<FSATransition> transitions;
+  final List<Transition> transitions;
   final automaton_state.State? selectedState;
   final ValueChanged<automaton_state.State?> onStateSelected;
   final ValueChanged<automaton_state.State> onStateMoved;
   final ValueChanged<Offset> onStateAdded;
-  final ValueChanged<FSATransition> onTransitionAdded;
+  final ValueChanged<Transition> onTransitionAdded;
   final ValueChanged<automaton_state.State> onStateEdited;
   final ValueChanged<automaton_state.State> onStateDeleted;
-  final ValueChanged<FSATransition> onTransitionDeleted;
+  final ValueChanged<Transition> onTransitionDeleted;
   final Widget child;
 
   const TouchGestureHandler({
@@ -59,7 +59,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   bool _showContextMenu = false;
   Offset? _contextMenuPosition;
   automaton_state.State? _contextMenuState;
-  FSATransition? _contextMenuTransition;
+  Transition? _contextMenuTransition;
 
   @override
   void dispose() {
@@ -185,7 +185,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   }
 
   /// Finds transition at given position
-  FSATransition? _findTransitionAt(Offset position) {
+  Transition? _findTransitionAt(Offset position) {
     for (final transition in widget.transitions) {
       if (_isPointOnTransition(position, transition)) {
         return transition;
@@ -202,7 +202,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   }
 
   /// Checks if point is on a transition line
-  bool _isPointOnTransition(Offset point, FSATransition transition) {
+  bool _isPointOnTransition(Offset point, Transition transition) {
     final fromPos = Offset(transition.fromState.position.x, transition.fromState.position.y);
     final toPos = Offset(transition.toState.position.x, transition.toState.position.y);
     


### PR DESCRIPTION
## Summary
- Add a PDA editor provider so the canvas can publish the constructed automaton, detect nondeterminism/lambda transitions, and support auto-layout/editing UI.
- Hook the PDA simulation panel to the real simulator, including stack symbol configuration, step-by-step traces, and result feedback.
- Implement PDA analysis actions and CFG conversion backed by new algorithms and asynchronous result handling.

## Testing
- `dart format lib/presentation/widgets/pda_algorithm_panel.dart` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4315fd84832ea5da434fcd9f4194