### PR TITLE
Add macOS runner host test

### DIFF
--- a/macos/RunnerTests/RunnerTests.swift
+++ b/macos/RunnerTests/RunnerTests.swift
@@ -4,9 +4,19 @@ import XCTest
 
 class RunnerTests: XCTestCase {
 
-  func testExample() {
-    // If you add code to the Runner application, consider adding tests here.
-    // See https://developer.apple.com/documentation/xctest for more information about using XCTest.
+  func testFlutterWindowIsConfiguredWithFlutterViewController() {
+    // Access the shared application instance to match the runner's startup path.
+    let app = NSApplication.shared
+    XCTAssertNotNil(app)
+
+    // Instantiate the runner window and trigger the wiring performed in awakeFromNib.
+    let window = MainFlutterWindow()
+    defer { window.close() }
+
+    window.awakeFromNib()
+
+    // The runner should host a FlutterViewController after setup.
+    XCTAssertTrue(window.contentViewController is FlutterViewController)
   }
 
 }


### PR DESCRIPTION
## Summary
- replace the placeholder RunnerTests case with a check that instantiating the main window results in a FlutterViewController
- touch the shared NSApplication instance so the test exercises the same startup path as the runner

## Testing
- `xcodebuild test -project macos/Runner.xcodeproj -scheme Runner -destination 'platform=macOS'` *(fails: `xcodebuild` is not available in the container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb177ae88832e9f91fbddef3bf05b