### PR TITLE
Draw curved transitions using bezier geometry

### DIFF
--- a/lib/presentation/widgets/touch_gesture_handler.dart
+++ b/lib/presentation/widgets/touch_gesture_handler.dart
@@ -263,7 +263,7 @@ class _TouchGestureHandlerState<T extends Transition>
       transition,
       stateRadius: widget.stateRadius,
       curvatureStrength: 45,
-      labelOffset: 12,
+      labelOffset: 16,
     );
 
     return _distanceToQuadratic(point, curve.start, curve.control, curve.end) <= 18;


### PR DESCRIPTION
## Summary
- render non-self-loop transitions using quadratic Bezier curves computed by TransitionCurve
- align arrowheads and labels with the curved geometry to avoid overlap between opposing transitions
- update touch hit-testing to follow the same curve parameters for accurate gesture detection

## Testing
- flutter test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc7458fcfc832ead0b582668f50230