### PR TITLE
Add automaton example assets and improve data source handling

### DIFF
--- a/jflutter_js/examples/afd_binary_divisible_by_3.json
+++ b/jflutter_js/examples/afd_binary_divisible_by_3.json
@@ -1,0 +1,42 @@
+{
+  "id": "example_afd_binary_divisible_by_3",
+  "name": "AFD - Binário divisível por 3",
+  "alphabet": ["0", "1"],
+  "states": [
+    {
+      "id": "q0",
+      "name": "q0",
+      "x": 100.0,
+      "y": 200.0,
+      "isInitial": true,
+      "isFinal": true
+    },
+    {
+      "id": "q1",
+      "name": "q1",
+      "x": 300.0,
+      "y": 120.0,
+      "isInitial": false,
+      "isFinal": false
+    },
+    {
+      "id": "q2",
+      "name": "q2",
+      "x": 300.0,
+      "y": 280.0,
+      "isInitial": false,
+      "isFinal": false
+    }
+  ],
+  "transitions": {
+    "q0|0": ["q0"],
+    "q0|1": ["q1"],
+    "q1|0": ["q2"],
+    "q1|1": ["q0"],
+    "q2|0": ["q1"],
+    "q2|1": ["q2"]
+  },
+  "initialId": "q0",
+  "nextId": 3,
+  "type": "dfa"
+}

--- a/jflutter_js/examples/afd_ends_with_a.json
+++ b/jflutter_js/examples/afd_ends_with_a.json
@@ -1,0 +1,32 @@
+{
+  "id": "example_afd_ends_with_a",
+  "name": "AFD - Termina com A",
+  "alphabet": ["a", "b"],
+  "states": [
+    {
+      "id": "q0",
+      "name": "q0",
+      "x": 100.0,
+      "y": 200.0,
+      "isInitial": true,
+      "isFinal": false
+    },
+    {
+      "id": "q1",
+      "name": "q1",
+      "x": 300.0,
+      "y": 200.0,
+      "isInitial": false,
+      "isFinal": true
+    }
+  ],
+  "transitions": {
+    "q0|a": ["q1"],
+    "q0|b": ["q0"],
+    "q1|a": ["q1"],
+    "q1|b": ["q0"]
+  },
+  "initialId": "q0",
+  "nextId": 2,
+  "type": "dfa"
+}

--- a/jflutter_js/examples/afd_parity_AB.json
+++ b/jflutter_js/examples/afd_parity_AB.json
@@ -1,0 +1,52 @@
+{
+  "id": "example_afd_parity_ab",
+  "name": "AFD - Paridade AB",
+  "alphabet": ["a", "b"],
+  "states": [
+    {
+      "id": "q0",
+      "name": "q0",
+      "x": 100.0,
+      "y": 160.0,
+      "isInitial": true,
+      "isFinal": true
+    },
+    {
+      "id": "q1",
+      "name": "q1",
+      "x": 320.0,
+      "y": 80.0,
+      "isInitial": false,
+      "isFinal": false
+    },
+    {
+      "id": "q2",
+      "name": "q2",
+      "x": 320.0,
+      "y": 240.0,
+      "isInitial": false,
+      "isFinal": false
+    },
+    {
+      "id": "q3",
+      "name": "q3",
+      "x": 540.0,
+      "y": 160.0,
+      "isInitial": false,
+      "isFinal": false
+    }
+  ],
+  "transitions": {
+    "q0|a": ["q1"],
+    "q0|b": ["q2"],
+    "q1|a": ["q0"],
+    "q1|b": ["q3"],
+    "q2|a": ["q3"],
+    "q2|b": ["q0"],
+    "q3|a": ["q2"],
+    "q3|b": ["q1"]
+  },
+  "initialId": "q0",
+  "nextId": 4,
+  "type": "dfa"
+}

--- a/jflutter_js/examples/afn_lambda_a_or_ab.json
+++ b/jflutter_js/examples/afn_lambda_a_or_ab.json
@@ -1,0 +1,55 @@
+{
+  "id": "example_afn_lambda_a_or_ab",
+  "name": "AFNλ - A ou AB",
+  "alphabet": ["a", "b", "λ"],
+  "states": [
+    {
+      "id": "q0",
+      "name": "q0",
+      "x": 100.0,
+      "y": 200.0,
+      "isInitial": true,
+      "isFinal": false
+    },
+    {
+      "id": "q1",
+      "name": "q1",
+      "x": 320.0,
+      "y": 120.0,
+      "isInitial": false,
+      "isFinal": true
+    },
+    {
+      "id": "q2",
+      "name": "q2",
+      "x": 320.0,
+      "y": 280.0,
+      "isInitial": false,
+      "isFinal": false
+    },
+    {
+      "id": "q3",
+      "name": "q3",
+      "x": 520.0,
+      "y": 280.0,
+      "isInitial": false,
+      "isFinal": false
+    },
+    {
+      "id": "q4",
+      "name": "q4",
+      "x": 520.0,
+      "y": 120.0,
+      "isInitial": false,
+      "isFinal": true
+    }
+  ],
+  "transitions": {
+    "q0|λ": ["q1", "q2"],
+    "q2|a": ["q3"],
+    "q3|b": ["q4"]
+  },
+  "initialId": "q0",
+  "nextId": 5,
+  "type": "nfaLambda"
+}

--- a/lib/data/data_sources/examples_data_source.dart
+++ b/lib/data/data_sources/examples_data_source.dart
@@ -37,7 +37,9 @@ class ExamplesDataSource {
         return Failure('Example not found: $name');
       }
 
-      final jsonString = await rootBundle.loadString('jflutter_js/examples/$fileName');
+      final assetPath = 'jflutter_js/examples/$fileName';
+
+      final jsonString = await rootBundle.loadString(assetPath);
       final json = jsonDecode(jsonString) as Map<String, dynamic>;
       
       // Convert legacy format to new format
@@ -52,6 +54,14 @@ class ExamplesDataSource {
       );
 
       return Success(example);
+    } on FlutterError catch (e) {
+      final message = e.message ?? e.toString();
+      if (message.contains('Unable to load asset')) {
+        return Failure(
+          'Example asset not found for $name. Expected at $assetPath',
+        );
+      }
+      return Failure('Error loading example $name: $message');
     } catch (e) {
       return Failure('Error loading example $name: $e');
     }
@@ -79,6 +89,8 @@ class ExamplesDataSource {
       }
     }
 
+    final type = json['type'] as String? ?? 'dfa';
+
     return AutomatonModel(
       id: DateTime.now().millisecondsSinceEpoch.toString(),
       name: 'Example Automaton',
@@ -87,7 +99,7 @@ class ExamplesDataSource {
       transitions: transitions,
       initialId: json['initialId'] as String?,
       nextId: json['nextId'] as int? ?? states.length,
-      type: 'dfa', // Default type
+      type: type,
     );
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -97,11 +97,11 @@ flutter:
   uses-material-design: true
 
   # To add assets to your application, add an assets section, like this:
-  # assets:
-  #   - jflutter_js/examples/afd_binary_divisible_by_3.json
-  #   - jflutter_js/examples/afd_ends_with_a.json
-  #   - jflutter_js/examples/afd_parity_AB.json
-  #   - jflutter_js/examples/afn_lambda_a_or_ab.json
+  assets:
+    - jflutter_js/examples/afd_binary_divisible_by_3.json
+    - jflutter_js/examples/afd_ends_with_a.json
+    - jflutter_js/examples/afd_parity_AB.json
+    - jflutter_js/examples/afn_lambda_a_or_ab.json
 
 flutter_launcher_icons:
   image_path: "icon.PNG"

--- a/test/unit/data/examples_data_source_test.dart
+++ b/test/unit/data/examples_data_source_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/data/data_sources/examples_data_source.dart';
+import 'package:jflutter/core/result.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late ExamplesDataSource dataSource;
+
+  setUp(() {
+    dataSource = ExamplesDataSource();
+  });
+
+  test('loadExample returns a successful result for known examples', () async {
+    final result = await dataSource.loadExample('AFD - Termina com A');
+
+    expect(result.isSuccess, isTrue);
+    final example = (result as Success).data;
+
+    expect(example.name, 'AFD - Termina com A');
+    expect(example.description, contains('terminam'));
+    expect(example.automaton.states.length, 2);
+    expect(example.automaton.alphabet, containsAll(<String>{'a', 'b'}));
+    expect(example.automaton.finalStates.length, 1);
+  });
+
+  test('loadExamples loads all available examples', () async {
+    final result = await dataSource.loadExamples();
+
+    expect(result.isSuccess, isTrue);
+    final examples = (result as Success).data;
+
+    expect(examples.length, 4);
+    expect(
+      examples.map((example) => example.name),
+      containsAll(<String>{
+        'AFD - Termina com A',
+        'AFD - Binário divisível por 3',
+        'AFD - Paridade AB',
+        'AFNλ - A ou AB',
+      }),
+    );
+  });
+
+  test('loadExample returns failure for unknown example name', () async {
+    final result = await dataSource.loadExample('Unknown Example');
+
+    expect(result.isFailure, isTrue);
+    expect(result.error, 'Example not found: Unknown Example');
+  });
+}


### PR DESCRIPTION
## Summary
- add the JSON automaton assets referenced by the examples data source
- register the new assets in the Flutter manifest and improve missing-asset errors
- cover example loading with unit tests

## Testing
- flutter pub get *(fails: Flutter SDK unavailable in container)*
- flutter test test/unit/data/examples_data_source_test.dart *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc25641b8832ea751aa8027fff4b8