### PR TITLE
Fix algorithm repository transition mapping

### DIFF
--- a/test/unit/algorithms/algorithm_repository_impl_test.dart
+++ b/test/unit/algorithms/algorithm_repository_impl_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/data/repositories/algorithm_repository_impl.dart';
+
+void main() {
+  group('AlgorithmRepositoryImpl conversions', () {
+    test('round-trips automaton entity preserving transitions and alphabet', () async {
+      final repository = AlgorithmRepositoryImpl();
+
+      const states = [
+        StateEntity(
+          id: 's0',
+          name: 'q0',
+          x: 0,
+          y: 0,
+          isInitial: true,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 's1',
+          name: 'q1',
+          x: 100,
+          y: 0,
+          isInitial: false,
+          isFinal: true,
+        ),
+        StateEntity(
+          id: 's2',
+          name: 'q2',
+          x: 200,
+          y: 0,
+          isInitial: false,
+          isFinal: false,
+        ),
+      ];
+
+      final transitions = {
+        's0|a': ['s1'],
+        's1|b': ['s0', 's2'],
+        's0|λ': ['s2'],
+      };
+
+      final entity = AutomatonEntity(
+        id: 'a1',
+        name: 'Automaton',
+        alphabet: {'a', 'b', 'λ'},
+        states: states,
+        transitions: transitions,
+        initialId: 's0',
+        nextId: 3,
+        type: AutomatonType.nfaLambda,
+      );
+
+      final result = await repository.removeLambdaTransitions(entity);
+
+      expect(result.isSuccess, isTrue);
+      final roundTripped = result.data!;
+
+      Map<String, List<String>> normalize(Map<String, List<String>> input) {
+        return input.map((key, value) {
+          final sorted = [...value]..sort();
+          return MapEntry(key, sorted);
+        });
+      }
+
+      expect(roundTripped.alphabet, equals(entity.alphabet));
+      expect(normalize(roundTripped.transitions), equals(normalize(transitions)));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- create FSATransition instances when converting automaton entities to the core model
- rebuild transition maps from core models so entity round-trips keep connections intact
- add a unit test covering entity-to-model-to-entity conversion of transitions and alphabet

## Testing
- `flutter test test/unit/algorithms/algorithm_repository_impl_test.dart` *(fails: flutter not available in environment)*
- `dart test test/unit/algorithms/algorithm_repository_impl_test.dart` *(fails: dart not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca32ac008832e8fc43c816384213a