### PR TITLE
Configure Android release signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,31 @@ flutter pub get
 flutter run
 ```
 
+### Android release signing
+
+Android release builds are signed with the `dev.jflutter.app` application ID. The Gradle script reads release keystore
+credentials from `android/key.properties`, so make sure the file exists before building a release artifact.
+
+1. Generate or obtain a release keystore (for example `android/keystores/jflutter-release.jks`). Keep this file out of
+   version control.
+2. Copy `android/key.properties.example` to `android/key.properties`.
+3. Replace the placeholder passwords and alias information with the values that match your keystore. The `storeFile`
+   entry can be an absolute path or a path relative to the project root.
+
+For CI/CD, store the keystore and credential values as encrypted secrets. During the workflow, recreate the keystore file
+and write `key.properties` before calling `flutter build`. Example (GitHub Actions):
+
+```bash
+mkdir -p android/keystores
+echo "$JFLUTTER_KEYSTORE_BASE64" | base64 --decode > android/keystores/jflutter-release.jks
+cat <<'EOF' > android/key.properties
+storeFile=keystores/jflutter-release.jks
+storePassword=$JFLUTTER_KEYSTORE_PASSWORD
+keyAlias=$JFLUTTER_KEY_ALIAS
+keyPassword=$JFLUTTER_KEY_PASSWORD
+EOF
+```
+
 ### Platform Support
 - ✅ **Android** - Full support with touch optimization
 - ✅ **iOS** - Full support with native feel (tested on iPhone 17 Pro Max)

--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.util.Properties
+
 plugins {
     id("com.android.application")
     id("kotlin-android")
@@ -5,8 +7,16 @@ plugins {
     id("dev.flutter.flutter-gradle-plugin")
 }
 
+val keystoreProperties = Properties()
+val keystorePropertiesFile = rootProject.file("key.properties")
+if (keystorePropertiesFile.exists()) {
+    keystorePropertiesFile.inputStream().use { keystoreProperties.load(it) }
+} else {
+    println("Warning: key.properties not found. Release builds will require a signing configuration.")
+}
+
 android {
-    namespace = "com.example.jflutter"
+    namespace = "dev.jflutter.app"
     compileSdk = flutter.compileSdkVersion
     ndkVersion = flutter.ndkVersion
 
@@ -20,8 +30,7 @@ android {
     }
 
     defaultConfig {
-        // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
-        applicationId = "com.example.jflutter"
+        applicationId = "dev.jflutter.app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = flutter.minSdkVersion
@@ -30,11 +39,25 @@ android {
         versionName = flutter.versionName
     }
 
+    signingConfigs {
+        create("release") {
+            val storeFilePath = keystoreProperties["storeFile"] as String?
+            if (!storeFilePath.isNullOrBlank()) {
+                storeFile = rootProject.file(storeFilePath)
+            }
+            storePassword = keystoreProperties["storePassword"] as String?
+            keyAlias = keystoreProperties["keyAlias"] as String?
+            keyPassword = keystoreProperties["keyPassword"] as String?
+        }
+    }
+
     buildTypes {
         release {
-            // TODO: Add your own signing config for the release build.
-            // Signing with the debug keys for now, so `flutter run --release` works.
-            signingConfig = signingConfigs.getByName("debug")
+            signingConfig = if (keystoreProperties.isNotEmpty()) {
+                signingConfigs.getByName("release")
+            } else {
+                signingConfigs.getByName("debug")
+            }
         }
     }
 }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="dev.jflutter.app">
     <application
         android:label="JFlutter"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/dev/jflutter/app/MainActivity.kt
+++ b/android/app/src/main/kotlin/dev/jflutter/app/MainActivity.kt
@@ -1,4 +1,4 @@
-package com.example.jflutter
+package dev.jflutter.app
 
 import io.flutter.embedding.android.FlutterActivity
 

--- a/android/key.properties.example
+++ b/android/key.properties.example
@@ -1,0 +1,7 @@
+# Example release keystore configuration for JFlutter.
+# Copy this file to android/key.properties and replace the placeholder values.
+# Never commit the real key.properties file because it contains sensitive credentials.
+storeFile=keystores/jflutter-release.jks
+storePassword=changeit
+keyAlias=jflutter
+keyPassword=changeit


### PR DESCRIPTION
## Summary
- update the Android application ID to the final dev.jflutter.app namespace
- add a release signing configuration that reads keystore credentials from key.properties
- document the keystore setup and add an example key.properties file for CI/CD workflows

## Testing
- ⚠️ `flutter analyze` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb185811c832eb6b9fb210b678828