### PR TITLE
Implement FAB creation flows for automata and grammars

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/automaton_provider.dart';
+import '../providers/grammar_provider.dart';
 import '../providers/home_navigation_provider.dart';
 import '../widgets/mobile_navigation.dart';
 import 'fsa_page.dart';
@@ -178,18 +180,32 @@ class _HomePageState extends ConsumerState<HomePage> {
     }
   }
 
-  void _createNewAutomaton(BuildContext context) {
-    // TODO: Implement new automaton creation
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Create new automaton - Coming soon!')),
+  Future<void> _createNewAutomaton(BuildContext context) async {
+    final automatonNotifier = ref.read(automatonProvider.notifier);
+
+    await automatonNotifier.createAutomaton(
+      name: 'Untitled Automaton',
+      alphabet: const ['0', '1'],
     );
+
+    if (!mounted) return;
+
+    final automatonState = ref.read(automatonProvider);
+    if (automatonState.error != null) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text(automatonState.error!)),
+      );
+      return;
+    }
+
+    ref.read(homeNavigationProvider.notifier).goToFsa();
   }
 
   void _createNewGrammar(BuildContext context) {
-    // TODO: Implement new grammar creation
-    ScaffoldMessenger.of(context).showSnackBar(
-      const SnackBar(content: Text('Create new grammar - Coming soon!')),
-    );
+    ref.read(grammarProvider.notifier).createNewGrammar();
+    ref
+        .read(homeNavigationProvider.notifier)
+        .setIndex(HomeNavigationNotifier.grammarIndex);
   }
 
   void _showHelpDialog(BuildContext context) {

--- a/lib/presentation/providers/grammar_provider.dart
+++ b/lib/presentation/providers/grammar_provider.dart
@@ -147,6 +147,23 @@ class GrammarProvider extends StateNotifier<GrammarState> {
     }
   }
 
+  /// Resets the grammar editor to a fresh grammar definition.
+  void createNewGrammar({
+    String? name,
+    String? startSymbol,
+    GrammarType? type,
+  }) {
+    state = GrammarState(
+      name: name ?? 'My Grammar',
+      startSymbol: startSymbol ?? 'S',
+      productions: const [],
+      type: type ?? GrammarType.regular,
+      isConverting: false,
+      nextProductionId: 1,
+      error: null,
+    );
+  }
+
   Grammar buildGrammar() {
     final now = DateTime.now();
     final nonTerminals = <String>{state.startSymbol};

--- a/test/integration/home_fab_actions_test.dart
+++ b/test/integration/home_fab_actions_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/app.dart';
+import 'package:jflutter/core/models/grammar.dart';
+import 'package:jflutter/presentation/pages/fsa_page.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:jflutter/presentation/providers/grammar_provider.dart';
+import 'package:jflutter/presentation/widgets/automaton_canvas.dart';
+import 'package:jflutter/presentation/widgets/grammar_editor.dart';
+
+void main() {
+  group('Home FAB actions', () {
+    testWidgets('creates a new automaton and opens the editor',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(const JFlutterApp());
+      await tester.pumpAndSettle();
+
+      expect(find.byType(FSAPage), findsOneWidget);
+
+      await tester.tap(find.byTooltip('Create New Automaton'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ProviderScope)),
+        listen: false,
+      );
+
+      final automatonState = container.read(automatonProvider);
+      expect(automatonState.currentAutomaton, isNotNull);
+
+      expect(find.byType(AutomatonCanvas), findsOneWidget);
+      expect(find.text('Empty Canvas'), findsNothing);
+    });
+
+    testWidgets('creates a new grammar and shows the grammar editor',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(const JFlutterApp());
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Grammar'));
+      await tester.pumpAndSettle();
+
+      final container = ProviderScope.containerOf(
+        tester.element(find.byType(ProviderScope)),
+        listen: false,
+      );
+
+      container.read(grammarProvider.notifier).addProduction(
+            leftSide: const ['S'],
+            rightSide: const ['a'],
+          );
+      await tester.pump();
+
+      await tester.tap(find.byTooltip('Create New Grammar'));
+      await tester.pumpAndSettle();
+
+      final grammarState = container.read(grammarProvider);
+      expect(grammarState.productions, isEmpty);
+      expect(grammarState.name, 'My Grammar');
+      expect(grammarState.startSymbol, 'S');
+      expect(grammarState.type, GrammarType.regular);
+
+      expect(find.byType(GrammarEditor), findsWidgets);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- wire the home page FAB to create new automata via AutomatonProvider and keep the editor in view
- add a reset helper on GrammarProvider and invoke it when starting a new grammar from the FAB
- cover the creation flows with widget tests that confirm the editors are opened with new entities

## Testing
- `flutter test` *(fails: flutter not installed in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cca2f35d18832e873c4939667a9680