### PR TITLE
Track TM canvas changes on TM page

### DIFF
--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/tm.dart';
+import '../../core/models/tm_transition.dart';
+import '../providers/tm_editor_provider.dart';
+import '../widgets/tm_algorithm_panel.dart';
 import '../widgets/tm_canvas.dart';
 import '../widgets/tm_simulation_panel.dart';
-import '../widgets/tm_algorithm_panel.dart';
 
 /// Page for working with Turing Machines
 class TMPage extends ConsumerStatefulWidget {
@@ -17,6 +21,42 @@ class _TMPageState extends ConsumerState<TMPage> {
   bool _showControls = true;
   bool _showSimulation = false;
   bool _showAlgorithms = false;
+  TM? _currentTM;
+  int _stateCount = 0;
+  int _transitionCount = 0;
+  Set<String> _tapeSymbols = const <String>{};
+  Set<String> _moveDirections = const <String>{};
+  Set<String> _nondeterministicTransitionIds = const <String>{};
+  bool _hasInitialState = false;
+  bool _hasAcceptingState = false;
+
+  bool get _isMachineReady =>
+      _currentTM != null && _hasInitialState && _hasAcceptingState;
+
+  bool get _hasMachine => _currentTM != null && _stateCount > 0;
+
+  @override
+  void initState() {
+    super.initState();
+
+    ref.listen<TMEditorState>(tmEditorProvider, (previous, next) {
+      if (!mounted) return;
+      if (next.tm == null && _currentTM != null) {
+        setState(() {
+          _currentTM = null;
+          _stateCount = 0;
+          _transitionCount = 0;
+          _tapeSymbols = const <String>{};
+          _moveDirections = const <String>{};
+          _nondeterministicTransitionIds = const <String>{};
+          _hasInitialState = false;
+          _hasAcceptingState = false;
+          _showSimulation = false;
+          _showAlgorithms = false;
+        });
+      }
+    });
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -51,7 +91,9 @@ class _TMPageState extends ConsumerState<TMPage> {
                     icon: Icons.play_arrow,
                     label: 'Simulate',
                     isActive: _showSimulation,
-                    onPressed: () => setState(() => _showSimulation = !_showSimulation),
+                    onPressed: () =>
+                        setState(() => _showSimulation = !_showSimulation),
+                    isEnabled: _isMachineReady,
                   ),
                 ),
                 const SizedBox(width: 8),
@@ -60,7 +102,9 @@ class _TMPageState extends ConsumerState<TMPage> {
                     icon: Icons.auto_awesome,
                     label: 'Algorithms',
                     isActive: _showAlgorithms,
-                    onPressed: () => setState(() => _showAlgorithms = !_showAlgorithms),
+                    onPressed: () =>
+                        setState(() => _showAlgorithms = !_showAlgorithms),
+                    isEnabled: _hasMachine,
                   ),
                 ),
               ],
@@ -85,9 +129,7 @@ class _TMPageState extends ConsumerState<TMPage> {
                               constraints: const BoxConstraints(maxHeight: 300),
                               child: TMCanvas(
                                 canvasKey: _canvasKey,
-                                onTMModified: (tm) {
-                                  // Handle TM modifications
-                                },
+                                onTMModified: _handleTMUpdate,
                               ),
                             ),
                             const SizedBox(height: 8),
@@ -116,29 +158,9 @@ class _TMPageState extends ConsumerState<TMPage> {
                   ],
 
                   // Info panel (always visible)
-                  Container(
+                  _buildInfoPanel(
+                    context,
                     margin: const EdgeInsets.all(8),
-                    padding: const EdgeInsets.all(16),
-                    decoration: BoxDecoration(
-                      color: Theme.of(context).colorScheme.surfaceVariant,
-                      borderRadius: BorderRadius.circular(8),
-                    ),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Text(
-                          'Turing Machine Editor',
-                          style: Theme.of(context).textTheme.titleMedium?.copyWith(
-                            fontWeight: FontWeight.bold,
-                          ),
-                        ),
-                        const SizedBox(height: 8),
-                        Text(
-                          'Create states, transitions with tape operations, and test strings. Turing machines can recognize recursively enumerable languages.',
-                          style: Theme.of(context).textTheme.bodyMedium,
-                        ),
-                      ],
-                    ),
                   ),
                 ],
               ),
@@ -159,9 +181,7 @@ class _TMPageState extends ConsumerState<TMPage> {
             margin: const EdgeInsets.all(8),
             child: TMCanvas(
               canvasKey: _canvasKey,
-              onTMModified: (tm) {
-                // Handle TM modifications
-              },
+              onTMModified: _handleTMUpdate,
             ),
           ),
         ),
@@ -183,8 +203,139 @@ class _TMPageState extends ConsumerState<TMPage> {
             child: const TMAlgorithmPanel(),
           ),
         ),
+        const SizedBox(width: 16),
+        Flexible(
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            child: _buildInfoPanel(context),
+          ),
+        ),
       ],
     );
+  }
+
+  void _handleTMUpdate(TM tm) {
+    final transitions = tm.tmTransitions;
+    final nondeterministic = _findNondeterministicTransitions(transitions);
+    final hasInitial = tm.initialState != null;
+    final hasAccepting = tm.acceptingStates.isNotEmpty;
+    final machineReady = hasInitial && hasAccepting;
+    final machineAvailable = tm.states.isNotEmpty;
+
+    setState(() {
+      _currentTM = tm;
+      _stateCount = tm.states.length;
+      _transitionCount = transitions.length;
+      _tapeSymbols = Set<String>.unmodifiable(tm.tapeAlphabet);
+      _moveDirections = Set<String>.unmodifiable(
+        transitions.map((t) => t.direction.name.toUpperCase()),
+      );
+      _nondeterministicTransitionIds = nondeterministic;
+      _hasInitialState = hasInitial;
+      _hasAcceptingState = hasAccepting;
+
+      if (!machineReady) {
+        _showSimulation = false;
+      }
+
+      if (!machineAvailable) {
+        _showAlgorithms = false;
+      }
+    });
+  }
+
+  Widget _buildInfoPanel(
+    BuildContext context, {
+    EdgeInsetsGeometry? margin,
+  }) {
+    final theme = Theme.of(context);
+    return Container(
+      margin: margin,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Turing Machine Overview',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Monitor the structure of your machine and resolve issues before running simulations or algorithms.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          _buildInfoRow('States', '$_stateCount', theme),
+          _buildInfoRow('Transitions', '$_transitionCount', theme),
+          _buildInfoRow('Tape Symbols', _formatSet(_tapeSymbols), theme),
+          _buildInfoRow('Move Directions', _formatSet(_moveDirections), theme),
+          _buildInfoRow('Initial State', _hasInitialState ? 'Yes' : 'No', theme),
+          _buildInfoRow('Accepting State', _hasAcceptingState ? 'Yes' : 'No', theme),
+          _buildInfoRow('Simulation Ready', _isMachineReady ? 'Yes' : 'No', theme),
+          _buildInfoRow(
+            'Nondeterministic Transitions',
+            _nondeterministicTransitionIds.isEmpty
+                ? '0'
+                : '${_nondeterministicTransitionIds.length}',
+            theme,
+          ),
+          if (_nondeterministicTransitionIds.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              'Resolve nondeterminism before running deterministic algorithms.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value, ThemeData theme) {
+    final textStyle = theme.textTheme.bodyMedium;
+    final emphasizedStyle = textStyle?.copyWith(fontWeight: FontWeight.w600);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Text(
+        '$label: $value',
+        style: emphasizedStyle,
+      ),
+    );
+  }
+
+  String _formatSet(Set<String> values) {
+    if (values.isEmpty) {
+      return '-';
+    }
+    final sorted = values.toList()..sort();
+    return sorted.join(', ');
+  }
+
+  Set<String> _findNondeterministicTransitions(Set<TMTransition> transitions) {
+    final grouped = <String, List<TMTransition>>{};
+
+    for (final transition in transitions) {
+      final key = [
+        transition.fromState.id,
+        transition.readSymbol,
+        transition.tapeNumber.toString(),
+      ].join('|');
+
+      grouped.putIfAbsent(key, () => <TMTransition>[]).add(transition);
+    }
+
+    return grouped.values
+        .where((list) => list.length > 1)
+        .expand((list) => list.map((transition) => transition.id))
+        .toSet();
   }
 
   Widget _buildToggleButton({
@@ -192,14 +343,15 @@ class _TMPageState extends ConsumerState<TMPage> {
     required String label,
     required bool isActive,
     required VoidCallback onPressed,
+    bool isEnabled = true,
   }) {
     return ElevatedButton.icon(
-      onPressed: onPressed,
+      onPressed: isEnabled ? onPressed : null,
       icon: Icon(icon, size: 16),
       label: Text(label, style: const TextStyle(fontSize: 11)),
       style: ElevatedButton.styleFrom(
-        backgroundColor: isActive 
-            ? Theme.of(context).colorScheme.primary 
+        backgroundColor: isActive
+            ? Theme.of(context).colorScheme.primary
             : Theme.of(context).colorScheme.surface,
         foregroundColor: isActive 
             ? Theme.of(context).colorScheme.onPrimary 

--- a/test/presentation/pages/tm_page_test.dart
+++ b/test/presentation/pages/tm_page_test.dart
@@ -1,0 +1,117 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/presentation/pages/tm_page.dart';
+import 'package:jflutter/presentation/widgets/tm_canvas.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  final binding = TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TMPage', () {
+    testWidgets('updates metadata when TMCanvas notifies about changes',
+        (tester) async {
+      binding.window.physicalSizeTestValue = const Size(900, 1600);
+      binding.window.devicePixelRatioTestValue = 1.0;
+      addTearDown(() {
+        binding.window.clearPhysicalSizeTestValue();
+        binding.window.clearDevicePixelRatioTestValue();
+      });
+
+      await tester.pumpWidget(
+        const ProviderScope(
+          child: MaterialApp(
+            home: TMPage(),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final simulateButtonFinder =
+          find.widgetWithText(ElevatedButton, 'Simulate');
+      final algorithmButtonFinder =
+          find.widgetWithText(ElevatedButton, 'Algorithms');
+
+      final simulateButtonInitial =
+          tester.widget<ElevatedButton>(simulateButtonFinder);
+      expect(simulateButtonInitial.onPressed, isNull);
+
+      final algorithmButtonInitial =
+          tester.widget<ElevatedButton>(algorithmButtonFinder);
+      expect(algorithmButtonInitial.onPressed, isNull);
+
+      final tmCanvas = tester.widget<TMCanvas>(find.byType(TMCanvas));
+      final tm = _buildSampleTM();
+
+      tmCanvas.onTMModified(tm);
+      await tester.pumpAndSettle();
+
+      expect(find.text('States: 2'), findsOneWidget);
+      expect(find.text('Transitions: 1'), findsOneWidget);
+      expect(find.text('Tape Symbols: B, a'), findsOneWidget);
+      expect(find.text('Move Directions: RIGHT'), findsOneWidget);
+      expect(find.text('Simulation Ready: Yes'), findsOneWidget);
+
+      final simulateButtonUpdated =
+          tester.widget<ElevatedButton>(simulateButtonFinder);
+      expect(simulateButtonUpdated.onPressed, isNotNull);
+
+      final algorithmButtonUpdated =
+          tester.widget<ElevatedButton>(algorithmButtonFinder);
+      expect(algorithmButtonUpdated.onPressed, isNotNull);
+    });
+  });
+}
+
+TM _buildSampleTM() {
+  final initialState = automaton_state.State(
+    id: 'q0',
+    label: 'q0',
+    position: Vector2.zero(),
+    isInitial: true,
+  );
+
+  final acceptingState = automaton_state.State(
+    id: 'q1',
+    label: 'q1',
+    position: Vector2(150, 0),
+    isAccepting: true,
+  );
+
+  final transition = TMTransition(
+    id: 't0',
+    fromState: initialState,
+    toState: acceptingState,
+    label: 'a',
+    readSymbol: 'a',
+    writeSymbol: 'a',
+    direction: TapeDirection.right,
+  );
+
+  const bounds = math.Rectangle<double>(0, 0, 400, 400);
+  final now = DateTime(2024, 1, 1);
+
+  return TM(
+    id: 'test',
+    name: 'Test TM',
+    states: {initialState, acceptingState},
+    transitions: {transition},
+    alphabet: {'a'},
+    initialState: initialState,
+    acceptingStates: {acceptingState},
+    created: now,
+    modified: now,
+    bounds: bounds,
+    tapeAlphabet: {'B', 'a'},
+    blankSymbol: 'B',
+    tapeCount: 1,
+    zoomLevel: 1,
+    panOffset: Vector2.zero(),
+  );
+}


### PR DESCRIPTION
## Summary
- store the latest Turing machine and derived metadata on the TM page
- update TM page panels and controls based on machine completeness
- add a regression test that verifies TM canvas edits update the page state

## Testing
- flutter test test/presentation/pages/tm_page_test.dart *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccb9aff740832e9aaefe02f4c6af93