### PR TITLE
Add Flutter app delegate launch unit test

### DIFF
--- a/ios/RunnerTests/RunnerTests.swift
+++ b/ios/RunnerTests/RunnerTests.swift
@@ -1,12 +1,27 @@
 import Flutter
 import UIKit
 import XCTest
+@testable import Runner
 
 class RunnerTests: XCTestCase {
+  func testFlutterAppDelegateSetsUpWindowAndRootController() {
+    let application = UIApplication.shared
+    let appDelegate = AppDelegate()
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+    let didFinishLaunching = appDelegate.application(application, didFinishLaunchingWithOptions: nil)
+
+    XCTAssertTrue(didFinishLaunching, "AppDelegate should report a successful launch")
+    XCTAssertNotNil(appDelegate.window, "AppDelegate should create the main window")
+
+    let rootViewController = appDelegate.window?.rootViewController
+    XCTAssertNotNil(rootViewController, "AppDelegate should assign a rootViewController")
+    XCTAssertTrue(
+      rootViewController is FlutterViewController,
+      "Root view controller should be a FlutterViewController"
+    )
+
+    let flutterViewController = rootViewController as? FlutterViewController
+    flutterViewController?.loadViewIfNeeded()
+    XCTAssertNotNil(flutterViewController?.view, "FlutterViewController should load its view successfully")
   }
-
 }


### PR DESCRIPTION
## Summary
- replace the placeholder Runner unit test with a check that exercises `AppDelegate`
- verify the Flutter app delegate reports a successful launch and installs a `FlutterViewController`
- ensure the Flutter root view loads during the test

## Testing
- `xcodebuild test -workspace Runner.xcworkspace -scheme Runner -destination 'platform=iOS Simulator,name=iPhone 14'` *(fails: command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb17edff0832e99e172285dbf6766