### PR TITLE
Add shared pumping lemma progress state and widget coverage

### DIFF
--- a/lib/presentation/providers/pumping_lemma_progress_provider.dart
+++ b/lib/presentation/providers/pumping_lemma_progress_provider.dart
@@ -1,0 +1,206 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+/// Describes the type of a progress history entry for the Pumping Lemma game.
+enum PumpingLemmaHistoryType { attempt, retry }
+
+/// Immutable history entry capturing interactions within the Pumping Lemma game.
+@immutable
+class PumpingLemmaHistoryEntry {
+  const PumpingLemmaHistoryEntry._({
+    required this.type,
+    this.challengeId,
+    this.challengeTitle,
+    this.language,
+    this.isCorrect,
+    required this.timestamp,
+  });
+
+  /// Creates a history entry for an answered challenge.
+  factory PumpingLemmaHistoryEntry.attempt({
+    required int challengeId,
+    required String challengeTitle,
+    required String language,
+    required bool isCorrect,
+    DateTime? timestamp,
+  }) {
+    return PumpingLemmaHistoryEntry._(
+      type: PumpingLemmaHistoryType.attempt,
+      challengeId: challengeId,
+      challengeTitle: challengeTitle,
+      language: language,
+      isCorrect: isCorrect,
+      timestamp: timestamp ?? DateTime.now(),
+    );
+  }
+
+  /// Creates a history entry for a retry request on the current challenge.
+  factory PumpingLemmaHistoryEntry.retry({
+    required int challengeId,
+    required String challengeTitle,
+    required String language,
+    DateTime? timestamp,
+  }) {
+    return PumpingLemmaHistoryEntry._(
+      type: PumpingLemmaHistoryType.retry,
+      challengeId: challengeId,
+      challengeTitle: challengeTitle,
+      language: language,
+      timestamp: timestamp ?? DateTime.now(),
+    );
+  }
+
+  /// The interaction type that produced this entry.
+  final PumpingLemmaHistoryType type;
+
+  /// Identifier of the related challenge when available.
+  final int? challengeId;
+
+  /// Title of the related challenge when available.
+  final String? challengeTitle;
+
+  /// Formal language description for the challenge when available.
+  final String? language;
+
+  /// Outcome of the attempt when [type] is [PumpingLemmaHistoryType.attempt].
+  final bool? isCorrect;
+
+  /// Timestamp describing when the entry was produced.
+  final DateTime timestamp;
+}
+
+/// Aggregated state describing the Pumping Lemma game progress.
+@immutable
+class PumpingLemmaProgressState {
+  const PumpingLemmaProgressState({
+    this.totalChallenges = 0,
+    this.completedChallengeIds = const <int>{},
+    this.score = 0,
+    this.attempts = 0,
+    this.history = const <PumpingLemmaHistoryEntry>[],
+  });
+
+  /// Total number of challenges available in the game.
+  final int totalChallenges;
+
+  /// Set of completed challenge identifiers.
+  final Set<int> completedChallengeIds;
+
+  /// Number of correctly solved challenges.
+  final int score;
+
+  /// Total number of submitted answers.
+  final int attempts;
+
+  /// Chronological log of relevant player interactions.
+  final List<PumpingLemmaHistoryEntry> history;
+
+  /// Count of completed challenges derived from [completedChallengeIds].
+  int get completedChallenges => completedChallengeIds.length;
+
+  /// Creates a new state object with updated fields.
+  PumpingLemmaProgressState copyWith({
+    int? totalChallenges,
+    Set<int>? completedChallengeIds,
+    int? score,
+    int? attempts,
+    List<PumpingLemmaHistoryEntry>? history,
+  }) {
+    return PumpingLemmaProgressState(
+      totalChallenges: totalChallenges ?? this.totalChallenges,
+      completedChallengeIds:
+          completedChallengeIds ?? this.completedChallengeIds,
+      score: score ?? this.score,
+      attempts: attempts ?? this.attempts,
+      history: history ?? this.history,
+    );
+  }
+}
+
+/// Manages the progress state for the Pumping Lemma game.
+class PumpingLemmaProgressNotifier
+    extends StateNotifier<PumpingLemmaProgressState> {
+  PumpingLemmaProgressNotifier()
+      : super(const PumpingLemmaProgressState());
+
+  /// Starts a fresh session with the provided total number of challenges.
+  void startNewGame({required int totalChallenges}) {
+    state = PumpingLemmaProgressState(
+      totalChallenges: totalChallenges,
+      completedChallengeIds: <int>{},
+      score: 0,
+      attempts: 0,
+      history: <PumpingLemmaHistoryEntry>[],
+    );
+  }
+
+  /// Records the result of an answered challenge.
+  void recordAnswer({
+    required int challengeId,
+    required String challengeTitle,
+    required String language,
+    required bool isCorrect,
+  }) {
+    final updatedHistory = <PumpingLemmaHistoryEntry>[
+      ...state.history,
+      PumpingLemmaHistoryEntry.attempt(
+        challengeId: challengeId,
+        challengeTitle: challengeTitle,
+        language: language,
+        isCorrect: isCorrect,
+      ),
+    ];
+
+    state = state.copyWith(
+      attempts: state.attempts + 1,
+      score: isCorrect ? state.score + 1 : state.score,
+      history: updatedHistory,
+    );
+  }
+
+  /// Marks a challenge as completed if it has not been recorded already.
+  void markChallengeCompleted(int challengeId) {
+    if (state.completedChallengeIds.contains(challengeId)) {
+      return;
+    }
+
+    final updatedCompleted = <int>{...state.completedChallengeIds, challengeId};
+    state = state.copyWith(completedChallengeIds: updatedCompleted);
+  }
+
+  /// Stores that the current challenge has been retried.
+  void recordRetry({
+    required int challengeId,
+    required String challengeTitle,
+    required String language,
+  }) {
+    final updatedHistory = <PumpingLemmaHistoryEntry>[
+      ...state.history,
+      PumpingLemmaHistoryEntry.retry(
+        challengeId: challengeId,
+        challengeTitle: challengeTitle,
+        language: language,
+      ),
+    ];
+
+    state = state.copyWith(history: updatedHistory);
+  }
+
+  /// Resets the game progress while preserving the total number of challenges.
+  void restartGame() {
+    final totalChallenges = state.totalChallenges;
+    state = PumpingLemmaProgressState(
+      totalChallenges: totalChallenges,
+      completedChallengeIds: <int>{},
+      score: 0,
+      attempts: 0,
+      history: <PumpingLemmaHistoryEntry>[],
+    );
+  }
+}
+
+/// Provider exposing the Pumping Lemma game progress state.
+final pumpingLemmaProgressProvider =
+    StateNotifierProvider<PumpingLemmaProgressNotifier, PumpingLemmaProgressState>(
+  (ref) => PumpingLemmaProgressNotifier(),
+);

--- a/lib/presentation/widgets/pumping_lemma_progress.dart
+++ b/lib/presentation/widgets/pumping_lemma_progress.dart
@@ -1,23 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-/// Progress tracking panel for the Pumping Lemma Game
-class PumpingLemmaProgress extends ConsumerStatefulWidget {
+import '../providers/pumping_lemma_progress_provider.dart';
+
+/// Progress tracking panel for the Pumping Lemma Game.
+class PumpingLemmaProgress extends ConsumerWidget {
   const PumpingLemmaProgress({super.key});
 
   @override
-  ConsumerState<PumpingLemmaProgress> createState() => _PumpingLemmaProgressState();
-}
+  Widget build(BuildContext context, WidgetRef ref) {
+    final progress = ref.watch(pumpingLemmaProgressProvider);
 
-class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
-  int _totalChallenges = 5;
-  int _completedChallenges = 0;
-  int _correctAnswers = 0;
-  int _totalAttempts = 0;
-  List<ChallengeResult> _challengeResults = [];
-
-  @override
-  Widget build(BuildContext context) {
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -26,11 +19,11 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
           children: [
             _buildHeader(context),
             const SizedBox(height: 16),
-            _buildOverallProgress(context),
+            _buildOverallProgress(context, progress),
             const SizedBox(height: 16),
-            _buildStatistics(context),
+            _buildStatistics(context, progress),
             const SizedBox(height: 16),
-            _buildChallengeHistory(context),
+            _buildChallengeHistory(context, progress),
           ],
         ),
       ),
@@ -48,16 +41,21 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
         Text(
           'Progress',
           style: Theme.of(context).textTheme.titleLarge?.copyWith(
-            fontWeight: FontWeight.bold,
-          ),
+                fontWeight: FontWeight.bold,
+              ),
         ),
       ],
     );
   }
 
-  Widget _buildOverallProgress(BuildContext context) {
-    final progress = _totalChallenges > 0 ? _completedChallenges / _totalChallenges : 0.0;
-    
+  Widget _buildOverallProgress(
+    BuildContext context,
+    PumpingLemmaProgressState progress,
+  ) {
+    final ratio = progress.totalChallenges > 0
+        ? progress.completedChallenges / progress.totalChallenges
+        : 0.0;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -70,13 +68,14 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
           Text(
             'Overall Progress',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-            ),
+                  fontWeight: FontWeight.w600,
+                ),
           ),
           const SizedBox(height: 12),
           LinearProgressIndicator(
-            value: progress,
-            backgroundColor: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+            value: ratio,
+            backgroundColor:
+                Theme.of(context).colorScheme.outline.withOpacity(0.2),
             valueColor: AlwaysStoppedAnimation<Color>(
               Theme.of(context).colorScheme.primary,
             ),
@@ -86,15 +85,15 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
             mainAxisAlignment: MainAxisAlignment.spaceBetween,
             children: [
               Text(
-                '$_completedChallenges / $_totalChallenges challenges completed',
+                '${progress.completedChallenges} / ${progress.totalChallenges} challenges completed',
                 style: Theme.of(context).textTheme.bodyMedium,
               ),
               Text(
-                '${(progress * 100).toInt()}%',
+                '${(ratio * 100).toInt()}%',
                 style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-                  fontWeight: FontWeight.bold,
-                  color: Theme.of(context).colorScheme.primary,
-                ),
+                      fontWeight: FontWeight.bold,
+                      color: Theme.of(context).colorScheme.primary,
+                    ),
               ),
             ],
           ),
@@ -103,9 +102,14 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
     );
   }
 
-  Widget _buildStatistics(BuildContext context) {
-    final accuracy = _totalAttempts > 0 ? _correctAnswers / _totalAttempts : 0.0;
-    
+  Widget _buildStatistics(
+    BuildContext context,
+    PumpingLemmaProgressState progress,
+  ) {
+    final accuracy = progress.attempts > 0
+        ? progress.score / progress.attempts
+        : 0.0;
+
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
@@ -118,8 +122,8 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
           Text(
             'Statistics',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-            ),
+                  fontWeight: FontWeight.w600,
+                ),
           ),
           const SizedBox(height: 12),
           Row(
@@ -138,7 +142,7 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
                 child: _buildStatCard(
                   context,
                   title: 'Correct',
-                  value: '$_correctAnswers',
+                  value: '${progress.score}',
                   icon: Icons.check_circle,
                   color: Colors.green,
                 ),
@@ -152,7 +156,7 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
                 child: _buildStatCard(
                   context,
                   title: 'Attempts',
-                  value: '$_totalAttempts',
+                  value: '${progress.attempts}',
                   icon: Icons.quiz,
                   color: Colors.blue,
                 ),
@@ -162,7 +166,7 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
                 child: _buildStatCard(
                   context,
                   title: 'Score',
-                  value: '$_correctAnswers/$_totalChallenges',
+                  value: '${progress.score}/${progress.totalChallenges}',
                   icon: Icons.star,
                   color: Colors.orange,
                 ),
@@ -199,46 +203,64 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
           Text(
             value,
             style: Theme.of(context).textTheme.titleLarge?.copyWith(
-              color: color,
-              fontWeight: FontWeight.bold,
-            ),
+                  color: color,
+                  fontWeight: FontWeight.bold,
+                ),
           ),
           Text(
             title,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-              color: color,
-            ),
+                  color: color,
+                ),
           ),
         ],
       ),
     );
   }
 
-  Widget _buildChallengeHistory(BuildContext context) {
+  Widget _buildChallengeHistory(
+    BuildContext context,
+    PumpingLemmaProgressState progress,
+  ) {
+    final entries = progress.history;
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         Text(
           'Challenge History',
           style: Theme.of(context).textTheme.titleMedium?.copyWith(
-            fontWeight: FontWeight.w600,
-          ),
+                fontWeight: FontWeight.w600,
+              ),
         ),
         const SizedBox(height: 8),
         Container(
           constraints: const BoxConstraints(maxHeight: 200),
-          child: _challengeResults.isEmpty
+          child: entries.isEmpty
               ? _buildEmptyHistory(context)
               : ListView.builder(
-                  itemCount: _challengeResults.length,
+                  itemCount: entries.length,
                   itemBuilder: (context, index) {
-                    final result = _challengeResults[index];
-                    return _buildChallengeResultItem(context, result, index);
+                    final entry = entries[index];
+                    return _buildHistoryItem(context, entry, index);
                   },
                 ),
         ),
       ],
     );
+  }
+
+  Widget _buildHistoryItem(
+    BuildContext context,
+    PumpingLemmaHistoryEntry entry,
+    int index,
+  ) {
+    switch (entry.type) {
+      case PumpingLemmaHistoryType.attempt:
+        return _buildAttemptItem(context, entry, index);
+      case PumpingLemmaHistoryType.retry:
+        return _buildRetryItem(context, entry);
+    }
   }
 
   Widget _buildEmptyHistory(BuildContext context) {
@@ -255,15 +277,15 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
           Text(
             'No challenges completed yet',
             style: Theme.of(context).textTheme.titleMedium?.copyWith(
-              color: Theme.of(context).colorScheme.outline,
-            ),
+                  color: Theme.of(context).colorScheme.outline,
+                ),
           ),
           const SizedBox(height: 8),
           Text(
             'Complete some challenges to see your progress here',
             style: Theme.of(context).textTheme.bodyMedium?.copyWith(
-              color: Theme.of(context).colorScheme.outline,
-            ),
+                  color: Theme.of(context).colorScheme.outline,
+                ),
             textAlign: TextAlign.center,
           ),
         ],
@@ -271,9 +293,14 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
     );
   }
 
-  Widget _buildChallengeResultItem(BuildContext context, ChallengeResult result, int index) {
-    final color = result.isCorrect ? Colors.green : Colors.red;
-    
+  Widget _buildAttemptItem(
+    BuildContext context,
+    PumpingLemmaHistoryEntry entry,
+    int index,
+  ) {
+    final color = entry.isCorrect == true ? Colors.green : Colors.red;
+    final title = entry.challengeTitle ?? 'Challenge ${entry.challengeId ?? index + 1}';
+
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
@@ -289,7 +316,7 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
             backgroundColor: color,
             child: Text(
               '${index + 1}',
-              style: TextStyle(
+              style: const TextStyle(
                 color: Colors.white,
                 fontSize: 12,
                 fontWeight: FontWeight.bold,
@@ -302,16 +329,23 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Text(
-                  result.challengeTitle,
+                  title,
                   style: Theme.of(context).textTheme.titleSmall?.copyWith(
-                    fontWeight: FontWeight.w600,
-                  ),
+                        fontWeight: FontWeight.w600,
+                      ),
                 ),
-                Text(
-                  result.language,
-                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                    fontFamily: 'monospace',
+                if (entry.language != null)
+                  Text(
+                    entry.language!,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                        ),
                   ),
+                Text(
+                  _formatTime(entry.timestamp),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: color,
+                      ),
                 ),
               ],
             ),
@@ -319,18 +353,81 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
           Column(
             children: [
               Icon(
-                result.isCorrect ? Icons.check_circle : Icons.cancel,
+                entry.isCorrect == true ? Icons.check_circle : Icons.cancel,
                 color: color,
                 size: 20,
               ),
               Text(
-                result.isCorrect ? 'Correct' : 'Wrong',
+                entry.isCorrect == true ? 'Correct' : 'Wrong',
                 style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color: color,
-                  fontWeight: FontWeight.bold,
-                ),
+                      color: color,
+                      fontWeight: FontWeight.bold,
+                    ),
               ),
             ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildRetryItem(
+    BuildContext context,
+    PumpingLemmaHistoryEntry entry,
+  ) {
+    final color = Colors.amber.shade700;
+    final title = entry.challengeTitle ?? 'Challenge ${entry.challengeId ?? '-'}';
+
+    return Container(
+      margin: const EdgeInsets.only(bottom: 8),
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.1),
+        border: Border.all(color: color.withOpacity(0.3)),
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Row(
+        children: [
+          CircleAvatar(
+            radius: 16,
+            backgroundColor: color,
+            child: const Icon(
+              Icons.refresh,
+              color: Colors.white,
+              size: 18,
+            ),
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Text(
+                  'Retry selected',
+                  style: Theme.of(context).textTheme.titleSmall?.copyWith(
+                        fontWeight: FontWeight.w600,
+                        color: color,
+                      ),
+                ),
+                Text(
+                  title,
+                  style: Theme.of(context).textTheme.bodySmall,
+                ),
+                if (entry.language != null)
+                  Text(
+                    entry.language!,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          fontFamily: 'monospace',
+                        ),
+                  ),
+                Text(
+                  _formatTime(entry.timestamp),
+                  style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                        color: color,
+                      ),
+                ),
+              ],
+            ),
           ),
         ],
       ),
@@ -343,37 +440,11 @@ class _PumpingLemmaProgressState extends ConsumerState<PumpingLemmaProgress> {
     return Colors.red;
   }
 
-  // Methods to update progress (would be called from the game)
-  void updateProgress(int completed, int correct, int attempts, List<ChallengeResult> results) {
-    setState(() {
-      _completedChallenges = completed;
-      _correctAnswers = correct;
-      _totalAttempts = attempts;
-      _challengeResults = results;
-    });
+  String _formatTime(DateTime timestamp) {
+    final local = timestamp.toLocal();
+    final hours = local.hour.toString().padLeft(2, '0');
+    final minutes = local.minute.toString().padLeft(2, '0');
+    final seconds = local.second.toString().padLeft(2, '0');
+    return '$hours:$minutes:$seconds';
   }
-
-  void resetProgress() {
-    setState(() {
-      _completedChallenges = 0;
-      _correctAnswers = 0;
-      _totalAttempts = 0;
-      _challengeResults.clear();
-    });
-  }
-}
-
-/// Data class for challenge results
-class ChallengeResult {
-  final String challengeTitle;
-  final String language;
-  final bool isCorrect;
-  final DateTime completedAt;
-
-  ChallengeResult({
-    required this.challengeTitle,
-    required this.language,
-    required this.isCorrect,
-    required this.completedAt,
-  });
 }

--- a/test/widget/pumping_lemma_progress_test.dart
+++ b/test/widget/pumping_lemma_progress_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:jflutter/presentation/providers/pumping_lemma_progress_provider.dart';
+import 'package:jflutter/presentation/widgets/pumping_lemma_game.dart';
+import 'package:jflutter/presentation/widgets/pumping_lemma_progress.dart';
+
+void main() {
+  Future<void> _answerChallenge(
+    WidgetTester tester, {
+    required bool isRegular,
+    required bool isLast,
+  }) async {
+    final yesFinder = find.text('Yes, it is regular');
+    final noFinder = find.text('No, it is not regular');
+
+    await tester.tap(isRegular ? yesFinder : noFinder);
+    await tester.pump();
+    await tester.tap(find.text('Submit Answer'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text(isLast ? 'Finish Game' : 'Next Challenge'));
+    await tester.pumpAndSettle();
+  }
+
+  testWidgets('shares progress between game and progress panel',
+      (WidgetTester tester) async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+
+    await tester.pumpWidget(
+      UncontrolledProviderScope(
+        container: container,
+        child: const MaterialApp(
+          home: Scaffold(
+            body: Row(
+              children: [
+                Expanded(child: PumpingLemmaGame()),
+                Expanded(child: PumpingLemmaProgress()),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('0 / 5 challenges completed'), findsOneWidget);
+
+    await tester.tap(find.text('Start Game'));
+    await tester.pumpAndSettle();
+
+    expect(container.read(pumpingLemmaProgressProvider).totalChallenges, 5);
+
+    await tester.tap(find.text('No, it is not regular'));
+    await tester.pump();
+    await tester.tap(find.text('Submit Answer'));
+    await tester.pumpAndSettle();
+
+    final afterFirstAttempt = container.read(pumpingLemmaProgressProvider);
+    expect(afterFirstAttempt.attempts, 1);
+    expect(afterFirstAttempt.score, 1);
+    expect(afterFirstAttempt.history.length, 1);
+    expect(afterFirstAttempt.history.last.isCorrect, isTrue);
+
+    await tester.tap(find.text('Next Challenge'));
+    await tester.pumpAndSettle();
+
+    final afterFirstCompletion = container.read(pumpingLemmaProgressProvider);
+    expect(afterFirstCompletion.completedChallenges, 1);
+    expect(find.text('1 / 5 challenges completed'), findsOneWidget);
+
+    await tester.tap(find.text('No, it is not regular'));
+    await tester.pump();
+    await tester.tap(find.text('Submit Answer'));
+    await tester.pumpAndSettle();
+
+    final afterWrongAttempt = container.read(pumpingLemmaProgressProvider);
+    expect(afterWrongAttempt.attempts, 2);
+    expect(afterWrongAttempt.score, 1);
+    expect(afterWrongAttempt.history.last.isCorrect, isFalse);
+
+    await tester.tap(find.text('Retry'));
+    await tester.pumpAndSettle();
+
+    final afterRetry = container.read(pumpingLemmaProgressProvider);
+    expect(afterRetry.history.length, 3);
+    expect(afterRetry.history.last.type, PumpingLemmaHistoryType.retry);
+    expect(find.text('Retry selected'), findsOneWidget);
+
+    await tester.tap(find.text('Yes, it is regular'));
+    await tester.pump();
+    await tester.tap(find.text('Submit Answer'));
+    await tester.pumpAndSettle();
+    await tester.tap(find.text('Next Challenge'));
+    await tester.pumpAndSettle();
+
+    await _answerChallenge(tester, isRegular: true, isLast: false);
+    await _answerChallenge(tester, isRegular: false, isLast: false);
+    await _answerChallenge(tester, isRegular: false, isLast: true);
+
+    expect(find.text('Game Complete!'), findsOneWidget);
+
+    await tester.tap(find.text('Play Again'));
+    await tester.pumpAndSettle();
+
+    final afterRestart = container.read(pumpingLemmaProgressProvider);
+    expect(afterRestart.attempts, 0);
+    expect(afterRestart.score, 0);
+    expect(afterRestart.completedChallenges, 0);
+    expect(afterRestart.history, isEmpty);
+    expect(find.text('0 / 5 challenges completed'), findsOneWidget);
+    expect(find.text('No challenges completed yet'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- introduce a Riverpod StateNotifier for pumping lemma game progress, including score, attempts, completion tracking, and history entries
- update the pumping lemma game and progress widgets to consume the shared provider for live statistics and logging
- add a widget test that exercises answering, retrying, finishing, and restarting challenges to verify provider-driven updates

## Testing
- not run (Flutter CLI unavailable in execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ccb9a9e5c8832ea47b470875d29c42