### PR TITLE
Implement DFA operations and simulation support

### DIFF
--- a/lib/core/algorithms.dart
+++ b/lib/core/algorithms.dart
@@ -2,6 +2,7 @@
 export 'algorithms/algorithm_operations.dart';
 export 'algorithms/automaton_simulator.dart';
 export 'algorithms/dfa_minimizer.dart';
+export 'algorithms/dfa_operations.dart';
 export 'algorithms/fa_to_regex_converter.dart';
 export 'algorithms/nfa_to_dfa_converter.dart';
 export 'algorithms/regex_to_nfa_converter.dart';

--- a/lib/core/algorithms/dfa_operations.dart
+++ b/lib/core/algorithms/dfa_operations.dart
@@ -1,0 +1,472 @@
+import 'dart:collection';
+
+import 'package:vector_math/vector_math_64.dart';
+
+import '../models/fsa.dart';
+import '../models/state.dart';
+import '../models/fsa_transition.dart';
+import '../models/transition.dart';
+import '../result.dart';
+import 'dfa_completer.dart';
+import 'nfa_to_dfa_converter.dart';
+
+/// Algorithms for high-level DFA and FSA manipulations used by the repository.
+class DFAOperations {
+  /// Computes the complement of a DFA by completing it and toggling final states.
+  static Result<FSA> complement(FSA dfa) {
+    try {
+      final completed = _completeWithAlphabet(dfa, dfa.alphabet);
+      final updated = _rebuildWithStateUpdate(
+        completed,
+        acceptingPredicate: (state) => !completed.acceptingStates.contains(state),
+      );
+      return ResultFactory.success(updated);
+    } catch (e) {
+      return ResultFactory.failure('Erro ao calcular complemento do DFA: $e');
+    }
+  }
+
+  /// Computes the union of two DFAs using the standard product construction.
+  static Result<FSA> union(FSA a, FSA b) {
+    return _productConstruction(
+      a,
+      b,
+      '∪',
+      (aAccepts, bAccepts) => aAccepts || bAccepts,
+    );
+  }
+
+  /// Computes the intersection of two DFAs.
+  static Result<FSA> intersection(FSA a, FSA b) {
+    return _productConstruction(
+      a,
+      b,
+      '∩',
+      (aAccepts, bAccepts) => aAccepts && bAccepts,
+    );
+  }
+
+  /// Computes the language difference a \ b for two DFAs.
+  static Result<FSA> difference(FSA a, FSA b) {
+    return _productConstruction(
+      a,
+      b,
+      '\\',
+      (aAccepts, bAccepts) => aAccepts && !bAccepts,
+    );
+  }
+
+  /// Computes the prefix-closure of a DFA by marking every state that can
+  /// reach an accepting state as accepting.
+  static Result<FSA> prefixClosure(FSA dfa) {
+    try {
+      final completed = _completeWithAlphabet(dfa, dfa.alphabet);
+      final reachable = _statesThatReachAccepting(completed);
+      final updated = _rebuildWithStateUpdate(
+        completed,
+        acceptingPredicate: reachable.contains,
+      );
+      return ResultFactory.success(updated);
+    } catch (e) {
+      return ResultFactory.failure('Erro ao calcular fecho por prefixos: $e');
+    }
+  }
+
+  /// Computes the suffix-closure of a DFA.
+  ///
+  /// This is achieved by adding a fresh initial state with ε-transitions to all
+  /// states reachable from the original initial state and determinising the
+  /// resulting NFA.
+  static Result<FSA> suffixClosure(FSA dfa) {
+    try {
+      if (dfa.initialState == null) {
+        return ResultFactory.failure('Automato não possui estado inicial definido.');
+      }
+
+      final completed = _completeWithAlphabet(dfa, dfa.alphabet);
+      final reachable = _statesReachableFromInitial(completed);
+      final stateCopies = <String, State>{
+        for (final state in completed.states)
+          state.id: state.copyWith(
+            isInitial: false,
+            isAccepting: completed.acceptingStates.contains(state),
+          ),
+      };
+
+      final newInitial = State(
+        id: '${completed.initialState!.id}_suffix_start',
+        label: 'start',
+        position: completed.initialState!.position + Vector2(40, -40),
+        isInitial: true,
+        isAccepting: reachable.any((state) => completed.acceptingStates.contains(state)),
+      );
+
+      final transitions = <FSATransition>{
+        for (final transition in completed.fsaTransitions)
+          transition.copyWith(
+            fromState: stateCopies[transition.fromState.id],
+            toState: stateCopies[transition.toState.id],
+          ),
+      };
+
+      for (final state in reachable) {
+        final target = stateCopies[state.id];
+        if (target != null) {
+          transitions.add(FSATransition.epsilon(
+            id: 't_suffix_${newInitial.id}_${target.id}',
+            fromState: newInitial,
+            toState: target,
+          ));
+        }
+      }
+
+      final nfaStates = stateCopies.values.toSet()..add(newInitial);
+      final nfa = FSA(
+        id: '${dfa.id}_suffix_nfa',
+        name: '${dfa.name} (Suffix Closure NFA)',
+        states: nfaStates,
+        transitions: transitions,
+        alphabet: completed.alphabet,
+        initialState: newInitial,
+        acceptingStates: nfaStates.where((s) => s.isAccepting).toSet(),
+        created: completed.created,
+        modified: DateTime.now(),
+        bounds: completed.bounds,
+        zoomLevel: completed.zoomLevel,
+        panOffset: completed.panOffset,
+      );
+
+      final determinised = NFAToDFAConverter.convert(nfa);
+      if (determinised.isFailure) {
+        return ResultFactory.failure(determinised.error!);
+      }
+
+      final dfaResult = determinised.data!;
+      final renamed = dfaResult.copyWith(
+        id: '${dfa.id}_suffix_closure',
+        name: '${dfa.name} (Suffix Closure)',
+        modified: DateTime.now(),
+      );
+
+      return ResultFactory.success(renamed);
+    } catch (e) {
+      return ResultFactory.failure('Erro ao calcular fecho por sufixos: $e');
+    }
+  }
+
+  static Result<FSA> _productConstruction(
+    FSA a,
+    FSA b,
+    String operation,
+    bool Function(bool, bool) acceptancePredicate,
+  ) {
+    try {
+      if (a.initialState == null || b.initialState == null) {
+        return ResultFactory.failure('Ambos DFAs precisam ter estado inicial definido.');
+      }
+
+      final combinedAlphabet = {...a.alphabet, ...b.alphabet};
+      final completedA = _completeWithAlphabet(a, combinedAlphabet);
+      final completedB = _completeWithAlphabet(b, combinedAlphabet);
+
+      final queue = Queue<(State, State)>();
+      final visited = <String, State>{};
+      final transitions = <FSATransition>{};
+
+      State _createState(State first, State second, {required bool isInitial}) {
+        final isAccepting = acceptancePredicate(
+          completedA.acceptingStates.contains(first),
+          completedB.acceptingStates.contains(second),
+        );
+
+        final state = State(
+          id: '${first.id}_${second.id}',
+          label: '(${first.label},${second.label})',
+          position: (first.position + second.position) / 2,
+          isInitial: isInitial,
+          isAccepting: isAccepting,
+        );
+        return state;
+      }
+
+      State _getOrCreate(State first, State second, {required bool isInitial}) {
+        final key = '${first.id}|${second.id}';
+        final existing = visited[key];
+        if (existing != null) {
+          return existing;
+        }
+        final created = _createState(first, second, isInitial: isInitial);
+        visited[key] = created;
+        queue.add((first, second));
+        return created;
+      }
+
+      State _nextState(FSA dfa, State state, String symbol) {
+        final transitionsForSymbol = dfa
+            .getTransitionsFromStateOnSymbol(state, symbol)
+            .whereType<FSATransition>()
+            .toList();
+        if (transitionsForSymbol.isEmpty) {
+          throw StateError('Deterministic automaton expected transition for $symbol');
+        }
+        return transitionsForSymbol.first.toState;
+      }
+
+      final initialState = _getOrCreate(
+        completedA.initialState!,
+        completedB.initialState!,
+        isInitial: true,
+      );
+
+      while (queue.isNotEmpty) {
+        final (stateA, stateB) = queue.removeFirst();
+        final currentKey = '${stateA.id}|${stateB.id}';
+        final currentState = visited[currentKey]!;
+
+        for (final symbol in combinedAlphabet) {
+          final nextA = _nextState(completedA, stateA, symbol);
+          final nextB = _nextState(completedB, stateB, symbol);
+          final targetState = _getOrCreate(nextA, nextB, isInitial: false);
+          transitions.add(FSATransition.deterministic(
+            id: 't_${currentState.id}_${symbol}_${targetState.id}',
+            fromState: currentState,
+            toState: targetState,
+            symbol: symbol,
+          ));
+        }
+      }
+
+      final states = visited.values.toSet();
+      final acceptingStates = states.where((s) => s.isAccepting).toSet();
+
+      final product = FSA(
+        id: '${a.id}_${operation}_${b.id}',
+        name: '${a.name} $operation ${b.name}',
+        states: states,
+        transitions: transitions,
+        alphabet: combinedAlphabet,
+        initialState: initialState,
+        acceptingStates: acceptingStates,
+        created: a.created,
+        modified: DateTime.now(),
+        bounds: a.bounds,
+        zoomLevel: a.zoomLevel,
+        panOffset: a.panOffset,
+      );
+
+      return ResultFactory.success(product);
+    } catch (e) {
+      return ResultFactory.failure('Erro ao combinar DFAs ($operation): $e');
+    }
+  }
+
+  static FSA _completeWithAlphabet(FSA dfa, Set<String> alphabet) {
+    final updated = dfa.copyWith(alphabet: alphabet);
+    return DFACompleter.complete(updated);
+  }
+
+  static FSA _rebuildWithStateUpdate(
+    FSA base, {
+    required bool Function(State) acceptingPredicate,
+  }) {
+    final stateCopies = <String, State>{};
+    for (final state in base.states) {
+      final newState = state.copyWith(
+        isInitial: base.initialState?.id == state.id,
+        isAccepting: acceptingPredicate(state),
+      );
+      stateCopies[state.id] = newState;
+    }
+
+    final transitions = <FSATransition>{};
+    for (final transition in base.fsaTransitions) {
+      final fromState = stateCopies[transition.fromState.id]!;
+      final toState = stateCopies[transition.toState.id]!;
+      transitions.add(transition.copyWith(
+        fromState: fromState,
+        toState: toState,
+      ));
+    }
+
+    final states = stateCopies.values.toSet();
+    final acceptingStates = states.where((s) => s.isAccepting).toSet();
+
+    return FSA(
+      id: base.id,
+      name: base.name,
+      states: states,
+      transitions: transitions,
+      alphabet: base.alphabet,
+      initialState: stateCopies[base.initialState?.id],
+      acceptingStates: acceptingStates,
+      created: base.created,
+      modified: DateTime.now(),
+      bounds: base.bounds,
+      zoomLevel: base.zoomLevel,
+      panOffset: base.panOffset,
+    );
+  }
+
+  static Set<State> _statesThatReachAccepting(FSA dfa) {
+    final reverseMap = <String, Set<State>>{};
+    for (final transition in dfa.fsaTransitions) {
+      reverseMap.putIfAbsent(transition.toState.id, () => <State>{});
+      reverseMap[transition.toState.id]!.add(transition.fromState);
+    }
+
+    final stack = List<State>.from(dfa.acceptingStates);
+    final reachable = <State>{...dfa.acceptingStates};
+
+    while (stack.isNotEmpty) {
+      final state = stack.removeLast();
+      for (final predecessor in reverseMap[state.id] ?? const <State>{}) {
+        if (reachable.add(predecessor)) {
+          stack.add(predecessor);
+        }
+      }
+    }
+
+    return reachable;
+  }
+
+  static Set<State> _statesReachableFromInitial(FSA dfa) {
+    if (dfa.initialState == null) {
+      return const <State>{};
+    }
+
+    final visited = <State>{};
+    final queue = Queue<State>()..add(dfa.initialState!);
+    visited.add(dfa.initialState!);
+
+    while (queue.isNotEmpty) {
+      final state = queue.removeFirst();
+      for (final transition in dfa.getTransitionsFrom(state).whereType<FSATransition>()) {
+        if (visited.add(transition.toState)) {
+          queue.add(transition.toState);
+        }
+      }
+    }
+
+    return visited;
+  }
+}
+
+/// Algorithms for NFA manipulation.
+class FSAOperations {
+  /// Removes lambda (epsilon) transitions from an FSA, producing an equivalent
+  /// automaton without lambda transitions.
+  static Result<FSA> removeLambdaTransitions(FSA automaton) {
+    try {
+      final stateCopies = <String, State>{
+        for (final state in automaton.states)
+          state.id: state.copyWith(
+            isInitial: automaton.initialState?.id == state.id,
+            isAccepting: false,
+          ),
+      };
+
+      final epsilonClosures = <String, Set<State>>{
+        for (final state in automaton.states)
+          state.id: _epsilonClosure(automaton, state),
+      };
+
+      final acceptingStates = <State>{};
+      stateCopies.updateAll((id, state) {
+        final closure = epsilonClosures[id]!;
+        final isAccepting = closure.any(automaton.acceptingStates.contains);
+        final updated = state.copyWith(isAccepting: isAccepting);
+        if (isAccepting) {
+          acceptingStates.add(updated);
+        }
+        return updated;
+      });
+
+      final alphabet = automaton.alphabet.where((symbol) => !_isLambdaSymbol(symbol)).toSet();
+      final newTransitions = <FSATransition>{};
+
+      for (final state in automaton.states) {
+        final closure = epsilonClosures[state.id]!;
+        for (final symbol in alphabet) {
+          final destinations = <State>{};
+          for (final closureState in closure) {
+            final outgoing = automaton
+                .getTransitionsFromStateOnSymbol(closureState, symbol)
+                .whereType<FSATransition>();
+            for (final transition in outgoing) {
+              destinations.addAll(epsilonClosures[transition.toState.id]!);
+            }
+          }
+
+          if (destinations.isNotEmpty) {
+            final fromState = stateCopies[state.id]!;
+            final transitionType = destinations.length > 1
+                ? TransitionType.nondeterministic
+                : TransitionType.deterministic;
+            for (final destination in destinations) {
+              final toState = stateCopies[destination.id]!;
+              newTransitions.add(FSATransition(
+                id: 't_${fromState.id}_${symbol}_${toState.id}',
+                fromState: fromState,
+                toState: toState,
+                label: symbol,
+                inputSymbols: {symbol},
+                lambdaSymbol: null,
+                type: transitionType,
+              ));
+            }
+          }
+        }
+      }
+
+      final initialState = automaton.initialState != null
+          ? stateCopies[automaton.initialState!.id]
+          : null;
+
+      final resultingFsa = FSA(
+        id: '${automaton.id}_no_lambda',
+        name: '${automaton.name} (λ-removed)',
+        states: stateCopies.values.toSet(),
+        transitions: newTransitions,
+        alphabet: alphabet,
+        initialState: initialState,
+        acceptingStates: stateCopies.values.where((s) => s.isAccepting).toSet(),
+        created: automaton.created,
+        modified: DateTime.now(),
+        bounds: automaton.bounds,
+        zoomLevel: automaton.zoomLevel,
+        panOffset: automaton.panOffset,
+      );
+
+      return ResultFactory.success(resultingFsa);
+    } catch (e) {
+      return ResultFactory.failure('Erro ao remover transições lambda: $e');
+    }
+  }
+
+  static Set<State> _epsilonClosure(FSA automaton, State start) {
+    final closure = <State>{start};
+    final queue = Queue<State>()..add(start);
+
+    while (queue.isNotEmpty) {
+      final state = queue.removeFirst();
+      final epsilonTransitions = automaton.fsaTransitions.where(
+        (transition) =>
+            transition.isEpsilonTransition && transition.fromState.id == state.id,
+      );
+
+      for (final transition in epsilonTransitions) {
+        final target = transition.toState;
+        if (closure.add(target)) {
+          queue.add(target);
+        }
+      }
+    }
+
+    return closure;
+  }
+
+  static bool _isLambdaSymbol(String symbol) {
+    final normalized = symbol.trim().toLowerCase();
+    return normalized == 'ε' || normalized == 'λ' || normalized == 'lambda';
+  }
+}

--- a/lib/data/repositories/algorithm_repository_impl.dart
+++ b/lib/data/repositories/algorithm_repository_impl.dart
@@ -1,4 +1,5 @@
 import 'dart:math' as math;
+import 'package:collection/collection.dart';
 import 'package:vector_math/vector_math_64.dart';
 import '../../core/repositories/automaton_repository.dart';
 import '../../core/entities/automaton_entity.dart';
@@ -6,6 +7,7 @@ import '../../core/result.dart';
 import '../../core/models/automaton.dart' as model_automaton;
 import '../../core/models/state.dart' as automaton_state;
 import '../../core/models/transition.dart' as model_transition;
+import '../../core/models/fsa_transition.dart' as fsa_transition;
 import '../../core/models/fsa.dart';
 import '../../core/algorithms.dart' as algorithms;
 import '../../core/dfa_algorithms.dart' as dfa_alg;
@@ -39,10 +41,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   Future<Result<AutomatonEntity>> removeLambdaTransitions(AutomatonEntity nfaEntity) async {
     try {
       final nfa = _entityToAutomaton(nfaEntity) as FSA; // Converte para o modelo
-      // For now, return the same NFA as lambda removal is not implemented
-      final result = nfa;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.FSAOperations.removeLambdaTransitions(nfa);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro na remoção de transições lambda: $e');
     }
@@ -80,10 +85,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   Future<Result<AutomatonEntity>> complementDfa(AutomatonEntity dfaEntity) async {
     try {
       final dfa = _entityToAutomaton(dfaEntity) as FSA; // Converte para o modelo
-      // For now, return the same DFA as complement is not implemented
-      final result = dfa;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.DFAOperations.complement(dfa);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro no complemento do DFA: $e');
     }
@@ -94,10 +102,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
     try {
       final a = _entityToAutomaton(aEntity) as FSA; // Converte para o modelo
       final b = _entityToAutomaton(bEntity) as FSA; // Converte para o modelo
-      // For now, return the first DFA as union is not implemented
-      final result = a;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.DFAOperations.union(a, b);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro na união de DFAs: $e');
     }
@@ -108,10 +119,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
     try {
       final a = _entityToAutomaton(aEntity) as FSA; // Converte para o modelo
       final b = _entityToAutomaton(bEntity) as FSA; // Converte para o modelo
-      // For now, return the first DFA as intersection is not implemented
-      final result = a;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.DFAOperations.intersection(a, b);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro na interseção de DFAs: $e');
     }
@@ -122,10 +136,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
     try {
       final a = _entityToAutomaton(aEntity) as FSA; // Converte para o modelo
       final b = _entityToAutomaton(bEntity) as FSA; // Converte para o modelo
-      // For now, return the first DFA as difference is not implemented
-      final result = a;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.DFAOperations.difference(a, b);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro na diferença de DFAs: $e');
     }
@@ -135,10 +152,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   Future<Result<AutomatonEntity>> prefixClosureDfa(AutomatonEntity dfaEntity) async {
     try {
       final dfa = _entityToAutomaton(dfaEntity) as FSA; // Converte para o modelo
-      // For now, return the same DFA as prefix closure is not implemented
-      final result = dfa;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.DFAOperations.prefixClosure(dfa);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro no fecho por prefixos: $e');
     }
@@ -148,10 +168,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   Future<Result<AutomatonEntity>> suffixClosureDfa(AutomatonEntity dfaEntity) async {
     try {
       final dfa = _entityToAutomaton(dfaEntity) as FSA; // Converte para o modelo
-      // For now, return the same DFA as suffix closure is not implemented
-      final result = dfa;
-      final resultEntity = _automatonToEntity(result, model_automaton.AutomatonType.fsa); // Converte de volta
-      return Success(resultEntity);
+      final result = algorithms.DFAOperations.suffixClosure(dfa);
+      if (result.isSuccess) {
+        final resultEntity = _automatonToEntity(result.data!, model_automaton.AutomatonType.fsa);
+        return Success(resultEntity);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro no fecho por sufixos: $e');
     }
@@ -175,8 +198,13 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   @override
   Future<StringResult> dfaToRegex(AutomatonEntity dfaEntity, {bool allowLambda = false}) async {
     try {
-      // TODO: Implement DFA to regex conversion
-      return Failure('DFA to regex conversion not yet implemented');
+      final dfa = _entityToAutomaton(dfaEntity) as FSA;
+      final result = regex_alg.FAToRegexConverter.convert(dfa);
+      if (result.isSuccess) {
+        return Success(result.data!);
+      } else {
+        return Failure(result.error!);
+      }
     } catch (e) {
       return Failure('Erro na conversão DFA → ER: $e');
     }
@@ -210,14 +238,17 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   Future<Result<SimulationResult>> simulateWord(AutomatonEntity automatonEntity, String word) async {
     try {
       final automaton = _entityToAutomaton(automatonEntity) as FSA; // Converte para o modelo
-      // For now, return false as word running is not implemented
-      final runResult = false;
-      final simulationResult = SimulationResult.success(
-        inputString: word,
-        steps: [],
-        executionTime: Duration.zero,
+      final simResult = algorithms.AutomatonSimulator.simulate(
+        automaton,
+        word,
+        stepByStep: true,
       );
-      return Success(simulationResult);
+
+      if (simResult.isFailure) {
+        return Failure(simResult.error!);
+      }
+
+      return Success(simResult.data!);
     } catch (e) {
       return Failure('Erro na simulação da palavra: $e');
     }
@@ -245,21 +276,58 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   // Helper methods for conversion between entities and core automaton objects
   model_automaton.Automaton _entityToAutomaton(AutomatonEntity entity) {
     final states = entity.states.map((s) => automaton_state.State(
-      id: s.id,
-      label: s.name,
-      position: Vector2(s.x, s.y),
-      isInitial: s.isInitial,
-      isAccepting: s.isFinal,
-    )).toSet();
+          id: s.id,
+          label: s.name,
+          position: Vector2(s.x, s.y),
+          isInitial: s.isInitial,
+          isAccepting: s.isFinal,
+        )).toSet();
 
-    // Mapeia o estado inicial corretamente
-    final initialState = entity.initialId != null 
-      ? states.firstWhere((s) => s.id == entity.initialId) 
-      : null;
+    final stateMap = {for (final state in states) state.id: state};
 
-    // TODO: A lógica de transição precisa ser implementada corretamente.
-    // Por enquanto, vamos criar uma estrutura vazia para compilar.
+    final initialState = entity.initialId != null
+        ? stateMap[entity.initialId]
+        : states.firstWhereOrNull((s) => s.isInitial);
+
     final transitions = <model_transition.Transition>{};
+    entity.transitions.forEach((key, destinations) {
+      final parts = key.split('|');
+      if (parts.length != 2) {
+        return;
+      }
+
+      final fromState = stateMap[parts[0]];
+      if (fromState == null) {
+        return;
+      }
+
+      final symbol = parts[1];
+      final isLambda = _isLambdaSymbol(symbol);
+      final transitionType = destinations.length > 1 || isLambda
+          ? model_transition.TransitionType.nondeterministic
+          : model_transition.TransitionType.deterministic;
+
+      for (final destinationId in destinations) {
+        final toState = stateMap[destinationId];
+        if (toState == null) {
+          continue;
+        }
+
+        transitions.add(fsa_transition.FSATransition(
+          id: 't_${fromState.id}_${symbol}_${toState.id}',
+          fromState: fromState,
+          toState: toState,
+          label: symbol,
+          inputSymbols: isLambda ? const <String>{} : {symbol},
+          lambdaSymbol: isLambda ? symbol : null,
+          type: transitionType,
+        ));
+      }
+    });
+
+    final acceptingStates = states
+        .where((state) => state.isAccepting)
+        .toSet();
 
     return FSA(
       id: entity.id,
@@ -268,7 +336,7 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
       transitions: transitions,
       alphabet: entity.alphabet,
       initialState: initialState,
-      acceptingStates: states.where((s) => s.isAccepting).toSet(),
+      acceptingStates: acceptingStates,
       created: DateTime.now(),
       modified: DateTime.now(),
       bounds: const math.Rectangle(0, 0, 800, 600),
@@ -276,29 +344,54 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
   }
 
   AutomatonEntity _automatonToEntity(model_automaton.Automaton automaton, model_automaton.AutomatonType type) {
-    final states = automaton.states.map((s) => StateEntity(
-      id: s.id,
-      name: s.label,
-      x: s.position.x,
-      y: s.position.y,
-      isInitial: s.isInitial,
-      isFinal: s.isAccepting,
-    )).toList();
+    final states = automaton.states.map((s) {
+      final isInitial = automaton.initialState?.id == s.id;
+      final isFinal = automaton.acceptingStates.any((acc) => acc.id == s.id);
+      return StateEntity(
+        id: s.id,
+        name: s.label,
+        x: s.position.x,
+        y: s.position.y,
+        isInitial: isInitial,
+        isFinal: isFinal,
+      );
+    }).toList();
 
-    // TODO: A lógica de transição reversa precisa ser implementada.
-    // Por enquanto, vamos criar uma estrutura vazia para compilar.
-    final transitions = <String, List<String>>{};
+    final transitions = <String, Set<String>>{};
+    for (final transition in automaton.transitions.whereType<fsa_transition.FSATransition>()) {
+      final symbols = transition.isEpsilonTransition
+          ? {transition.lambdaSymbol ?? 'ε'}
+          : transition.inputSymbols;
+
+      for (final symbol in symbols) {
+        final key = '${transition.fromState.id}|$symbol';
+        transitions.putIfAbsent(key, () => <String>{});
+        transitions[key]!.add(transition.toState.id);
+      }
+    }
+
+    final orderedTransitions = transitions.map(
+      (key, value) {
+        final destinations = value.toList()..sort();
+        return MapEntry(key, destinations);
+      },
+    );
 
     return AutomatonEntity(
       id: automaton.id,
       name: automaton.name,
       type: AutomatonType.values.byName(type.name),
       states: states,
-      transitions: transitions,
+      transitions: orderedTransitions,
       alphabet: automaton.alphabet,
       initialId: automaton.initialState?.id,
-      nextId: states.length, // Estimativa simples
+      nextId: states.length,
     );
+  }
+
+  bool _isLambdaSymbol(String symbol) {
+    final normalized = symbol.trim().toLowerCase();
+    return normalized == 'ε' || normalized == 'lambda' || normalized == 'λ';
   }
 
   GrammarEntity _grammarToEntity(model_grammar.Grammar grammar) {

--- a/test/unit/algorithms/test_algorithm_repository_impl.dart
+++ b/test/unit/algorithms/test_algorithm_repository_impl.dart
@@ -1,0 +1,229 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/models/simulation_result.dart';
+import 'package:jflutter/data/repositories/algorithm_repository_impl.dart';
+
+AutomatonEntity _createLambdaNfa() {
+  return AutomatonEntity(
+    id: 'lambda_nfa',
+    name: 'Lambda NFA',
+    alphabet: {'a', 'ε'},
+    states: const [
+      StateEntity(id: 'q0', name: 'q0', x: 0, y: 0, isInitial: true, isFinal: false),
+      StateEntity(id: 'q1', name: 'q1', x: 100, y: 0, isInitial: false, isFinal: true),
+    ],
+    transitions: {
+      'q0|ε': ['q1'],
+      'q1|a': ['q1'],
+    },
+    initialId: 'q0',
+    nextId: 2,
+    type: AutomatonType.nfaLambda,
+  );
+}
+
+AutomatonEntity _createEvenZeroDfa() {
+  return AutomatonEntity(
+    id: 'even_zero',
+    name: 'Even number of 0s',
+    alphabet: {'0', '1'},
+    states: const [
+      StateEntity(id: 'e0', name: 'e0', x: 0, y: 0, isInitial: true, isFinal: true),
+      StateEntity(id: 'e1', name: 'e1', x: 100, y: 0, isInitial: false, isFinal: false),
+    ],
+    transitions: {
+      'e0|0': ['e1'],
+      'e0|1': ['e0'],
+      'e1|0': ['e0'],
+      'e1|1': ['e1'],
+    },
+    initialId: 'e0',
+    nextId: 2,
+    type: AutomatonType.dfa,
+  );
+}
+
+AutomatonEntity _createEndsWithOneDfa() {
+  return AutomatonEntity(
+    id: 'ends_with_one',
+    name: 'Ends with 1',
+    alphabet: {'0', '1'},
+    states: const [
+      StateEntity(id: 's0', name: 's0', x: 0, y: 0, isInitial: true, isFinal: false),
+      StateEntity(id: 's1', name: 's1', x: 100, y: 0, isInitial: false, isFinal: true),
+    ],
+    transitions: {
+      's0|0': ['s0'],
+      's0|1': ['s1'],
+      's1|0': ['s0'],
+      's1|1': ['s1'],
+    },
+    initialId: 's0',
+    nextId: 2,
+    type: AutomatonType.dfa,
+  );
+}
+
+AutomatonEntity _createExactAbDfa() {
+  return AutomatonEntity(
+    id: 'exact_ab',
+    name: 'Accepts only ab',
+    alphabet: {'a', 'b'},
+    states: const [
+      StateEntity(id: 'q0', name: 'q0', x: 0, y: 0, isInitial: true, isFinal: false),
+      StateEntity(id: 'q1', name: 'q1', x: 100, y: 0, isInitial: false, isFinal: false),
+      StateEntity(id: 'q2', name: 'q2', x: 200, y: 0, isInitial: false, isFinal: true),
+      StateEntity(id: 'dead', name: 'dead', x: 300, y: 0, isInitial: false, isFinal: false),
+    ],
+    transitions: {
+      'q0|a': ['q1'],
+      'q0|b': ['dead'],
+      'q1|a': ['dead'],
+      'q1|b': ['q2'],
+      'q2|a': ['dead'],
+      'q2|b': ['dead'],
+      'dead|a': ['dead'],
+      'dead|b': ['dead'],
+    },
+    initialId: 'q0',
+    nextId: 4,
+    type: AutomatonType.dfa,
+  );
+}
+
+Future<bool> _accepts(
+  AlgorithmRepositoryImpl repository,
+  AutomatonEntity automaton,
+  String word,
+) async {
+  final result = await repository.simulateWord(automaton, word);
+  expect(result.isSuccess, isTrue, reason: result.error);
+  final SimulationResult simulation = result.data!;
+  return simulation.accepted;
+}
+
+void main() {
+  group('AlgorithmRepositoryImpl algorithms', () {
+    late AlgorithmRepositoryImpl repository;
+
+    setUp(() {
+      repository = AlgorithmRepositoryImpl();
+    });
+
+    test('removeLambdaTransitions removes epsilon transitions and updates acceptance', () async {
+      final result = await repository.removeLambdaTransitions(_createLambdaNfa());
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final automaton = result.data!;
+
+      expect(automaton.alphabet.contains('ε'), isFalse);
+      expect(automaton.transitions.keys.any((key) => key.contains('ε')), isFalse);
+
+      final q0 = automaton.states.firstWhere((state) => state.id == 'q0');
+      expect(q0.isFinal, isTrue);
+      expect(automaton.transitions['q0|a'], contains('q1'));
+
+      expect(await _accepts(repository, automaton, ''), isTrue);
+      expect(await _accepts(repository, automaton, 'aa'), isTrue);
+    });
+
+    test('complementDfa toggles acceptance', () async {
+      final dfa = _createEvenZeroDfa();
+      final result = await repository.complementDfa(dfa);
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final complement = result.data!;
+
+      expect(await _accepts(repository, dfa, '00'), isTrue);
+      expect(await _accepts(repository, complement, '00'), isFalse);
+      expect(await _accepts(repository, dfa, '0'), isFalse);
+      expect(await _accepts(repository, complement, '0'), isTrue);
+    });
+
+    test('unionDfa combines languages correctly', () async {
+      final result = await repository.unionDfa(
+        _createEvenZeroDfa(),
+        _createEndsWithOneDfa(),
+      );
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final union = result.data!;
+
+      expect(await _accepts(repository, union, '1'), isTrue);
+      expect(await _accepts(repository, union, '00'), isTrue);
+      expect(await _accepts(repository, union, '0'), isFalse);
+    });
+
+    test('intersectionDfa retains common language', () async {
+      final result = await repository.intersectionDfa(
+        _createEvenZeroDfa(),
+        _createEndsWithOneDfa(),
+      );
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final intersection = result.data!;
+
+      expect(await _accepts(repository, intersection, '1'), isTrue);
+      expect(await _accepts(repository, intersection, '11'), isTrue);
+      expect(await _accepts(repository, intersection, '10'), isFalse);
+      expect(await _accepts(repository, intersection, '0'), isFalse);
+    });
+
+    test('differenceDfa subtracts second language from first', () async {
+      final result = await repository.differenceDfa(
+        _createEvenZeroDfa(),
+        _createEndsWithOneDfa(),
+      );
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final difference = result.data!;
+
+      expect(await _accepts(repository, difference, '00'), isTrue);
+      expect(await _accepts(repository, difference, '1'), isFalse);
+    });
+
+    test('prefixClosureDfa marks prefixes leading to acceptance', () async {
+      final result = await repository.prefixClosureDfa(_createExactAbDfa());
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final closure = result.data!;
+
+      expect(await _accepts(repository, closure, ''), isTrue);
+      expect(await _accepts(repository, closure, 'a'), isTrue);
+      expect(await _accepts(repository, closure, 'ab'), isTrue);
+      expect(await _accepts(repository, closure, 'b'), isFalse);
+    });
+
+    test('suffixClosureDfa accepts suffixes of original language', () async {
+      final result = await repository.suffixClosureDfa(_createExactAbDfa());
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final closure = result.data!;
+
+      expect(await _accepts(repository, closure, ''), isTrue);
+      expect(await _accepts(repository, closure, 'b'), isTrue);
+      expect(await _accepts(repository, closure, 'ab'), isTrue);
+      expect(await _accepts(repository, closure, 'a'), isFalse);
+    });
+
+    test('simulateWord delegates to simulator and returns detailed result', () async {
+      final result = await repository.simulateWord(_createEvenZeroDfa(), '01');
+      expect(result.isSuccess, isTrue, reason: result.error);
+      final simulation = result.data!;
+      expect(simulation.steps.length, greaterThan(1));
+      expect(simulation.accepted, isTrue);
+    });
+
+    test('dfaToRegex produces equivalent regex', () async {
+      final regexResult = await repository.dfaToRegex(_createExactAbDfa());
+      expect(regexResult.isSuccess, isTrue, reason: regexResult.error);
+      final regexString = regexResult.data!;
+      expect(regexString.isNotEmpty, isTrue);
+
+      final nfaResult = await repository.regexToNfa(regexString);
+      expect(nfaResult.isSuccess, isTrue, reason: nfaResult.error);
+      final dfaResult = await repository.nfaToDfa(nfaResult.data!);
+      expect(dfaResult.isSuccess, isTrue, reason: dfaResult.error);
+
+      final equivalence = await repository.areEquivalent(
+        _createExactAbDfa(),
+        dfaResult.data!,
+      );
+      expect(equivalence.isSuccess, isTrue, reason: equivalence.error);
+      expect(equivalence.data, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- wire algorithm repository methods to real DFA/FSA operations including lambda removal, complement, set operations, and closures
- add reusable DFA/FSA operation helpers to the core algorithms layer and improve entity/model conversions
- introduce unit tests covering the repository algorithms, simulation, and DFA-to-regex pipeline

## Testing
- `flutter test test/unit/algorithms/test_algorithm_repository_impl.dart` *(fails: flutter command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca312b648832eadd72ea3ced1d4e3