### PR TITLE
Implement automaton repository conversions and tests

### DIFF
--- a/lib/data/repositories/automaton_repository_impl.dart
+++ b/lib/data/repositories/automaton_repository_impl.dart
@@ -1,4 +1,11 @@
+import 'dart:math' as math;
+
+import 'package:vector_math/vector_math_64.dart';
+
 import '../../core/entities/automaton_entity.dart';
+import '../../core/models/fsa.dart';
+import '../../core/models/fsa_transition.dart';
+import '../../core/models/state.dart';
 import '../../core/result.dart';
 import '../../core/repositories/automaton_repository.dart';
 import '../services/automaton_service.dart';
@@ -12,9 +19,14 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<AutomatonResult> saveAutomaton(AutomatonEntity automaton) async {
     try {
-      // Convert AutomatonEntity to FSA and save
-      // This is a simplified conversion - in a real app you'd have proper mapping
-      return Success(automaton);
+      final request = _convertEntityToRequest(automaton);
+      final result = _automatonService.saveAutomaton(automaton.id, request);
+
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
+      return Success(_convertFsaToEntity(result.data!));
     } catch (e) {
       return Failure('Failed to save automaton: $e');
     }
@@ -23,9 +35,12 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<AutomatonResult> loadAutomaton(String id) async {
     try {
-      // Load automaton by ID
-      // This is a placeholder implementation
-      return Failure('Automaton with ID $id not found');
+      final result = _automatonService.getAutomaton(id);
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
+      return Success(_convertFsaToEntity(result.data!));
     } catch (e) {
       return Failure('Failed to load automaton: $e');
     }
@@ -34,8 +49,16 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<ListResult<AutomatonEntity>> loadAllAutomatons() async {
     try {
-      // Load all automatons
-      return Success(<AutomatonEntity>[]);
+      final result = _automatonService.listAutomata();
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
+      final automatons = result.data!
+          .map(_convertFsaToEntity)
+          .toList();
+
+      return Success(automatons);
     } catch (e) {
       return Failure('Failed to load automatons: $e');
     }
@@ -44,7 +67,11 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<BoolResult> deleteAutomaton(String id) async {
     try {
-      // Delete automaton by ID
+      final result = _automatonService.deleteAutomaton(id);
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
       return Success(true);
     } catch (e) {
       return Failure('Failed to delete automaton: $e');
@@ -54,8 +81,13 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<StringResult> exportAutomaton(AutomatonEntity automaton) async {
     try {
-      // Export automaton to JSON
-      return Success('{}');
+      final fsa = _convertEntityToFsa(automaton);
+      final result = _automatonService.exportAutomaton(fsa);
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
+      return Success(result.data!);
     } catch (e) {
       return Failure('Failed to export automaton: $e');
     }
@@ -64,8 +96,12 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<AutomatonResult> importAutomaton(String jsonString) async {
     try {
-      // Import automaton from JSON
-      return Failure('Import not implemented');
+      final result = _automatonService.importAutomaton(jsonString);
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
+      return Success(_convertFsaToEntity(result.data!));
     } catch (e) {
       return Failure('Failed to import automaton: $e');
     }
@@ -74,10 +110,209 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
   @override
   Future<BoolResult> validateAutomaton(AutomatonEntity automaton) async {
     try {
-      // Validate automaton
-      return Success(true);
+      final fsa = _convertEntityToFsa(automaton);
+      final result = _automatonService.validateAutomaton(fsa);
+      if (result.isFailure) {
+        return Failure(result.error!);
+      }
+
+      return Success(result.data!);
     } catch (e) {
       return Failure('Failed to validate automaton: $e');
     }
+  }
+
+  CreateAutomatonRequest _convertEntityToRequest(AutomatonEntity automaton) {
+    final states = automaton.states
+        .map((state) => StateData(
+              id: state.id,
+              name: state.name,
+              position: Point(state.x, state.y),
+              isInitial: state.isInitial || automaton.initialId == state.id,
+              isAccepting: state.isFinal,
+            ))
+        .toList();
+
+    final transitions = <TransitionData>[];
+    automaton.transitions.forEach((key, destinations) {
+      final parts = key.split('|');
+      if (parts.length != 2) {
+        return;
+      }
+      final fromStateId = parts[0];
+      final symbol = parts[1];
+      for (final toStateId in destinations) {
+        transitions.add(TransitionData(
+          fromStateId: fromStateId,
+          toStateId: toStateId,
+          symbol: symbol,
+        ));
+      }
+    });
+
+    final bounds = _calculateBounds(automaton.states);
+
+    return CreateAutomatonRequest(
+      name: automaton.name,
+      description: null,
+      states: states,
+      transitions: transitions,
+      alphabet: automaton.alphabet.toList(),
+      bounds: bounds,
+    );
+  }
+
+  AutomatonEntity _convertFsaToEntity(FSA automaton) {
+    final states = automaton.states
+        .map((state) => StateEntity(
+              id: state.id,
+              name: state.label,
+              x: state.position.x,
+              y: state.position.y,
+              isInitial: state.isInitial,
+              isFinal: state.isAccepting,
+            ))
+        .toList();
+
+    final transitions = <String, List<String>>{};
+    for (final transition in automaton.transitions.whereType<FSATransition>()) {
+      final symbols = <String>{};
+      if (transition.lambdaSymbol != null) {
+        symbols.add(transition.lambdaSymbol!);
+      } else {
+        symbols.addAll(transition.inputSymbols);
+      }
+
+      for (final symbol in symbols) {
+        final key = '${transition.fromState.id}|$symbol';
+        transitions.putIfAbsent(key, () => <String>[]).add(transition.toState.id);
+      }
+    }
+
+    final type = automaton.hasEpsilonTransitions
+        ? AutomatonType.nfaLambda
+        : automaton.isDeterministic
+            ? AutomatonType.dfa
+            : AutomatonType.nfa;
+
+    return AutomatonEntity(
+      id: automaton.id,
+      name: automaton.name,
+      alphabet: automaton.alphabet,
+      states: states,
+      transitions: transitions,
+      initialId: automaton.initialState?.id,
+      nextId: states.length,
+      type: type,
+    );
+  }
+
+  FSA _convertEntityToFsa(AutomatonEntity automaton) {
+    final states = automaton.states
+        .map((state) => State(
+              id: state.id,
+              label: state.name,
+              position: Vector2(state.x, state.y),
+              isInitial: state.isInitial || automaton.initialId == state.id,
+              isAccepting: state.isFinal,
+            ))
+        .toSet();
+
+    final stateById = {for (final state in states) state.id: state};
+
+    final transitions = <FSATransition>{};
+    var transitionIndex = 0;
+
+    automaton.transitions.forEach((key, destinations) {
+      final parts = key.split('|');
+      if (parts.length != 2) {
+        return;
+      }
+
+      final fromState = stateById[parts[0]];
+      if (fromState == null) {
+        throw StateError('Unknown from state ${parts[0]}');
+      }
+
+      final symbol = parts[1];
+      final isLambda = symbol == 'λ' || symbol == 'ε' || symbol.toLowerCase() == 'lambda';
+
+      for (final destination in destinations) {
+        final toState = stateById[destination];
+        if (toState == null) {
+          throw StateError('Unknown to state $destination');
+        }
+
+        transitions.add(FSATransition(
+          id: 't${automaton.id}_$transitionIndex',
+          fromState: fromState,
+          toState: toState,
+          label: symbol,
+          inputSymbols: isLambda ? <String>{} : {symbol},
+          lambdaSymbol: isLambda ? symbol : null,
+        ));
+        transitionIndex++;
+      }
+    });
+
+    final initialState = automaton.initialId != null
+        ? stateById[automaton.initialId!]
+        : () {
+            try {
+              return states.firstWhere((s) => s.isInitial);
+            } catch (_) {
+              return null;
+            }
+          }();
+
+    final acceptingStates = states.where((state) => state.isAccepting).toSet();
+
+    final boundsRect = _calculateBounds(automaton.states);
+    final bounds = math.Rectangle(
+      boundsRect.left,
+      boundsRect.top,
+      boundsRect.right - boundsRect.left,
+      boundsRect.bottom - boundsRect.top,
+    );
+
+    return FSA(
+      id: automaton.id,
+      name: automaton.name,
+      states: states,
+      transitions: transitions,
+      alphabet: automaton.alphabet,
+      initialState: initialState,
+      acceptingStates: acceptingStates,
+      created: DateTime.now(),
+      modified: DateTime.now(),
+      bounds: bounds,
+    );
+  }
+
+  Rect _calculateBounds(List<StateEntity> states) {
+    if (states.isEmpty) {
+      return const Rect(0, 0, 800, 600);
+    }
+
+    var minX = states.first.x;
+    var minY = states.first.y;
+    var maxX = states.first.x;
+    var maxY = states.first.y;
+
+    for (final state in states.skip(1)) {
+      minX = math.min(minX, state.x);
+      minY = math.min(minY, state.y);
+      maxX = math.max(maxX, state.x);
+      maxY = math.max(maxY, state.y);
+    }
+
+    const padding = 50.0;
+
+    return Rect(
+      minX - padding,
+      minY - padding,
+      maxX + padding,
+      maxY + padding,
+    );
   }
 }

--- a/lib/data/services/automaton_service.dart
+++ b/lib/data/services/automaton_service.dart
@@ -1,78 +1,112 @@
+import 'dart:convert';
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 import '../../core/models/fsa.dart';
 import '../../core/models/state.dart';
 import '../../core/models/fsa_transition.dart';
 import '../../core/result.dart';
+import '../../core/models/automaton.dart' as core_models;
 
 /// Service for automaton CRUD operations
 class AutomatonService {
   final List<FSA> _automata = [];
   int _nextId = 1;
 
+  FSA _buildAutomatonFromRequest(
+    CreateAutomatonRequest request, {
+    required String id,
+    DateTime? created,
+    DateTime? modified,
+  }) {
+    if (request.name.isEmpty) {
+      throw ArgumentError('Automaton name cannot be empty');
+    }
+
+    final states = <State>[];
+    for (final stateData in request.states) {
+      final state = State(
+        id: stateData.id,
+        label: stateData.name,
+        position: Vector2(stateData.position.x, stateData.position.y),
+        isInitial: stateData.isInitial,
+        isAccepting: stateData.isAccepting,
+      );
+      states.add(state);
+    }
+
+    final stateById = {for (final state in states) state.id: state};
+
+    final transitions = <FSATransition>{};
+    var transitionIndex = 0;
+    for (final transitionData in request.transitions) {
+      final fromState = stateById[transitionData.fromStateId];
+      final toState = stateById[transitionData.toStateId];
+      if (fromState == null || toState == null) {
+        throw StateError(
+            'Transition references unknown state: ${transitionData.fromStateId} -> ${transitionData.toStateId}');
+      }
+
+      final symbol = transitionData.symbol;
+      final isLambda = symbol == 'λ' || symbol == 'ε' || symbol.toLowerCase() == 'lambda';
+
+      transitions.add(FSATransition(
+        id: 't${id}_$transitionIndex',
+        fromState: fromState,
+        toState: toState,
+        label: symbol,
+        inputSymbols: isLambda ? <String>{} : {symbol},
+        lambdaSymbol: isLambda ? symbol : null,
+      ));
+      transitionIndex++;
+    }
+
+    State? initialState;
+    try {
+      initialState = states.firstWhere((s) => s.isInitial);
+    } catch (_) {
+      initialState = null;
+    }
+
+    final acceptingStates = states.where((s) => s.isAccepting).toSet();
+
+    final bounds = math.Rectangle(
+      request.bounds.left,
+      request.bounds.top,
+      request.bounds.right - request.bounds.left,
+      request.bounds.bottom - request.bounds.top,
+    );
+
+    return FSA(
+      id: id,
+      name: request.name,
+      description: request.description ?? '',
+      states: states.toSet(),
+      transitions: transitions,
+      alphabet: request.alphabet.toSet(),
+      initialState: initialState,
+      acceptingStates: acceptingStates,
+      created: created ?? DateTime.now(),
+      modified: modified ?? DateTime.now(),
+      bounds: bounds,
+    );
+  }
+
   /// Creates a new automaton
   Result<FSA> createAutomaton(CreateAutomatonRequest request) {
     try {
-      // Validate request
-      if (request.name.isEmpty) {
-            return ResultFactory.failure('Automaton name cannot be empty');
-      }
-
-      // Create states
-      final states = <State>[];
-      for (final stateData in request.states) {
-        final state = State(
-          id: stateData.id,
-          label: stateData.name,
-          position: Vector2(stateData.position.x, stateData.position.y),
-          isInitial: stateData.isInitial,
-          isAccepting: stateData.isAccepting,
-        );
-        states.add(state);
-      }
-
-      // Create transitions
-      final transitions = <FSATransition>[];
-      for (final transitionData in request.transitions) {
-        final fromState = states.firstWhere((s) => s.id == transitionData.fromStateId);
-        final toState = states.firstWhere((s) => s.id == transitionData.toStateId);
-        
-        final transition = FSATransition(
-          id: 't${_nextId++}',
-          fromState: fromState,
-          toState: toState,
-          label: transitionData.symbol,
-          inputSymbols: {transitionData.symbol},
-        );
-        transitions.add(transition);
-      }
-
-      // Create automaton
-      final automaton = FSA(
-        id: _nextId.toString(),
-        name: request.name,
-        description: request.description ?? '',
-        states: states.toSet(),
-        alphabet: request.alphabet.toSet(),
-        initialState: states.firstWhere((s) => s.isInitial),
-        acceptingStates: states.where((s) => s.isAccepting).toSet(),
-        transitions: transitions.toSet(),
-        bounds: math.Rectangle(
-          request.bounds.left,
-          request.bounds.top,
-          request.bounds.right - request.bounds.left,
-          request.bounds.bottom - request.bounds.top,
-        ),
+      final id = (_nextId++).toString();
+      final automaton = _buildAutomatonFromRequest(
+        request,
+        id: id,
         created: DateTime.now(),
         modified: DateTime.now(),
       );
 
       _automata.add(automaton);
-      _nextId++;
 
       return ResultFactory.success(automaton);
     } catch (e) {
-          return ResultFactory.failure('Error creating automaton: $e');
+      return ResultFactory.failure('Error creating automaton: $e');
     }
   }
 
@@ -94,21 +128,43 @@ class AutomatonService {
         return ResultFactory.failure('Automaton not found: $id');
       }
 
-      // Create updated automaton (similar to createAutomaton)
-      final result = createAutomaton(request);
-      if (!result.isSuccess) {
-        return result;
-      }
-
-      final updatedAutomaton = result.data!.copyWith(
+      final existing = _automata[index];
+      final updatedAutomaton = _buildAutomatonFromRequest(
+        request,
         id: id,
+        created: existing.created,
         modified: DateTime.now(),
       );
 
       _automata[index] = updatedAutomaton;
-          return ResultFactory.success(updatedAutomaton);
+      return ResultFactory.success(updatedAutomaton);
     } catch (e) {
-          return ResultFactory.failure('Error updating automaton: $e');
+      return ResultFactory.failure('Error updating automaton: $e');
+    }
+  }
+
+  /// Saves an automaton using a specific ID (creates or updates)
+  Result<FSA> saveAutomaton(String id, CreateAutomatonRequest request) {
+    try {
+      final index = _automata.indexWhere((a) => a.id == id);
+      final created = index == -1 ? DateTime.now() : _automata[index].created;
+
+      final automaton = _buildAutomatonFromRequest(
+        request,
+        id: id,
+        created: created,
+        modified: DateTime.now(),
+      );
+
+      if (index == -1) {
+        _automata.add(automaton);
+      } else {
+        _automata[index] = automaton;
+      }
+
+      return ResultFactory.success(automaton);
+    } catch (e) {
+      return ResultFactory.failure('Error saving automaton: $e');
     }
   }
 
@@ -137,6 +193,55 @@ class AutomatonService {
     _automata.clear();
     _nextId = 1;
     return ResultFactory.success(null);
+  }
+
+  /// Exports an automaton to JSON
+  Result<String> exportAutomaton(FSA automaton) {
+    try {
+      final jsonString = jsonEncode(automaton.toJson());
+      return ResultFactory.success(jsonString);
+    } catch (e) {
+      return ResultFactory.failure('Error exporting automaton: $e');
+    }
+  }
+
+  /// Imports an automaton from JSON
+  Result<FSA> importAutomaton(String jsonString) {
+    try {
+      final decoded = jsonDecode(jsonString);
+      if (decoded is! Map<String, dynamic>) {
+        return ResultFactory.failure('Invalid automaton JSON format');
+      }
+
+      final automaton = core_models.Automaton.fromJson(decoded);
+      if (automaton is! FSA) {
+        return ResultFactory.failure('Unsupported automaton type for import');
+      }
+
+      final index = _automata.indexWhere((a) => a.id == automaton.id);
+      if (index == -1) {
+        _automata.add(automaton);
+      } else {
+        _automata[index] = automaton;
+      }
+
+      return ResultFactory.success(automaton);
+    } catch (e) {
+      return ResultFactory.failure('Error importing automaton: $e');
+    }
+  }
+
+  /// Validates an automaton
+  Result<bool> validateAutomaton(FSA automaton) {
+    try {
+      final errors = automaton.validate();
+      if (errors.isEmpty) {
+        return ResultFactory.success(true);
+      }
+      return ResultFactory.failure('Validation failed: ${errors.join(', ')}');
+    } catch (e) {
+      return ResultFactory.failure('Error validating automaton: $e');
+    }
   }
 }
 

--- a/test/unit/repositories/automaton_repository_impl_test.dart
+++ b/test/unit/repositories/automaton_repository_impl_test.dart
@@ -1,0 +1,162 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/lib/core/entities/automaton_entity.dart';
+import 'package:jflutter/lib/core/result.dart';
+import 'package:jflutter/lib/data/repositories/automaton_repository_impl.dart';
+import 'package:jflutter/lib/data/services/automaton_service.dart';
+
+void main() {
+  late AutomatonService service;
+  late AutomatonRepositoryImpl repository;
+
+  setUp(() {
+    service = AutomatonService();
+    repository = AutomatonRepositoryImpl(service);
+  });
+
+  AutomatonEntity buildAutomaton({String id = 'auto-1'}) {
+    return AutomatonEntity(
+      id: id,
+      name: 'Test Automaton',
+      alphabet: {'0', '1'},
+      states: const [
+        StateEntity(
+          id: 'q0',
+          name: 'q0',
+          x: 100,
+          y: 100,
+          isInitial: true,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 'q1',
+          name: 'q1',
+          x: 300,
+          y: 100,
+          isInitial: false,
+          isFinal: true,
+        ),
+      ],
+      transitions: {
+        'q0|0': ['q1'],
+        'q1|1': ['q0'],
+      },
+      initialId: 'q0',
+      nextId: 2,
+      type: AutomatonType.dfa,
+    );
+  }
+
+  group('save/load/delete', () {
+    test('saves and loads automaton preserving data', () async {
+      final automaton = buildAutomaton();
+
+      final saveResult = await repository.saveAutomaton(automaton);
+      expect(saveResult, isA<Success<AutomatonEntity>>());
+      expect(saveResult.data!.id, equals(automaton.id));
+      expect(saveResult.data!.states.length, equals(2));
+
+      final loadResult = await repository.loadAutomaton(automaton.id);
+      expect(loadResult, isA<Success<AutomatonEntity>>());
+      expect(loadResult.data!.name, equals('Test Automaton'));
+      expect(loadResult.data!.transitions['q0|0'], equals(['q1']));
+    });
+
+    test('returns failure when loading unknown automaton', () async {
+      final loadResult = await repository.loadAutomaton('missing');
+      expect(loadResult, isA<Failure<AutomatonEntity>>());
+    });
+
+    test('loadAll returns persisted automatons', () async {
+      final automaton1 = buildAutomaton();
+      final automaton2 = buildAutomaton(id: 'auto-2');
+
+      await repository.saveAutomaton(automaton1);
+      await repository.saveAutomaton(automaton2);
+
+      final listResult = await repository.loadAllAutomatons();
+      expect(listResult, isA<Success<List<AutomatonEntity>>>());
+      expect(listResult.data, isNotNull);
+      expect(listResult.data!.length, equals(2));
+    });
+
+    test('delete removes persisted automaton', () async {
+      final automaton = buildAutomaton();
+      await repository.saveAutomaton(automaton);
+
+      final deleteResult = await repository.deleteAutomaton(automaton.id);
+      expect(deleteResult, isA<Success<bool>>());
+
+      final reload = await repository.loadAutomaton(automaton.id);
+      expect(reload, isA<Failure<AutomatonEntity>>());
+    });
+
+    test('delete returns failure for unknown id', () async {
+      final deleteResult = await repository.deleteAutomaton('missing');
+      expect(deleteResult, isA<Failure<bool>>());
+    });
+  });
+
+  group('export/import', () {
+    test('exports automaton as JSON and re-imports', () async {
+      final automaton = buildAutomaton();
+      await repository.saveAutomaton(automaton);
+
+      final exportResult = await repository.exportAutomaton(automaton);
+      expect(exportResult, isA<Success<String>>());
+      final json = exportResult.data!;
+      expect(json, contains('Test Automaton'));
+
+      service.clearAutomata();
+      final importResult = await repository.importAutomaton(json);
+      expect(importResult, isA<Success<AutomatonEntity>>());
+      expect(importResult.data!.states.length, equals(2));
+    });
+
+    test('import returns failure for invalid json', () async {
+      final result = await repository.importAutomaton('{invalid json');
+      expect(result, isA<Failure<AutomatonEntity>>());
+    });
+  });
+
+  group('validation', () {
+    test('validate returns success for valid automaton', () async {
+      final automaton = buildAutomaton();
+      final result = await repository.validateAutomaton(automaton);
+      expect(result, isA<Success<bool>>());
+      expect(result.data, isTrue);
+    });
+
+    test('validate returns failure for invalid automaton', () async {
+      final invalidAutomaton = AutomatonEntity(
+        id: 'invalid',
+        name: 'Invalid',
+        alphabet: const {},
+        states: const [],
+        transitions: const {},
+        initialId: null,
+        nextId: 0,
+        type: AutomatonType.dfa,
+      );
+
+      final result = await repository.validateAutomaton(invalidAutomaton);
+      expect(result, isA<Failure<bool>>());
+    });
+  });
+
+  test('save propagates service failure', () async {
+    final invalidAutomaton = AutomatonEntity(
+      id: 'invalid',
+      name: '',
+      alphabet: const {},
+      states: const [],
+      transitions: const {},
+      initialId: null,
+      nextId: 0,
+      type: AutomatonType.dfa,
+    );
+
+    final result = await repository.saveAutomaton(invalidAutomaton);
+    expect(result, isA<Failure<AutomatonEntity>>());
+  });
+}


### PR DESCRIPTION
## Summary
- add robust conversion helpers in the automaton repository to bridge entities and service DTOs while wiring up all CRUD, import/export, and validation operations
- extend the automaton service with reusable builders plus save/import/export/validate helpers to support repository flows and propagate failures
- cover repository save/load/delete/import/export/validate behavior with unit tests exercising persistence and error paths

## Testing
- ⚠️ `flutter test test/unit/repositories/automaton_repository_impl_test.dart` *(fails: flutter command not available in environment)*
- ⚠️ `dart test test/unit/repositories/automaton_repository_impl_test.dart` *(fails: dart command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca32e4464832eb0a8bbf7bc6a068d