### PR TITLE
Implement automaton layout algorithms

### DIFF
--- a/lib/features/layout/layout_repository_impl.dart
+++ b/lib/features/layout/layout_repository_impl.dart
@@ -1,4 +1,5 @@
 
+import 'dart:collection';
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 import '../../core/entities/automaton_entity.dart';
@@ -6,6 +7,14 @@ import '../../core/repositories/automaton_repository.dart';
 import '../../core/result.dart';
 
 class LayoutRepositoryImpl implements LayoutRepository {
+  static const Vector2 _canvasSize = Vector2(800, 600);
+  static const double _canvasPadding = 60;
+  static const double _minLayoutSize = 160;
+  static const double _goldenAngle = math.pi * (3 - math.sqrt(5));
+
+  static Vector2 get _canvasCenter =>
+      Vector2(_canvasSize.x / 2, _canvasSize.y / 2);
+
   @override
   Future<AutomatonResult> applyAutoLayout(AutomatonEntity automaton) async {
     final states = automaton.states;
@@ -25,31 +34,372 @@ class LayoutRepositoryImpl implements LayoutRepository {
       newStates.add(states[i].copyWith(x: x, y: y));
     }
 
-    return Success(automaton.copyWith(states: newStates));
+    final positionedStates = _mergeStates(states, newStates);
+    return Success(automaton.copyWith(states: positionedStates));
   }
 
   @override
   Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) async {
-    return Failure('Balanced layout not implemented');
+    final states = automaton.states;
+    if (states.isEmpty) {
+      return Success(automaton);
+    }
+
+    final area = _computeLayoutArea(states);
+    final columns = area.columns;
+    int rows = (states.length / columns).ceil();
+    if (rows < 1) rows = 1;
+
+    final newStates = <StateEntity>[];
+    final double top = area.center.y - area.height / 2;
+    final double verticalSpacing = rows > 1 ? area.height / (rows - 1) : 0;
+
+    int index = 0;
+    for (int row = 0; row < rows; row++) {
+      if (index >= states.length) break;
+      final remaining = states.length - index;
+      final itemsInRow = row == rows - 1
+          ? remaining
+          : (remaining < columns ? remaining : columns);
+
+      final horizontalSpacing = itemsInRow > 1
+          ? area.width / (itemsInRow - 1)
+          : 0;
+      final effectiveWidth = horizontalSpacing * (itemsInRow - 1);
+      final startX = itemsInRow > 1
+          ? area.center.x - effectiveWidth / 2
+          : area.center.x;
+
+      for (int col = 0; col < itemsInRow; col++) {
+        if (index >= states.length) break;
+        final state = states[index];
+        final x = startX + col * horizontalSpacing;
+        final y = rows == 1 ? area.center.y : top + row * verticalSpacing;
+        newStates.add(state.copyWith(x: x, y: y));
+        index++;
+      }
+    }
+
+    final positionedStates = _mergeStates(states, newStates);
+    return Success(automaton.copyWith(states: positionedStates));
   }
 
   @override
   Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) async {
-    return Failure('Compact layout not implemented');
+    final states = automaton.states;
+    if (states.isEmpty) {
+      return Success(automaton);
+    }
+
+    final area = _computeLayoutArea(states, scaleX: 0.8, scaleY: 0.8);
+    final center = area.center;
+    final maxRadiusX = area.width / 2;
+    final maxRadiusY = area.height / 2;
+    final maxRadius = math.min(maxRadiusX, maxRadiusY);
+    final spacing = maxRadius /
+        math.max(1, math.sqrt(states.length.toDouble()));
+
+    final newStates = <StateEntity>[];
+    for (int i = 0; i < states.length; i++) {
+      final angle = i * _goldenAngle;
+      final radius = spacing * math.sqrt(i + 1);
+      final target = Vector2(
+        center.x + math.cos(angle) * radius,
+        center.y + math.sin(angle) * radius,
+      );
+      final clamped = _clampToArea(target, center, maxRadiusX, maxRadiusY);
+      newStates.add(states[i].copyWith(x: clamped.x, y: clamped.y));
+    }
+
+    final positionedStates = _mergeStates(states, newStates);
+    return Success(automaton.copyWith(states: positionedStates));
   }
 
   @override
   Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) async {
-    return Failure('Hierarchical layout not implemented');
+    final states = automaton.states;
+    if (states.isEmpty) {
+      return Success(automaton);
+    }
+
+    final stateById = {for (final s in states) s.id: s};
+    final adjacency = <String, Set<String>>{};
+    for (final entry in automaton.transitions.entries) {
+      final from = entry.key.split('|').first;
+      adjacency.putIfAbsent(from, () => <String>{}).addAll(entry.value);
+    }
+
+    final visited = <String>{};
+    final layers = <List<StateEntity>>[];
+    final queue = Queue<(String, int)>();
+
+    if (automaton.initialId != null && stateById.containsKey(automaton.initialId)) {
+      queue.add((automaton.initialId!, 0));
+    }
+
+    for (final state in states) {
+      if (queue.any((entry) => entry.$1 == state.id)) continue;
+      if (state.id == automaton.initialId) continue;
+      queue.add((state.id, 0));
+    }
+
+    while (queue.isNotEmpty) {
+      final (id, depth) = queue.removeFirst();
+      if (visited.contains(id)) {
+        continue;
+      }
+      final state = stateById[id];
+      if (state == null) {
+        continue;
+      }
+      visited.add(id);
+      while (layers.length <= depth) {
+        layers.add(<StateEntity>[]);
+      }
+      layers[depth].add(state);
+
+      for (final neighbor in adjacency[id] ?? const <String>{}) {
+        if (!visited.contains(neighbor) && stateById.containsKey(neighbor)) {
+          queue.add((neighbor, depth + 1));
+        }
+      }
+    }
+
+    final remaining = states.where((s) => !visited.contains(s.id));
+    for (final state in remaining) {
+      layers.add([state]);
+    }
+
+    final area = _computeLayoutArea(states, scaleX: 1.1, scaleY: 1.3);
+    final newStates = <StateEntity>[];
+    final left = area.center.x - area.width / 2;
+    final top = area.center.y - area.height / 2;
+    final verticalSpacing = layers.length > 1 ? area.height / (layers.length - 1) : 0;
+
+    for (int i = 0; i < layers.length; i++) {
+      final layerStates = layers[i];
+      if (layerStates.isEmpty) continue;
+      final y = layers.length == 1 ? area.center.y : top + i * verticalSpacing;
+      final count = layerStates.length;
+      final horizontalSpacing = count > 1 ? area.width / (count - 1) : 0;
+      final startX = count > 1
+          ? left
+          : area.center.x;
+
+      for (int j = 0; j < layerStates.length; j++) {
+        final state = layerStates[j];
+        final x = count > 1 ? startX + j * horizontalSpacing : startX;
+        newStates.add(state.copyWith(x: x, y: y));
+      }
+    }
+
+    final positionedStates = _mergeStates(states, newStates);
+    return Success(automaton.copyWith(states: positionedStates));
   }
 
   @override
   Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) async {
-    return Failure('Spread layout not implemented');
+    final states = automaton.states;
+    if (states.isEmpty) {
+      return Success(automaton);
+    }
+
+    if (states.length == 1) {
+      final area = _computeLayoutArea(states, scaleX: 1.2, scaleY: 1.2);
+      return Success(
+        automaton.copyWith(
+          states: [states.first.copyWith(x: area.center.x, y: area.center.y)],
+        ),
+      );
+    }
+
+    final area = _computeLayoutArea(states, scaleX: 1.2, scaleY: 1.2);
+    final maxRadiusX = area.width / 2;
+    final maxRadiusY = area.height / 2;
+    final rings = math.max(1, math.sqrt(states.length).ceil());
+    final perRing = (states.length / rings).ceil();
+
+    final newStates = <StateEntity>[];
+    int processed = 0;
+    for (int ring = 0; ring < rings && processed < states.length; ring++) {
+      final remaining = states.length - processed;
+      final ringSize = ring == rings - 1 ? remaining : math.min(perRing, remaining);
+      final ringFactor = rings == 1 ? 1.0 : (ring + 1) / rings;
+      final radiusX = maxRadiusX * ringFactor;
+      final radiusY = maxRadiusY * ringFactor;
+
+      for (int i = 0; i < ringSize; i++) {
+        final state = states[processed + i];
+        final angle = (2 * math.pi * i) / ringSize;
+        final x = area.center.x + math.cos(angle) * radiusX;
+        final y = area.center.y + math.sin(angle) * radiusY;
+        newStates.add(state.copyWith(x: x, y: y));
+      }
+      processed += ringSize;
+    }
+
+    final positionedStates = _mergeStates(states, newStates);
+    return Success(automaton.copyWith(states: positionedStates));
   }
 
   @override
   Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) async {
-    return Failure('Center automaton not implemented');
+    final states = automaton.states;
+    if (states.isEmpty) {
+      return Success(automaton);
+    }
+
+    final centroid = _computeCentroid(states);
+    final offset = _canvasCenter - centroid;
+    final newStates = [
+      for (final state in states)
+        state.copyWith(x: state.x + offset.x, y: state.y + offset.y)
+    ];
+
+    return Success(automaton.copyWith(states: newStates));
   }
+}
+
+class _Bounds {
+  final double minX;
+  final double minY;
+  final double maxX;
+  final double maxY;
+
+  const _Bounds({
+    required this.minX,
+    required this.minY,
+    required this.maxX,
+    required this.maxY,
+  });
+
+  double get width => maxX - minX;
+  double get height => maxY - minY;
+
+  Vector2 get center => Vector2(
+        (minX + maxX) / 2,
+        (minY + maxY) / 2,
+      );
+
+  factory _Bounds.fromStates(List<StateEntity> states) {
+    double minX = double.infinity;
+    double minY = double.infinity;
+    double maxX = double.negativeInfinity;
+    double maxY = double.negativeInfinity;
+
+    for (final state in states) {
+      if (state.x < minX) minX = state.x;
+      if (state.y < minY) minY = state.y;
+      if (state.x > maxX) maxX = state.x;
+      if (state.y > maxY) maxY = state.y;
+    }
+
+    if (minX == double.infinity) {
+      return const _Bounds(minX: 0, minY: 0, maxX: 0, maxY: 0);
+    }
+
+    return _Bounds(minX: minX, minY: minY, maxX: maxX, maxY: maxY);
+  }
+}
+
+class _LayoutArea {
+  final Vector2 center;
+  final double width;
+  final double height;
+  final int columns;
+
+  const _LayoutArea({
+    required this.center,
+    required this.width,
+    required this.height,
+    required this.columns,
+  });
+}
+
+_LayoutArea _computeLayoutArea(
+  List<StateEntity> states, {
+  double scaleX = 1.0,
+  double scaleY = 1.0,
+}) {
+  final bounds = _Bounds.fromStates(states);
+  final baseCenter = bounds.center;
+  final width = _scaledDimension(
+    bounds.width,
+    scaleX,
+    LayoutRepositoryImpl._canvasSize.x,
+  );
+  final height = _scaledDimension(
+    bounds.height,
+    scaleY,
+    LayoutRepositoryImpl._canvasSize.y,
+  );
+  final center = _adjustCenter(baseCenter, width, height);
+  int columns = math.sqrt(states.length).ceil();
+  if (columns < 1) {
+    columns = 1;
+  }
+
+  return _LayoutArea(center: center, width: width, height: height, columns: columns);
+}
+
+double _scaledDimension(double original, double scale, double canvasDimension) {
+  final available = math.max(1.0, canvasDimension - 2 * LayoutRepositoryImpl._canvasPadding);
+  final minSize = math.min(LayoutRepositoryImpl._minLayoutSize, available);
+  final base = math.max(original.abs(), LayoutRepositoryImpl._minLayoutSize);
+  final scaled = base * scale;
+  final clamped = scaled.clamp(minSize, available);
+  return clamped.toDouble();
+}
+
+Vector2 _adjustCenter(Vector2 desired, double width, double height) {
+  final halfWidth = width / 2;
+  final halfHeight = height / 2;
+  final minX = LayoutRepositoryImpl._canvasPadding + halfWidth;
+  final maxX = LayoutRepositoryImpl._canvasSize.x - LayoutRepositoryImpl._canvasPadding - halfWidth;
+  final minY = LayoutRepositoryImpl._canvasPadding + halfHeight;
+  final maxY = LayoutRepositoryImpl._canvasSize.y - LayoutRepositoryImpl._canvasPadding - halfHeight;
+
+  final x = desired.x.clamp(minX, maxX);
+  final y = desired.y.clamp(minY, maxY);
+  return Vector2(x.toDouble(), y.toDouble());
+}
+
+Vector2 _clampToArea(
+  Vector2 point,
+  Vector2 center,
+  double radiusX,
+  double radiusY,
+) {
+  final minX = center.x - radiusX;
+  final maxX = center.x + radiusX;
+  final minY = center.y - radiusY;
+  final maxY = center.y + radiusY;
+
+  return Vector2(
+    point.x.clamp(minX, maxX).toDouble(),
+    point.y.clamp(minY, maxY).toDouble(),
+  );
+}
+
+Vector2 _computeCentroid(List<StateEntity> states) {
+  double sumX = 0;
+  double sumY = 0;
+  for (final state in states) {
+    sumX += state.x;
+    sumY += state.y;
+  }
+  return Vector2(sumX / states.length, sumY / states.length);
+}
+
+List<StateEntity> _mergeStates(
+  List<StateEntity> original,
+  Iterable<StateEntity> positioned,
+) {
+  final positionedById = <String, StateEntity>{
+    for (final state in positioned) state.id: state,
+  };
+
+  return [
+    for (final state in original) positionedById[state.id] ?? state,
+  ];
 }

--- a/test/unit/features/layout_repository_impl_test.dart
+++ b/test/unit/features/layout_repository_impl_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/lib/core/entities/automaton_entity.dart';
+import 'package:jflutter/lib/features/layout/layout_repository_impl.dart';
+
+void main() {
+  late LayoutRepositoryImpl repository;
+
+  setUp(() {
+    repository = LayoutRepositoryImpl();
+  });
+
+  AutomatonEntity buildAutomaton() {
+    return const AutomatonEntity(
+      id: 'auto',
+      name: 'Test',
+      alphabet: {'0', '1'},
+      states: [
+        StateEntity(
+          id: 'q0',
+          name: 'q0',
+          x: 60,
+          y: 80,
+          isInitial: true,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 'q1',
+          name: 'q1',
+          x: 280,
+          y: 120,
+          isInitial: false,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 'q2',
+          name: 'q2',
+          x: 520,
+          y: 160,
+          isInitial: false,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 'q3',
+          name: 'q3',
+          x: 140,
+          y: 360,
+          isInitial: false,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 'q4',
+          name: 'q4',
+          x: 420,
+          y: 380,
+          isInitial: false,
+          isFinal: false,
+        ),
+        StateEntity(
+          id: 'q5',
+          name: 'q5',
+          x: 660,
+          y: 420,
+          isInitial: false,
+          isFinal: true,
+        ),
+      ],
+      transitions: {
+        'q0|0': ['q1', 'q2'],
+        'q1|1': ['q3'],
+        'q2|0': ['q3'],
+        'q3|1': ['q4'],
+        'q4|0': ['q5'],
+      },
+      initialId: 'q0',
+      nextId: 6,
+      type: AutomatonType.dfa,
+    );
+  }
+
+  test('balanced layout arranges states in grid within canvas bounds', () async {
+    final automaton = buildAutomaton();
+    final result = await repository.applyBalancedLayout(automaton);
+
+    expect(result.isSuccess, isTrue);
+    final laidOut = result.data!;
+    expect(laidOut.states, hasLength(automaton.states.length));
+
+    final bounds = _boundsOf(laidOut.states);
+    expect(bounds.width, greaterThan(0));
+    expect(bounds.height, greaterThan(0));
+    expect(_withinCanvas(bounds), isTrue);
+  });
+
+  test('compact layout keeps automaton tighter than original bounds', () async {
+    final automaton = buildAutomaton();
+    final originalBounds = _boundsOf(automaton.states);
+
+    final result = await repository.applyCompactLayout(automaton);
+
+    expect(result.isSuccess, isTrue);
+    final laidOut = result.data!;
+    final bounds = _boundsOf(laidOut.states);
+
+    expect(bounds.width <= originalBounds.width + 1e-6, isTrue);
+    expect(bounds.height <= originalBounds.height + 1e-6, isTrue);
+    expect(_withinCanvas(bounds), isTrue);
+  });
+
+  test('hierarchical layout places successors on lower levels', () async {
+    final automaton = buildAutomaton();
+    final result = await repository.applyHierarchicalLayout(automaton);
+
+    expect(result.isSuccess, isTrue);
+    final laidOut = result.data!;
+    final yById = {for (final state in laidOut.states) state.id: state.y};
+
+    expect(yById['q0']! <= yById['q1']!, isTrue);
+    expect(yById['q0']! <= yById['q2']!, isTrue);
+    expect(yById['q1']! <= yById['q3']!, isTrue);
+    expect(yById['q3']! <= yById['q4']!, isTrue);
+    expect(yById['q4']! <= yById['q5']!, isTrue);
+
+    final bounds = _boundsOf(laidOut.states);
+    expect(_withinCanvas(bounds), isTrue);
+  });
+
+  test('spread layout expands positions compared to compact layout', () async {
+    final automaton = buildAutomaton();
+    final compact = await repository.applyCompactLayout(automaton);
+    final spread = await repository.applySpreadLayout(automaton);
+
+    expect(compact.isSuccess, isTrue);
+    expect(spread.isSuccess, isTrue);
+
+    final compactBounds = _boundsOf(compact.data!.states);
+    final spreadBounds = _boundsOf(spread.data!.states);
+
+    expect(spreadBounds.width + 1e-6, greaterThanOrEqualTo(compactBounds.width));
+    expect(spreadBounds.height + 1e-6, greaterThanOrEqualTo(compactBounds.height));
+    expect(_withinCanvas(spreadBounds), isTrue);
+  });
+
+  test('center automaton recenters centroid on canvas', () async {
+    final automaton = buildAutomaton();
+    final result = await repository.centerAutomaton(automaton);
+
+    expect(result.isSuccess, isTrue);
+    final laidOut = result.data!;
+
+    final centroid = _centroidOf(laidOut.states);
+    expect(centroid.$1, closeTo(400, 1e-6));
+    expect(centroid.$2, closeTo(300, 1e-6));
+  });
+}
+
+class _BoundsData {
+  final double minX;
+  final double minY;
+  final double maxX;
+  final double maxY;
+
+  const _BoundsData(this.minX, this.minY, this.maxX, this.maxY);
+
+  double get width => maxX - minX;
+  double get height => maxY - minY;
+}
+
+_BoundsData _boundsOf(List<StateEntity> states) {
+  double minX = double.infinity;
+  double minY = double.infinity;
+  double maxX = double.negativeInfinity;
+  double maxY = double.negativeInfinity;
+
+  for (final state in states) {
+    if (state.x < minX) minX = state.x;
+    if (state.y < minY) minY = state.y;
+    if (state.x > maxX) maxX = state.x;
+    if (state.y > maxY) maxY = state.y;
+  }
+
+  return _BoundsData(minX, minY, maxX, maxY);
+}
+
+bool _withinCanvas(_BoundsData bounds) {
+  const double padding = 60;
+  const double width = 800;
+  const double height = 600;
+  return bounds.minX >= padding - 1e-6 &&
+      bounds.maxX <= width - padding + 1e-6 &&
+      bounds.minY >= padding - 1e-6 &&
+      bounds.maxY <= height - padding + 1e-6;
+}
+
+(double, double) _centroidOf(List<StateEntity> states) {
+  double sumX = 0;
+  double sumY = 0;
+  for (final state in states) {
+    sumX += state.x;
+    sumY += state.y;
+  }
+  return (sumX / states.length, sumY / states.length);
+}


### PR DESCRIPTION
## Summary
- implement balanced, compact, hierarchical, and spread layouts with shared geometry helpers and canvas bounds awareness
- add centering logic to translate automata so their centroid aligns with the canvas center
- create unit tests that exercise each layout strategy and verify generated coordinates stay in range

## Testing
- flutter test test/unit/features/layout_repository_impl_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccaa4f4668832e81843f092d7558b8