### PR TITLE
Improve automaton canvas gestures and editing

### DIFF
--- a/lib/presentation/widgets/pda_canvas.dart
+++ b/lib/presentation/widgets/pda_canvas.dart
@@ -48,9 +48,9 @@ class _PDACanvasState extends State<PDACanvas> {
               ),
               child: ClipRRect(
                 borderRadius: BorderRadius.circular(8),
-                child: TouchGestureHandler(
+                child: TouchGestureHandler<PDATransition>(
                   states: _states,
-                  transitions: _transitions.cast(),
+                  transitions: _transitions,
                   selectedState: _selectedState,
                   onStateSelected: _selectState,
                   onStateMoved: _moveState,
@@ -59,6 +59,7 @@ class _PDACanvasState extends State<PDACanvas> {
                   onStateEdited: _editState,
                   onStateDeleted: _deleteState,
                   onTransitionDeleted: _deleteTransition,
+                  onTransitionEdited: _editTransition,
                   child: CustomPaint(
                     key: widget.canvasKey,
                     painter: _PDACanvasPainter(
@@ -68,6 +69,9 @@ class _PDACanvasState extends State<PDACanvas> {
                     ),
                     size: Size.infinite,
                   ),
+                  stateRadius: 25,
+                  selfLoopBaseRadius: 36,
+                  selfLoopSpacing: 10,
                 ),
               ),
             ),
@@ -159,7 +163,7 @@ class _PDACanvasState extends State<PDACanvas> {
 
   void _moveState(automaton_state.State state) {
     setState(() {
-      final index = _states.indexOf(state);
+      final index = _states.indexWhere((s) => s.id == state.id);
       if (index != -1) {
         _states[index] = state;
       }
@@ -181,20 +185,16 @@ class _PDACanvasState extends State<PDACanvas> {
     });
   }
 
-  void _addTransition(FSATransition transition) {
-    // Convert FSA transition to PDA transition
-    final pdaTransition = PDATransition(
-      id: transition.id,
-      fromState: transition.fromState,
-      toState: transition.toState,
-      label: transition.label,
-      inputSymbol: transition.label,
-      popSymbol: 'Z', // Default stack symbol
-      pushSymbol: 'Z', // Default stack symbol
+  Future<void> _addTransition(FSATransition transition) async {
+    final result = await _showTransitionDialog(
+      from: transition.fromState,
+      to: transition.toState,
     );
+    if (result == null) return;
 
     setState(() {
-      _transitions.add(pdaTransition);
+      _transitions.add(result);
+      _isAddingTransition = false;
     });
   }
 
@@ -204,8 +204,8 @@ class _PDACanvasState extends State<PDACanvas> {
 
   void _deleteState(automaton_state.State state) {
     setState(() {
-      _states.remove(state);
-      _transitions.removeWhere((t) => 
+      _states.removeWhere((s) => s.id == state.id);
+      _transitions.removeWhere((t) =>
           t.fromState == state || t.toState == state);
       if (_selectedState == state) {
         _selectedState = null;
@@ -213,9 +213,25 @@ class _PDACanvasState extends State<PDACanvas> {
     });
   }
 
-  void _deleteTransition(FSATransition transition) {
+  void _deleteTransition(PDATransition transition) {
     setState(() {
-      _transitions.remove(transition);
+      _transitions.removeWhere((t) => t.id == transition.id);
+    });
+  }
+
+  Future<void> _editTransition(PDATransition transition) async {
+    final result = await _showTransitionDialog(
+      from: transition.fromState,
+      to: transition.toState,
+      existing: transition,
+    );
+    if (result == null) return;
+
+    setState(() {
+      final index = _transitions.indexWhere((t) => t.id == transition.id);
+      if (index != -1) {
+        _transitions[index] = result.copyWith(id: transition.id);
+      }
     });
   }
 
@@ -236,13 +252,119 @@ class _PDACanvasState extends State<PDACanvas> {
         state: state,
         onStateUpdated: (updatedState) {
           setState(() {
-            final index = _states.indexOf(state);
+            final index = _states.indexWhere((s) => s.id == state.id);
             if (index != -1) {
               _states[index] = updatedState;
             }
           });
         },
       ),
+    );
+  }
+
+  Future<PDATransition?> _showTransitionDialog({
+    required automaton_state.State from,
+    required automaton_state.State to,
+    PDATransition? existing,
+  }) async {
+    final inputController = TextEditingController(text: existing?.inputSymbol ?? '');
+    final popController = TextEditingController(text: existing?.popSymbol ?? '');
+    final pushController = TextEditingController(text: existing?.pushSymbol ?? '');
+
+    final result = await showDialog<PDATransition>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text(existing == null ? 'Add Transition' : 'Edit Transition'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildDialogField(
+                controller: inputController,
+                label: 'Input Symbol (ε for lambda)',
+              ),
+              const SizedBox(height: 12),
+              _buildDialogField(
+                controller: popController,
+                label: 'Pop Symbol (ε for lambda)',
+              ),
+              const SizedBox(height: 12),
+              _buildDialogField(
+                controller: pushController,
+                label: 'Push Symbol (ε for lambda)',
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () {
+                final transition = _buildTransition(
+                  from: from,
+                  to: to,
+                  id: existing?.id ?? 't${_transitions.length + 1}',
+                  input: inputController.text.trim(),
+                  pop: popController.text.trim(),
+                  push: pushController.text.trim(),
+                );
+                Navigator.of(context).pop(transition);
+              },
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+
+    inputController.dispose();
+    popController.dispose();
+    pushController.dispose();
+    return result;
+  }
+
+  Widget _buildDialogField({
+    required TextEditingController controller,
+    required String label,
+  }) {
+    return TextField(
+      controller: controller,
+      decoration: InputDecoration(
+        labelText: label,
+        border: const OutlineInputBorder(),
+      ),
+    );
+  }
+
+  PDATransition _buildTransition({
+    required automaton_state.State from,
+    required automaton_state.State to,
+    required String id,
+    required String input,
+    required String pop,
+    required String push,
+  }) {
+    final isLambdaInput = input.isEmpty || input == 'ε';
+    final isLambdaPop = pop.isEmpty || pop == 'ε';
+    final isLambdaPush = push.isEmpty || push == 'ε';
+
+    final displayInput = isLambdaInput ? 'ε' : input;
+    final displayPop = isLambdaPop ? 'ε' : pop;
+    final displayPush = isLambdaPush ? 'ε' : push;
+
+    return PDATransition(
+      id: id,
+      fromState: from,
+      toState: to,
+      label: '$displayInput, $displayPop/$displayPush',
+      inputSymbol: isLambdaInput ? '' : input,
+      popSymbol: isLambdaPop ? '' : pop,
+      pushSymbol: isLambdaPush ? '' : push,
+      isLambdaInput: isLambdaInput,
+      isLambdaPop: isLambdaPop,
+      isLambdaPush: isLambdaPush,
     );
   }
 }
@@ -328,69 +450,63 @@ class _PDACanvasPainter extends CustomPainter {
   }
 
   void _drawTransition(Canvas canvas, PDATransition transition) {
-    final fromPos = Offset(transition.fromState.position.x, transition.fromState.position.y);
-    final toPos = Offset(transition.toState.position.x, transition.toState.position.y);
-
     final paint = Paint()
       ..color = Colors.black
       ..style = PaintingStyle.stroke
       ..strokeWidth = 2;
 
-    // Draw transition line
-    canvas.drawLine(fromPos, toPos, paint);
+    if (transition.fromState == transition.toState) {
+      _drawSelfLoop(canvas, transition, paint);
+      return;
+    }
 
-    // Draw arrow
-    _drawArrow(canvas, fromPos, toPos);
-
-    // Draw transition label
-    final midPoint = Offset(
-      (fromPos.dx + toPos.dx) / 2,
-      (fromPos.dy + toPos.dy) / 2 - 20,
+    final curve = TransitionCurve.compute(
+      transitions,
+      transition,
+      stateRadius: 25,
+      curvatureStrength: 38,
+      labelOffset: 14,
     );
 
-    final textPainter = TextPainter(
-      text: TextSpan(
-        text: '${transition.inputSymbol}, ${transition.stackPop}/${transition.stackPush}',
-        style: const TextStyle(
-          color: Colors.black,
-          fontSize: 12,
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      textDirection: TextDirection.ltr,
-    );
-    textPainter.layout();
-    textPainter.paint(
+    final path = Path()
+      ..moveTo(curve.start.dx, curve.start.dy)
+      ..quadraticBezierTo(
+        curve.control.dx,
+        curve.control.dy,
+        curve.end.dx,
+        curve.end.dy,
+      );
+    canvas.drawPath(path, paint);
+
+    _drawArrow(canvas, curve.end, curve.tangentAngle, paint);
+    _drawLabel(
       canvas,
-      Offset(
-        midPoint.dx - textPainter.width / 2,
-        midPoint.dy - textPainter.height / 2,
-      ),
+      curve.labelPosition,
+      _formatTransitionLabel(transition),
     );
   }
 
-  void _drawArrow(Canvas canvas, Offset from, Offset to) {
-    final angle = math.atan2(to.dy - from.dy, to.dx - from.dx);
+  void _drawArrow(
+    Canvas canvas,
+    Offset position,
+    double angle,
+    Paint paint,
+  ) {
     const arrowLength = 15.0;
     const arrowAngle = math.pi / 6;
 
     final arrow1 = Offset(
-      to.dx - arrowLength * math.cos(angle - arrowAngle),
-      to.dy - arrowLength * math.sin(angle - arrowAngle),
+      position.dx - arrowLength * math.cos(angle - arrowAngle),
+      position.dy - arrowLength * math.sin(angle - arrowAngle),
     );
 
     final arrow2 = Offset(
-      to.dx - arrowLength * math.cos(angle + arrowAngle),
-      to.dy - arrowLength * math.sin(angle + arrowAngle),
+      position.dx - arrowLength * math.cos(angle + arrowAngle),
+      position.dy - arrowLength * math.sin(angle + arrowAngle),
     );
 
-    final paint = Paint()
-      ..color = Colors.black
-      ..style = PaintingStyle.stroke
-      ..strokeWidth = 2;
-
-    canvas.drawLine(to, arrow1, paint);
-    canvas.drawLine(to, arrow2, paint);
+    canvas.drawLine(position, arrow1, paint);
+    canvas.drawLine(position, arrow2, paint);
   }
 
   void _drawInitialArrow(Canvas canvas, Offset center) {
@@ -403,7 +519,80 @@ class _PDACanvasPainter extends CustomPainter {
       ..strokeWidth = 3;
 
     canvas.drawLine(arrowStart, arrowEnd, paint);
-    _drawArrow(canvas, arrowStart, arrowEnd);
+    final angle = math.atan2(arrowEnd.dy - arrowStart.dy, arrowEnd.dx - arrowStart.dx);
+    _drawArrow(canvas, arrowEnd, angle, paint);
+  }
+
+  void _drawSelfLoop(Canvas canvas, PDATransition transition, Paint paint) {
+    final center = Offset(
+      transition.fromState.position.x,
+      transition.fromState.position.y,
+    );
+
+    const baseRadius = 36.0;
+    const spacing = 10.0;
+
+    final loops = transitions
+        .where((t) => t.fromState.id == transition.fromState.id && t.fromState == t.toState)
+        .toList();
+    final index = loops.indexOf(transition);
+    final radius = baseRadius + index * spacing;
+
+    final rect = Rect.fromCircle(
+      center: Offset(center.dx, center.dy - radius),
+      radius: radius,
+    );
+
+    const startAngle = 1.1 * math.pi;
+    const sweepAngle = 1.6 * math.pi;
+    final path = Path()..addArc(rect, startAngle, sweepAngle);
+    canvas.drawPath(path, paint);
+
+    final endAngle = startAngle + sweepAngle;
+    final arrowPoint = Offset(
+      rect.center.dx + rect.width / 2 * math.cos(endAngle),
+      rect.center.dy + rect.height / 2 * math.sin(endAngle),
+    );
+    _drawArrow(canvas, arrowPoint, endAngle + math.pi / 2, paint);
+
+    final labelPosition = Offset(
+      rect.center.dx,
+      rect.top - 12,
+    );
+    _drawLabel(
+      canvas,
+      labelPosition,
+      _formatTransitionLabel(transition),
+    );
+  }
+
+  void _drawLabel(Canvas canvas, Offset position, String text) {
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: text,
+        style: const TextStyle(
+          color: Colors.black,
+          fontSize: 12,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    );
+    textPainter.layout();
+    textPainter.paint(
+      canvas,
+      Offset(
+        position.dx - textPainter.width / 2,
+        position.dy - textPainter.height / 2,
+      ),
+    );
+  }
+
+  String _formatTransitionLabel(PDATransition transition) {
+    final input = transition.isLambdaInput ? 'ε' : transition.inputSymbol;
+    final pop = transition.isLambdaPop ? 'ε' : transition.popSymbol;
+    final push = transition.isLambdaPush ? 'ε' : transition.pushSymbol;
+    return '$input, $pop/$push';
   }
 
   @override

--- a/lib/presentation/widgets/touch_gesture_handler.dart
+++ b/lib/presentation/widgets/touch_gesture_handler.dart
@@ -3,21 +3,26 @@ import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart';
 import '../../core/models/state.dart' as automaton_state;
-import '../../core/models/fsa_transition.dart';
+import '../../core/models/transition.dart';
+import 'transition_geometry.dart';
 
 /// Comprehensive touch gesture handler for mobile automaton editing
-class TouchGestureHandler extends StatefulWidget {
+class TouchGestureHandler<T extends Transition> extends StatefulWidget {
   final List<automaton_state.State> states;
-  final List<FSATransition> transitions;
+  final List<T> transitions;
   final automaton_state.State? selectedState;
   final ValueChanged<automaton_state.State?> onStateSelected;
   final ValueChanged<automaton_state.State> onStateMoved;
   final ValueChanged<Offset> onStateAdded;
-  final ValueChanged<FSATransition> onTransitionAdded;
+  final ValueChanged<T> onTransitionAdded;
   final ValueChanged<automaton_state.State> onStateEdited;
   final ValueChanged<automaton_state.State> onStateDeleted;
-  final ValueChanged<FSATransition> onTransitionDeleted;
+  final ValueChanged<T> onTransitionDeleted;
+  final ValueChanged<T> onTransitionEdited;
   final Widget child;
+  final double stateRadius;
+  final double selfLoopBaseRadius;
+  final double selfLoopSpacing;
 
   const TouchGestureHandler({
     super.key,
@@ -31,26 +36,35 @@ class TouchGestureHandler extends StatefulWidget {
     required this.onStateEdited,
     required this.onStateDeleted,
     required this.onTransitionDeleted,
+    required this.onTransitionEdited,
     required this.child,
+    this.stateRadius = 30,
+    this.selfLoopBaseRadius = 40,
+    this.selfLoopSpacing = 12,
   });
 
   @override
-  State<TouchGestureHandler> createState() => _TouchGestureHandlerState();
+  State<TouchGestureHandler<T>> createState() => _TouchGestureHandlerState<T>();
 }
 
-class _TouchGestureHandlerState extends State<TouchGestureHandler> {
+class _TouchGestureHandlerState<T extends Transition>
+    extends State<TouchGestureHandler<T>> {
   // Gesture state
   automaton_state.State? _draggedState;
   Offset? _dragStartPosition;
+  Offset? _dragStartCanvasPosition;
   bool _isDragging = false;
   bool _isZooming = false;
   double _scale = 1.0;
+  double _initialScale = 1.0;
   Offset _panOffset = Offset.zero;
-  
+  Offset _initialPanOffset = Offset.zero;
+  bool _isPanning = false;
+
   // Long press handling
   Timer? _longPressTimer;
   Offset? _longPressPosition;
-  
+
   // Double tap handling
   DateTime? _lastTapTime;
   Offset? _lastTapPosition;
@@ -59,7 +73,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   bool _showContextMenu = false;
   Offset? _contextMenuPosition;
   automaton_state.State? _contextMenuState;
-  FSATransition? _contextMenuTransition;
+  T? _contextMenuTransition;
 
   @override
   void dispose() {
@@ -67,27 +81,37 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
     super.dispose();
   }
 
+  /// Converts a local position (affected by current pan/zoom) to canvas coordinates
+  Offset _toCanvasCoordinates(Offset position) {
+    final translated = position - _panOffset;
+    if (_scale == 0) {
+      return translated;
+    }
+    return Offset(translated.dx / _scale, translated.dy / _scale);
+  }
+
   /// Handles tap gestures
   void _handleTap(TapDownDetails details) {
     final position = details.localPosition;
+    final canvasPosition = _toCanvasCoordinates(position);
     final now = DateTime.now();
-    
+
     // Check for double tap
-    if (_lastTapTime != null && 
+    if (_lastTapTime != null &&
         now.difference(_lastTapTime!).inMilliseconds < 300 &&
         _lastTapPosition != null &&
         (position - _lastTapPosition!).distance < 20) {
-      _handleDoubleTap(position);
+      _handleDoubleTap(position, canvasPosition);
       return;
     }
-    
+
     _lastTapTime = now;
     _lastTapPosition = position;
-    
+
     // Find state or transition at tap position
-    final state = _findStateAt(position);
-    final transition = _findTransitionAt(position);
-    
+    final state = _findStateAt(canvasPosition);
+    final transition = _findTransitionAt(canvasPosition);
+
     if (state != null) {
       widget.onStateSelected(state);
     } else if (transition != null) {
@@ -100,10 +124,16 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   }
 
   /// Handles double tap for editing
-  void _handleDoubleTap(Offset position) {
-    final state = _findStateAt(position);
+  void _handleDoubleTap(Offset localPosition, Offset canvasPosition) {
+    final state = _findStateAt(canvasPosition);
     if (state != null) {
       widget.onStateEdited(state);
+      return;
+    }
+
+    final transition = _findTransitionAt(canvasPosition);
+    if (transition != null) {
+      widget.onTransitionEdited(transition);
     }
   }
 
@@ -122,9 +152,10 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
 
   /// Shows context menu at position
   void _showContextMenuAt(Offset position) {
-    final state = _findStateAt(position);
-    final transition = _findTransitionAt(position);
-    
+    final canvasPosition = _toCanvasCoordinates(position);
+    final state = _findStateAt(canvasPosition);
+    final transition = _findTransitionAt(canvasPosition);
+
     setState(() {
       _showContextMenu = true;
       _contextMenuPosition = position;
@@ -137,15 +168,27 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   /// Handles scale start for zooming and panning
   void _handleScaleStart(ScaleStartDetails details) {
     _isZooming = true;
-    
+
     // Check if this is a single finger drag (pan)
     if (details.pointerCount == 1) {
-      final state = _findStateAt(details.localFocalPoint);
+      final canvasPoint = _toCanvasCoordinates(details.localFocalPoint);
+      final state = _findStateAt(canvasPoint);
       if (state != null) {
         _draggedState = state;
         _dragStartPosition = details.localFocalPoint;
+        _dragStartCanvasPosition = Offset(state.position.x, state.position.y);
         _isDragging = true;
+        _isPanning = false;
       }
+      if (!_isDragging) {
+        _isPanning = true;
+        _draggedState = null;
+        _dragStartPosition = details.localFocalPoint;
+      }
+    } else {
+      _initialScale = _scale;
+      _initialPanOffset = _panOffset;
+      _isPanning = false;
     }
   }
 
@@ -153,15 +196,22 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   void _handleScaleUpdate(ScaleUpdateDetails details) {
     if (_isDragging && _draggedState != null && details.pointerCount == 1) {
       // Handle single finger drag
-      final newPosition = _dragStartPosition! + details.focalPointDelta;
+      final deltaLocal = details.localFocalPoint - _dragStartPosition!;
+      final deltaCanvas = Offset(deltaLocal.dx / _scale, deltaLocal.dy / _scale);
+      final startCanvas = _dragStartCanvasPosition!;
+      final newPosition = startCanvas + deltaCanvas;
       widget.onStateMoved(_draggedState!.copyWith(
         position: Vector2(newPosition.dx, newPosition.dy),
       ));
+    } else if (_isPanning && details.pointerCount == 1) {
+      setState(() {
+        _panOffset += details.focalPointDelta;
+      });
     } else if (details.pointerCount > 1) {
       // Handle multi-finger zoom and pan
       setState(() {
-        _scale = math.max(0.5, math.min(3.0, _scale * details.scale));
-        _panOffset += details.focalPointDelta;
+        _scale = math.max(0.5, math.min(3.0, _initialScale * details.scale));
+        _panOffset = _initialPanOffset + details.focalPointDelta;
       });
     }
   }
@@ -170,8 +220,10 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   void _handleScaleEnd(ScaleEndDetails details) {
     _isZooming = false;
     _isDragging = false;
+    _isPanning = false;
     _draggedState = null;
     _dragStartPosition = null;
+    _dragStartCanvasPosition = null;
   }
 
   /// Finds state at given position
@@ -185,7 +237,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   }
 
   /// Finds transition at given position
-  FSATransition? _findTransitionAt(Offset position) {
+  T? _findTransitionAt(Offset position) {
     for (final transition in widget.transitions) {
       if (_isPointOnTransition(position, transition)) {
         return transition;
@@ -198,25 +250,79 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
   bool _isPointInState(Offset point, automaton_state.State state) {
     final statePosition = Offset(state.position.x, state.position.y);
     final distance = (point - statePosition).distance;
-    return distance <= 30; // State radius
+    return distance <= widget.stateRadius;
   }
 
   /// Checks if point is on a transition line
-  bool _isPointOnTransition(Offset point, FSATransition transition) {
-    final fromPos = Offset(transition.fromState.position.x, transition.fromState.position.y);
-    final toPos = Offset(transition.toState.position.x, transition.toState.position.y);
-    
-    // Calculate distance from point to line
-    final lineLength = (toPos - fromPos).distance;
-    if (lineLength == 0) return false;
-    
-    final pointToFrom = point - fromPos;
-    final fromToTo = toPos - fromPos;
-    final t = (pointToFrom.dx * fromToTo.dx + pointToFrom.dy * fromToTo.dy) / (lineLength * lineLength);
-    final tClamped = t.clamp(0.0, 1.0);
-    final closestPoint = fromPos + (toPos - fromPos) * tClamped;
-    
-    return (point - closestPoint).distance <= 10; // Transition line thickness
+  bool _isPointOnTransition(Offset point, T transition) {
+    if (transition.fromState == transition.toState) {
+      return _isPointOnSelfLoop(point, transition);
+    }
+
+    final curve = TransitionCurve.compute(
+      widget.transitions,
+      transition,
+      stateRadius: widget.stateRadius,
+      curvatureStrength: 45,
+      labelOffset: 12,
+    );
+
+    return _distanceToQuadratic(point, curve.start, curve.control, curve.end) <= 18;
+  }
+
+  bool _isPointOnSelfLoop(Offset point, T transition) {
+    final center = Offset(
+      transition.fromState.position.x,
+      transition.fromState.position.y,
+    );
+    final loops = widget.transitions
+        .where((t) => t.fromState.id == transition.fromState.id && t.fromState == t.toState)
+        .toList();
+    final index = loops.indexOf(transition);
+    final radius = widget.selfLoopBaseRadius + index * widget.selfLoopSpacing;
+    final loopCenter = Offset(center.dx, center.dy - radius);
+
+    final distance = (point - loopCenter).distance;
+    if ((distance - radius).abs() > 18) {
+      return false;
+    }
+
+    final angle = math.atan2(point.dy - loopCenter.dy, point.dx - loopCenter.dx);
+    final normalized = _normalizeAngle(angle);
+    final start = _normalizeAngle(1.1 * math.pi);
+    final end = start + 1.6 * math.pi;
+    final adjusted = normalized < start ? normalized + 2 * math.pi : normalized;
+    return adjusted >= start && adjusted <= end;
+  }
+
+  double _distanceToQuadratic(
+    Offset point,
+    Offset start,
+    Offset control,
+    Offset end,
+  ) {
+    double minDistance = double.infinity;
+    const segments = 24;
+    for (var i = 0; i <= segments; i++) {
+      final t = i / segments;
+      final sample = TransitionCurve.pointAt(start, control, end, t);
+      final distance = (point - sample).distance;
+      if (distance < minDistance) {
+        minDistance = distance;
+      }
+    }
+    return minDistance;
+  }
+
+  double _normalizeAngle(double angle) {
+    var a = angle;
+    while (a < 0) {
+      a += 2 * math.pi;
+    }
+    while (a >= 2 * math.pi) {
+      a -= 2 * math.pi;
+    }
+    return a;
   }
 
   /// Closes context menu
@@ -235,6 +341,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
       children: [
         // Main gesture detector
         GestureDetector(
+          behavior: HitTestBehavior.opaque,
           onTapDown: _handleTap,
           onLongPressStart: _handleLongPressStart,
           onLongPressEnd: _handleLongPressEnd,
@@ -303,7 +410,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
                 icon: Icons.edit,
                 label: 'Edit Transition',
                 onTap: () {
-                  // TODO: Implement transition editing
+                  widget.onTransitionEdited(_contextMenuTransition as T);
                   _closeContextMenu();
                 },
               ),
@@ -312,7 +419,7 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
                 icon: Icons.delete,
                 label: 'Delete Transition',
                 onTap: () {
-                  widget.onTransitionDeleted(_contextMenuTransition!);
+                  widget.onTransitionDeleted(_contextMenuTransition as T);
                   _closeContextMenu();
                 },
               ),
@@ -323,7 +430,8 @@ class _TouchGestureHandlerState extends State<TouchGestureHandler> {
                 icon: Icons.add_circle,
                 label: 'Add State',
                 onTap: () {
-                  widget.onStateAdded(_contextMenuPosition!);
+                  final canvasPoint = _toCanvasCoordinates(_contextMenuPosition!);
+                  widget.onStateAdded(canvasPoint);
                   _closeContextMenu();
                 },
               ),

--- a/lib/presentation/widgets/transition_geometry.dart
+++ b/lib/presentation/widgets/transition_geometry.dart
@@ -1,0 +1,126 @@
+import 'dart:math' as math;
+import 'package:flutter/material.dart';
+import '../../core/models/transition.dart';
+
+/// Geometry helper for drawing curved transitions without overlaps.
+class TransitionCurve {
+  final Offset start;
+  final Offset control;
+  final Offset end;
+  final Offset labelPosition;
+  final double tangentAngle;
+
+  const TransitionCurve({
+    required this.start,
+    required this.control,
+    required this.end,
+    required this.labelPosition,
+    required this.tangentAngle,
+  });
+
+  /// Computes geometry for the [current] transition relative to [transitions].
+  static TransitionCurve compute<T extends Transition>(
+    List<T> transitions,
+    T current, {
+    required double stateRadius,
+    double curvatureStrength = 45,
+    double labelOffset = 16,
+  }) {
+    final from = Offset(current.fromState.position.x, current.fromState.position.y);
+    final to = Offset(current.toState.position.x, current.toState.position.y);
+    final direction = to - from;
+    final distance = direction.distance;
+    final unit = distance == 0
+        ? const Offset(1, 0)
+        : Offset(direction.dx / distance, direction.dy / distance);
+
+    final start = from + unit * stateRadius;
+    final end = to - unit * stateRadius;
+
+    final orderedGroup = transitions
+        .where((t) =>
+            t.fromState.id == current.fromState.id &&
+            t.toState.id == current.toState.id &&
+            t.fromState != t.toState)
+        .toList();
+    final orderedIndex = orderedGroup.indexOf(current);
+    final orderedTotal = orderedGroup.length;
+
+    final unorderedTotal = transitions
+        .where((t) =>
+            t.fromState != t.toState &&
+            ((t.fromState.id == current.fromState.id &&
+                    t.toState.id == current.toState.id) ||
+                (t.fromState.id == current.toState.id &&
+                    t.toState.id == current.fromState.id)))
+        .length;
+
+    double offsetFactor = 0.0;
+    if (orderedTotal > 1) {
+      offsetFactor = orderedIndex - (orderedTotal - 1) / 2;
+    } else if (unorderedTotal > 1) {
+      offsetFactor = current.fromState.id.compareTo(current.toState.id) < 0 ? 0.5 : -0.5;
+    }
+
+    final normal = Offset(-unit.dy, unit.dx);
+    final controlOffset = normal * curvatureStrength * offsetFactor;
+    final midPoint = Offset((start.dx + end.dx) / 2, (start.dy + end.dy) / 2);
+    final control = midPoint + controlOffset;
+
+    final labelPoint = _quadraticPoint(start, control, end, 0.5);
+    final labelDirection = offsetFactor == 0
+        ? 1.0
+        : offsetFactor > 0
+            ? 1.0
+            : -1.0;
+    final labelPosition = labelPoint + normal * labelOffset * labelDirection;
+
+    final derivative = _quadraticDerivative(start, control, end, 1.0);
+    final tangentAngle = math.atan2(derivative.dy, derivative.dx);
+
+    return TransitionCurve(
+      start: start,
+      control: control,
+      end: end,
+      labelPosition: labelPosition,
+      tangentAngle: tangentAngle,
+    );
+  }
+
+  static Offset _quadraticPoint(
+    Offset start,
+    Offset control,
+    Offset end,
+    double t,
+  ) {
+    final oneMinusT = 1 - t;
+    return start * (oneMinusT * oneMinusT) +
+        control * (2 * oneMinusT * t) +
+        end * (t * t);
+  }
+
+  /// Returns a point along the quadratic curve at parameter [t].
+  static Offset pointAt(
+    Offset start,
+    Offset control,
+    Offset end,
+    double t,
+  ) => _quadraticPoint(start, control, end, t);
+
+  static Offset _quadraticDerivative(
+    Offset start,
+    Offset control,
+    Offset end,
+    double t,
+  ) {
+    return (control - start) * (2 * (1 - t)) + (end - control) * (2 * t);
+  }
+
+  /// Returns the derivative of the quadratic curve at parameter [t].
+  static Offset derivativeAt(
+    Offset start,
+    Offset control,
+    Offset end,
+    double t,
+  ) => _quadraticDerivative(start, control, end, t);
+}


### PR DESCRIPTION
## Summary
- add a reusable touch gesture handler that supports single-finger panning, state dragging, and transition hit testing
- enhance the FA, PDA, and TM canvases with transition editing dialogs, curved rendering, and better state updates
- introduce a shared transition geometry helper for consistent bezier paths and self-loop spacing

## Testing
- flutter test *(fails: flutter command not found)*
- dart format lib/presentation/widgets *(fails: dart command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4321204c832eb495975e98313387