### PR TITLE
Implement persistent settings storage

### DIFF
--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -1,0 +1,103 @@
+/// Model representing persisted application settings.
+class SettingsModel {
+  /// Symbol used to represent the empty string.
+  final String emptyStringSymbol;
+
+  /// Symbol used to represent epsilon transitions.
+  final String epsilonSymbol;
+
+  /// Theme mode preference (system, light, dark).
+  final String themeMode;
+
+  /// Whether to display the grid on the canvas.
+  final bool showGrid;
+
+  /// Whether to display coordinates on the canvas.
+  final bool showCoordinates;
+
+  /// Whether autosave is enabled.
+  final bool autoSave;
+
+  /// Whether to display tooltips.
+  final bool showTooltips;
+
+  /// Size of the grid in logical pixels.
+  final double gridSize;
+
+  /// Size of nodes in logical pixels.
+  final double nodeSize;
+
+  /// Base font size in the interface.
+  final double fontSize;
+
+  const SettingsModel({
+    this.emptyStringSymbol = 'λ',
+    this.epsilonSymbol = 'ε',
+    this.themeMode = 'system',
+    this.showGrid = true,
+    this.showCoordinates = false,
+    this.autoSave = true,
+    this.showTooltips = true,
+    this.gridSize = 20.0,
+    this.nodeSize = 30.0,
+    this.fontSize = 14.0,
+  });
+
+  /// Creates a new [SettingsModel] with updated values.
+  SettingsModel copyWith({
+    String? emptyStringSymbol,
+    String? epsilonSymbol,
+    String? themeMode,
+    bool? showGrid,
+    bool? showCoordinates,
+    bool? autoSave,
+    bool? showTooltips,
+    double? gridSize,
+    double? nodeSize,
+    double? fontSize,
+  }) {
+    return SettingsModel(
+      emptyStringSymbol: emptyStringSymbol ?? this.emptyStringSymbol,
+      epsilonSymbol: epsilonSymbol ?? this.epsilonSymbol,
+      themeMode: themeMode ?? this.themeMode,
+      showGrid: showGrid ?? this.showGrid,
+      showCoordinates: showCoordinates ?? this.showCoordinates,
+      autoSave: autoSave ?? this.autoSave,
+      showTooltips: showTooltips ?? this.showTooltips,
+      gridSize: gridSize ?? this.gridSize,
+      nodeSize: nodeSize ?? this.nodeSize,
+      fontSize: fontSize ?? this.fontSize,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    if (other.runtimeType != runtimeType) return false;
+    return other is SettingsModel &&
+        other.emptyStringSymbol == emptyStringSymbol &&
+        other.epsilonSymbol == epsilonSymbol &&
+        other.themeMode == themeMode &&
+        other.showGrid == showGrid &&
+        other.showCoordinates == showCoordinates &&
+        other.autoSave == autoSave &&
+        other.showTooltips == showTooltips &&
+        other.gridSize == gridSize &&
+        other.nodeSize == nodeSize &&
+        other.fontSize == fontSize;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        emptyStringSymbol,
+        epsilonSymbol,
+        themeMode,
+        showGrid,
+        showCoordinates,
+        autoSave,
+        showTooltips,
+        gridSize,
+        nodeSize,
+        fontSize,
+      );
+}

--- a/lib/core/repositories/settings_repository.dart
+++ b/lib/core/repositories/settings_repository.dart
@@ -1,0 +1,10 @@
+import '../models/settings_model.dart';
+
+/// Repository contract for persisting and retrieving user settings.
+abstract class SettingsRepository {
+  /// Loads previously saved settings or returns defaults when unavailable.
+  Future<SettingsModel> loadSettings();
+
+  /// Persists the provided [settings].
+  Future<void> saveSettings(SettingsModel settings);
+}

--- a/lib/data/repositories/settings_repository_impl.dart
+++ b/lib/data/repositories/settings_repository_impl.dart
@@ -1,0 +1,73 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+import '../../core/models/settings_model.dart';
+import '../../core/repositories/settings_repository.dart';
+
+/// Settings repository backed by [SharedPreferences].
+class SharedPreferencesSettingsRepository implements SettingsRepository {
+  const SharedPreferencesSettingsRepository({
+    Future<SharedPreferences> Function()? preferencesProvider,
+  }) : _preferencesProvider = preferencesProvider;
+
+  static const String _emptyStringSymbolKey = 'settings_empty_string_symbol';
+  static const String _epsilonSymbolKey = 'settings_epsilon_symbol';
+  static const String _themeModeKey = 'settings_theme_mode';
+  static const String _showGridKey = 'settings_show_grid';
+  static const String _showCoordinatesKey = 'settings_show_coordinates';
+  static const String _autoSaveKey = 'settings_auto_save';
+  static const String _showTooltipsKey = 'settings_show_tooltips';
+  static const String _gridSizeKey = 'settings_grid_size';
+  static const String _nodeSizeKey = 'settings_node_size';
+  static const String _fontSizeKey = 'settings_font_size';
+
+  final Future<SharedPreferences> Function()? _preferencesProvider;
+
+  Future<SharedPreferences> _getPreferences() {
+    final provider = _preferencesProvider;
+    if (provider != null) {
+      return provider();
+    }
+    return SharedPreferences.getInstance();
+  }
+
+  @override
+  Future<SettingsModel> loadSettings() async {
+    final prefs = await _getPreferences();
+    const defaults = SettingsModel();
+
+    return SettingsModel(
+      emptyStringSymbol: prefs.getString(_emptyStringSymbolKey) ?? defaults.emptyStringSymbol,
+      epsilonSymbol: prefs.getString(_epsilonSymbolKey) ?? defaults.epsilonSymbol,
+      themeMode: prefs.getString(_themeModeKey) ?? defaults.themeMode,
+      showGrid: prefs.getBool(_showGridKey) ?? defaults.showGrid,
+      showCoordinates: prefs.getBool(_showCoordinatesKey) ?? defaults.showCoordinates,
+      autoSave: prefs.getBool(_autoSaveKey) ?? defaults.autoSave,
+      showTooltips: prefs.getBool(_showTooltipsKey) ?? defaults.showTooltips,
+      gridSize: prefs.getDouble(_gridSizeKey) ?? defaults.gridSize,
+      nodeSize: prefs.getDouble(_nodeSizeKey) ?? defaults.nodeSize,
+      fontSize: prefs.getDouble(_fontSizeKey) ?? defaults.fontSize,
+    );
+  }
+
+  @override
+  Future<void> saveSettings(SettingsModel settings) async {
+    final prefs = await _getPreferences();
+
+    final results = await Future.wait<bool>([
+      prefs.setString(_emptyStringSymbolKey, settings.emptyStringSymbol),
+      prefs.setString(_epsilonSymbolKey, settings.epsilonSymbol),
+      prefs.setString(_themeModeKey, settings.themeMode),
+      prefs.setBool(_showGridKey, settings.showGrid),
+      prefs.setBool(_showCoordinatesKey, settings.showCoordinates),
+      prefs.setBool(_autoSaveKey, settings.autoSave),
+      prefs.setBool(_showTooltipsKey, settings.showTooltips),
+      prefs.setDouble(_gridSizeKey, settings.gridSize),
+      prefs.setDouble(_nodeSizeKey, settings.nodeSize),
+      prefs.setDouble(_fontSizeKey, settings.fontSize),
+    ]);
+
+    if (results.any((success) => !success)) {
+      throw Exception('Failed to save settings');
+    }
+  }
+}

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -1,7 +1,16 @@
 import 'package:flutter/material.dart';
 
+import 'package:jflutter/core/models/settings_model.dart';
+import 'package:jflutter/core/repositories/settings_repository.dart';
+import 'package:jflutter/data/repositories/settings_repository_impl.dart';
+
 class SettingsPage extends StatefulWidget {
-  const SettingsPage({super.key});
+  const SettingsPage({
+    super.key,
+    SettingsRepository? repository,
+  }) : repository = repository ?? const SharedPreferencesSettingsRepository();
+
+  final SettingsRepository repository;
 
   @override
   State<SettingsPage> createState() => _SettingsPageState();
@@ -9,16 +18,7 @@ class SettingsPage extends StatefulWidget {
 
 class _SettingsPageState extends State<SettingsPage> {
   bool _isLoading = false;
-  String _emptyStringSymbol = 'λ';
-  String _epsilonSymbol = 'ε';
-  String _themeMode = 'system';
-  bool _showGrid = true;
-  bool _showCoordinates = false;
-  bool _autoSave = true;
-  bool _showTooltips = true;
-  double _gridSize = 20.0;
-  double _nodeSize = 30.0;
-  double _fontSize = 14.0;
+  SettingsModel _settings = const SettingsModel();
 
   @override
   void initState() {
@@ -31,37 +31,75 @@ class _SettingsPageState extends State<SettingsPage> {
       _isLoading = true;
     });
 
-    // Simulate loading settings
-    await Future.delayed(const Duration(milliseconds: 500));
-
-    setState(() {
-      _isLoading = false;
-    });
+    try {
+      final settings = await widget.repository.loadSettings();
+      if (!mounted) return;
+      setState(() {
+        _settings = settings;
+        _isLoading = false;
+      });
+    } catch (error, stackTrace) {
+      debugPrint('Failed to load settings: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      if (!mounted) return;
+      setState(() {
+        _isLoading = false;
+      });
+      _showError('Failed to load settings. Please try again.');
+    }
   }
 
   Future<void> _saveSettings() async {
-    // TODO: Implement settings persistence
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Settings saved!')),
-    );
+    final currentSettings = _settings;
+
+    try {
+      await widget.repository.saveSettings(currentSettings);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Settings saved!')),
+      );
+    } catch (error, stackTrace) {
+      debugPrint('Failed to save settings: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      if (!mounted) return;
+      _showError('Failed to save settings. Please try again.');
+    }
   }
 
   Future<void> _resetToDefaults() async {
+    const defaults = SettingsModel();
+
     setState(() {
-      _emptyStringSymbol = 'λ';
-      _epsilonSymbol = 'ε';
-      _themeMode = 'system';
-      _showGrid = true;
-      _showCoordinates = false;
-      _autoSave = true;
-      _showTooltips = true;
-      _gridSize = 20.0;
-      _nodeSize = 30.0;
-      _fontSize = 14.0;
+      _settings = defaults;
     });
-    
+
+    try {
+      await widget.repository.saveSettings(defaults);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Settings reset to defaults!')),
+      );
+    } catch (error, stackTrace) {
+      debugPrint('Failed to reset settings: $error');
+      debugPrintStack(stackTrace: stackTrace);
+      if (!mounted) return;
+      _showError('Failed to reset settings. Please try again.');
+    }
+  }
+
+  void _showError(String message) {
+    final theme = Theme.of(context);
     ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Settings reset to defaults!')),
+      SnackBar(
+        content: Text(message),
+        backgroundColor: theme.colorScheme.error,
+        behavior: SnackBarBehavior.floating,
+        action: SnackBarAction(
+          label: 'Dismiss',
+          textColor: theme.colorScheme.onError,
+          onPressed: () {},
+        ),
+      ),
     );
   }
 
@@ -97,19 +135,19 @@ class _SettingsPageState extends State<SettingsPage> {
             _buildSectionHeader('Symbols'),
             _buildSymbolSettings(),
             const SizedBox(height: 24),
-            
+
             _buildSectionHeader('Theme'),
             _buildThemeSettings(),
             const SizedBox(height: 24),
-            
+
             _buildSectionHeader('Canvas'),
             _buildCanvasSettings(),
             const SizedBox(height: 24),
-            
+
             _buildSectionHeader('General'),
             _buildGeneralSettings(),
             const SizedBox(height: 24),
-            
+
             _buildSectionHeader('Actions'),
             _buildActionButtons(),
           ],
@@ -124,8 +162,8 @@ class _SettingsPageState extends State<SettingsPage> {
       child: Text(
         title,
         style: Theme.of(context).textTheme.titleLarge?.copyWith(
-          fontWeight: FontWeight.bold,
-        ),
+              fontWeight: FontWeight.bold,
+            ),
       ),
     );
   }
@@ -140,25 +178,35 @@ class _SettingsPageState extends State<SettingsPage> {
             _buildSimpleSetting(
               'Empty String Symbol',
               'Symbol used to represent empty string (λ or ε)',
-              _emptyStringSymbol,
-              ['λ (Lambda)', 'ε (Epsilon)'],
+              _settings.emptyStringSymbol,
+              const ['λ (Lambda)', 'ε (Epsilon)'],
               (value) {
                 setState(() {
-                  _emptyStringSymbol = value == 'λ (Lambda)' ? 'λ' : 'ε';
+                  _settings = _settings.copyWith(
+                    emptyStringSymbol: value == 'λ (Lambda)' ? 'λ' : 'ε',
+                  );
                 });
               },
+              chipKeyBuilder: (option) => ValueKey(
+                'settings_empty_string_${option.contains('Lambda') ? 'lambda' : 'epsilon'}',
+              ),
             ),
             const SizedBox(height: 16),
             _buildSimpleSetting(
               'Epsilon Symbol',
               'Symbol used to represent epsilon transitions',
-              _epsilonSymbol,
-              ['ε (Epsilon)', 'λ (Lambda)'],
+              _settings.epsilonSymbol,
+              const ['ε (Epsilon)', 'λ (Lambda)'],
               (value) {
                 setState(() {
-                  _epsilonSymbol = value == 'ε (Epsilon)' ? 'ε' : 'λ';
+                  _settings = _settings.copyWith(
+                    epsilonSymbol: value == 'ε (Epsilon)' ? 'ε' : 'λ',
+                  );
                 });
               },
+              chipKeyBuilder: (option) => ValueKey(
+                'settings_epsilon_${option.contains('Epsilon') ? 'epsilon' : 'lambda'}',
+              ),
             ),
           ],
         ),
@@ -176,13 +224,16 @@ class _SettingsPageState extends State<SettingsPage> {
             _buildSimpleSetting(
               'Theme Mode',
               'Choose your preferred theme',
-              _themeMode,
-              ['System', 'Light', 'Dark'],
+              _settings.themeMode,
+              const ['System', 'Light', 'Dark'],
               (value) {
                 setState(() {
-                  _themeMode = value.toLowerCase();
+                  _settings = _settings.copyWith(themeMode: value.toLowerCase());
                 });
               },
+              chipKeyBuilder: (option) => ValueKey(
+                'settings_theme_${option.toLowerCase()}',
+              ),
             ),
           ],
         ),
@@ -200,42 +251,67 @@ class _SettingsPageState extends State<SettingsPage> {
             _buildSwitchSetting(
               'Show Grid',
               'Display grid lines on canvas',
-              _showGrid,
-              (value) => setState(() => _showGrid = value),
+              _settings.showGrid,
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(showGrid: value);
+                });
+              },
+              switchKey: const ValueKey('settings_show_grid_switch'),
             ),
             const SizedBox(height: 16),
             _buildSwitchSetting(
               'Show Coordinates',
               'Display coordinate information',
-              _showCoordinates,
-              (value) => setState(() => _showCoordinates = value),
+              _settings.showCoordinates,
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(showCoordinates: value);
+                });
+              },
+              switchKey: const ValueKey('settings_show_coordinates_switch'),
             ),
             const SizedBox(height: 16),
             _buildSliderSetting(
               'Grid Size',
               'Size of grid cells',
-              _gridSize,
+              _settings.gridSize,
               10.0,
               50.0,
-              (value) => setState(() => _gridSize = value),
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(gridSize: value);
+                });
+              },
+              sliderKey: const ValueKey('settings_grid_size_slider'),
             ),
             const SizedBox(height: 16),
             _buildSliderSetting(
               'Node Size',
               'Size of automaton nodes',
-              _nodeSize,
+              _settings.nodeSize,
               20.0,
               60.0,
-              (value) => setState(() => _nodeSize = value),
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(nodeSize: value);
+                });
+              },
+              sliderKey: const ValueKey('settings_node_size_slider'),
             ),
             const SizedBox(height: 16),
             _buildSliderSetting(
               'Font Size',
               'Text size in the interface',
-              _fontSize,
+              _settings.fontSize,
               12.0,
               20.0,
-              (value) => setState(() => _fontSize = value),
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(fontSize: value);
+                });
+              },
+              sliderKey: const ValueKey('settings_font_size_slider'),
             ),
           ],
         ),
@@ -253,15 +329,25 @@ class _SettingsPageState extends State<SettingsPage> {
             _buildSwitchSetting(
               'Auto Save',
               'Automatically save changes',
-              _autoSave,
-              (value) => setState(() => _autoSave = value),
+              _settings.autoSave,
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(autoSave: value);
+                });
+              },
+              switchKey: const ValueKey('settings_auto_save_switch'),
             ),
             const SizedBox(height: 16),
             _buildSwitchSetting(
               'Show Tooltips',
               'Display helpful tooltips',
-              _showTooltips,
-              (value) => setState(() => _showTooltips = value),
+              _settings.showTooltips,
+              (value) {
+                setState(() {
+                  _settings = _settings.copyWith(showTooltips: value);
+                });
+              },
+              switchKey: const ValueKey('settings_show_tooltips_switch'),
             ),
           ],
         ),
@@ -281,6 +367,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 onPressed: _saveSettings,
                 icon: const Icon(Icons.save),
                 label: const Text('Save Settings'),
+                key: const ValueKey('settings_save_button'),
               ),
             ),
             const SizedBox(height: 12),
@@ -290,6 +377,7 @@ class _SettingsPageState extends State<SettingsPage> {
                 onPressed: _resetToDefaults,
                 icon: const Icon(Icons.restore),
                 label: const Text('Reset to Defaults'),
+                key: const ValueKey('settings_reset_button'),
               ),
             ),
           ],
@@ -303,8 +391,9 @@ class _SettingsPageState extends State<SettingsPage> {
     String subtitle,
     String currentValue,
     List<String> options,
-    Function(String) onChanged,
-  ) {
+    Function(String) onChanged, {
+    Key Function(String option)? chipKeyBuilder,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -322,13 +411,14 @@ class _SettingsPageState extends State<SettingsPage> {
           spacing: 8,
           children: options.map((option) {
             final isSelected = option.toLowerCase().contains(currentValue.toLowerCase()) ||
-                             (currentValue == 'λ' && option.contains('Lambda')) ||
-                             (currentValue == 'ε' && option.contains('Epsilon')) ||
-                             (currentValue == 'system' && option == 'System') ||
-                             (currentValue == 'light' && option == 'Light') ||
-                             (currentValue == 'dark' && option == 'Dark');
-            
+                (currentValue == 'λ' && option.contains('Lambda')) ||
+                (currentValue == 'ε' && option.contains('Epsilon')) ||
+                (currentValue == 'system' && option == 'System') ||
+                (currentValue == 'light' && option == 'Light') ||
+                (currentValue == 'dark' && option == 'Dark');
+
             return FilterChip(
+              key: chipKeyBuilder?.call(option),
               label: Text(option),
               selected: isSelected,
               onSelected: (selected) {
@@ -347,8 +437,9 @@ class _SettingsPageState extends State<SettingsPage> {
     String title,
     String subtitle,
     bool value,
-    Function(bool) onChanged,
-  ) {
+    Function(bool) onChanged, {
+    Key? switchKey,
+  }) {
     return Row(
       children: [
         Expanded(
@@ -368,6 +459,7 @@ class _SettingsPageState extends State<SettingsPage> {
           ),
         ),
         Switch(
+          key: switchKey,
           value: value,
           onChanged: onChanged,
         ),
@@ -381,8 +473,9 @@ class _SettingsPageState extends State<SettingsPage> {
     double value,
     double min,
     double max,
-    Function(double) onChanged,
-  ) {
+    Function(double) onChanged, {
+    Key? sliderKey,
+  }) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -400,6 +493,7 @@ class _SettingsPageState extends State<SettingsPage> {
           children: [
             Expanded(
               child: Slider(
+                key: sliderKey,
                 value: value,
                 min: min,
                 max: max,
@@ -419,3 +513,4 @@ class _SettingsPageState extends State<SettingsPage> {
     );
   }
 }
+

--- a/test/widget/settings_page_test.dart
+++ b/test/widget/settings_page_test.dart
@@ -1,0 +1,101 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+import 'package:jflutter/presentation/pages/settings_page.dart';
+
+void main() {
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  testWidgets('loads settings from stored preferences', (WidgetTester tester) async {
+    SharedPreferences.setMockInitialValues({
+      'settings_empty_string_symbol': 'ε',
+      'settings_epsilon_symbol': 'λ',
+      'settings_theme_mode': 'dark',
+      'settings_show_grid': false,
+      'settings_show_coordinates': true,
+      'settings_auto_save': false,
+      'settings_show_tooltips': false,
+      'settings_grid_size': 42.0,
+      'settings_node_size': 25.0,
+      'settings_font_size': 16.0,
+    });
+
+    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpAndSettle();
+
+    final emptyStringChip = tester.widget<FilterChip>(
+      find.byKey(const ValueKey('settings_empty_string_epsilon')),
+    );
+    expect(emptyStringChip.selected, isTrue);
+
+    final themeChip = tester.widget<FilterChip>(
+      find.byKey(const ValueKey('settings_theme_dark')),
+    );
+    expect(themeChip.selected, isTrue);
+
+    final showGridSwitch = tester.widget<Switch>(
+      find.byKey(const ValueKey('settings_show_grid_switch')),
+    );
+    expect(showGridSwitch.value, isFalse);
+
+    final showCoordinatesSwitch = tester.widget<Switch>(
+      find.byKey(const ValueKey('settings_show_coordinates_switch')),
+    );
+    expect(showCoordinatesSwitch.value, isTrue);
+
+    final gridSizeSlider = tester.widget<Slider>(
+      find.byKey(const ValueKey('settings_grid_size_slider')),
+    );
+    expect(gridSizeSlider.value, equals(42.0));
+  });
+
+  testWidgets('saves settings and restores them on next load', (WidgetTester tester) async {
+    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('settings_show_grid_switch')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('settings_show_tooltips_switch')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('settings_empty_string_epsilon')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('settings_theme_dark')));
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byKey(const ValueKey('settings_save_button')));
+    await tester.pump();
+    await tester.pump(const Duration(milliseconds: 500));
+
+    await tester.pumpWidget(const SizedBox.shrink());
+    await tester.pump();
+
+    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpAndSettle();
+
+    final reloadedGridSwitch = tester.widget<Switch>(
+      find.byKey(const ValueKey('settings_show_grid_switch')),
+    );
+    expect(reloadedGridSwitch.value, isFalse);
+
+    final reloadedTooltipSwitch = tester.widget<Switch>(
+      find.byKey(const ValueKey('settings_show_tooltips_switch')),
+    );
+    expect(reloadedTooltipSwitch.value, isFalse);
+
+    final reloadedEmptyChip = tester.widget<FilterChip>(
+      find.byKey(const ValueKey('settings_empty_string_epsilon')),
+    );
+    expect(reloadedEmptyChip.selected, isTrue);
+
+    final reloadedThemeChip = tester.widget<FilterChip>(
+      find.byKey(const ValueKey('settings_theme_dark')),
+    );
+    expect(reloadedThemeChip.selected, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add a reusable settings model and repository interface backed by SharedPreferences
- update the settings page to load/save preferences asynchronously with error handling and widget keys for testing
- add widget tests that ensure stored values are rendered and persist across app reloads

## Testing
- flutter test *(fails: `flutter` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca2fa2164832e9e79bc0810a489a5