### PR TITLE
Update web metadata for JFlutter tooling

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,7 +18,7 @@
 
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
-  <meta name="description" content="A new Flutter project.">
+  <meta name="description" content="Interactive formal-language toolkit for building, testing, and visualizing automata with Flutter.">
 
   <!-- iOS meta tags & icons -->
   <meta name="mobile-web-app-capable" content="yes">
@@ -29,7 +29,7 @@
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 
-  <title>jflutter</title>
+  <title>JFlutter Formal Language Toolkit</title>
   <link rel="manifest" href="manifest.json">
 </head>
 <body>

--- a/web/manifest.json
+++ b/web/manifest.json
@@ -1,11 +1,11 @@
 {
-    "name": "jflutter",
-    "short_name": "jflutter",
+    "name": "JFlutter Formal Language Toolkit",
+    "short_name": "JFlutter",
     "start_url": ".",
     "display": "standalone",
     "background_color": "#ffffff",
     "theme_color": "#ffffff",
-    "description": "A new Flutter project.",
+    "description": "Suite of Flutter tools for designing and simulating formal languages and automata.",
     "orientation": "portrait-primary",
     "prefer_related_applications": false,
     "icons": [


### PR DESCRIPTION
## Summary
- refresh the web app meta description and title to describe the formal-language toolkit
- align the web manifest name, short name, and description with JFlutter branding while retaining icons

## Testing
- ❌ `flutter build web` *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb170b340832ea4aa472b11403228