### PR TITLE
Update documentation to reflect completed navigation pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,13 +61,15 @@ This is the first major release of JFlutter, featuring a complete implementation
 - **Bottom Navigation** - Mobile-optimized navigation system
 
 #### Pages and Navigation
-- **HomePage** - Main navigation hub with 6 sections
+- **HomePage** - Main navigation hub with dedicated tabs for each toolset
 - **FSAPage** - Complete finite state automata interface
-- **GrammarPage** - Context-free grammar tools (placeholder)
-- **PDAPage** - Pushdown automata tools (placeholder)
-- **TMPage** - Turing machine tools (placeholder)
-- **LSystemPage** - L-system visualization (placeholder)
-- **PumpingLemmaPage** - Interactive pumping lemma game (placeholder)
+- **GrammarPage** - Full grammar editor with production management and conversion tools
+- **PDAPage** - Pushdown automata workspace with stack-aware simulation controls
+- **TMPage** - Turing machine construction and simulation environment
+- **RegexPage** - Regular expression testing and conversion utilities
+- **PumpingLemmaPage** - Interactive pumping lemma game with guided challenges
+- **SettingsPage** - Persistent preferences including symbols, themes, and canvas defaults
+- **HelpPage** - In-app documentation with tutorials for every major feature
 
 #### Interactive Components
 - **AutomatonCanvas** - Full-featured drawing canvas with:
@@ -181,22 +183,19 @@ This is the first major release of JFlutter, featuring a complete implementation
 #### Algorithm Coverage
 - **Finite Automata** - Complete DFA/NFA support
 - **Regular Expressions** - Regex to NFA and FA to regex conversion
-- **Context-Free Grammars** - Grammar parsing and analysis
+- **Context-Free Grammars** - Grammar parsing, editing, and PDA conversion
 - **Pumping Lemma** - Interactive educational game
-- **L-Systems** - Fractal pattern generation
-- **Advanced Automata** - PDA, TM, Mealy/Moore machines
+- **Advanced Automata** - PDA, TM, Mealy/Moore machines with dedicated tooling
 
 ### 🔮 Future Roadmap
 
 #### Planned Features
-- **Enhanced Visualizations** - Advanced algorithm step visualization
-- **File Import/Export** - JFLAP file compatibility
-- **Advanced Grammar Editor** - Visual context-free grammar editing
-- **PDA Canvas** - Pushdown automata visualization
-- **Turing Machine Interface** - Multi-tape machine interface
-- **L-System Visualizer** - Interactive fractal pattern generation
-- **Collaborative Features** - Share and collaborate on automata
-- **Educational Content** - Built-in tutorials and examples
+- **Enhanced Visualizations** - Deeper step-by-step explainers for algorithms
+- **Expanded Testing** - High-coverage unit and widget test suites
+- **Performance Tooling** - Profiling utilities for large automata
+- **Accessibility Improvements** - Screen reader and keyboard navigation support
+- **Collaboration Enhancements** - Shared workspaces and export options
+- **Educational Content** - Additional guided examples and lesson plans
 
 #### Technical Improvements
 - **Performance Optimization** - Further mobile performance improvements

--- a/COMPILATION_STATUS.md
+++ b/COMPILATION_STATUS.md
@@ -10,7 +10,6 @@ This is a comprehensive Flutter application for automaton theory education, incl
 - Turing Machines (TM)
 - Regular Expressions
 - Context-Free Grammars
-- L-Systems
 - Pumping Lemma games
 - Various algorithms and simulations
 
@@ -25,10 +24,12 @@ This is a comprehensive Flutter application for automaton theory education, incl
 ### UI Components
 - [x] **Touch Gesture Handler** - Mobile-optimized touch interactions
 - [x] **Grammar Editor** - Production rule management interface
-- [x] **L-System Components** - Controls, editor, and visualizer
 - [x] **PDA/TM Components** - Algorithm panels, canvases, and simulation controls
 - [x] **Pumping Lemma Game** - Interactive game with help and progress tracking
 - [x] **File Operations Panel** - File management UI with JFLAP support
+- [x] **Algorithm Panels** - Shared controls for conversions and analysis
+- [x] **Settings Interface** - Persisted preferences with theming and canvas controls
+- [x] **Help Center** - In-app documentation with multi-section tutorials
 
 ### Services and Data
 - [x] **File Operations Service** - Complete file management with JFLAP XML support
@@ -45,43 +46,33 @@ This is a comprehensive Flutter application for automaton theory education, incl
 ## 🚧 REMAINING TASKS
 
 ### High Priority
-1. **Settings Page**
-   - User preferences and configuration interface
-   - Theme selection and customization
-   - Export/import preferences
-
-2. **Help Page**
-   - Interactive documentation and tutorials
-   - Feature explanations and examples
-   - User guide integration
-
-3. **Unit Test Coverage**
+1. **Unit Test Coverage**
    - Comprehensive unit tests for all models
    - Algorithm testing and validation
    - Service layer testing
    - Widget testing for all components
 
 ### Medium Priority
-4. **Performance Optimization**
+2. **Performance Optimization**
    - Handle large automata efficiently
    - Memory optimization for complex simulations
    - Rendering performance improvements
    - Algorithm optimization for large datasets
 
-5. **Accessibility Features**
+3. **Accessibility Features**
    - Screen reader support
    - Keyboard navigation
    - High contrast themes
    - Voice-over compatibility
 
 ### Low Priority
-6. **Documentation**
+4. **Documentation**
    - API documentation updates
    - User guide completion
    - Developer documentation
    - Code comments and examples
 
-7. **Polish and Refinement**
+5. **Polish and Refinement**
    - UI/UX improvements
    - Error handling enhancements
    - Loading states and feedback
@@ -90,48 +81,35 @@ This is a comprehensive Flutter application for automaton theory education, incl
 ## 🔧 NEXT STEPS
 
 ### Immediate Actions Needed
-1. **Implement Settings Page**
-   ```dart
-   // Create lib/presentation/pages/settings_page.dart
-   // Include user preferences, theme selection, export/import settings
-   ```
-
-2. **Create Help Page**
-   ```dart
-   // Create lib/presentation/pages/help_page.dart
-   // Include interactive documentation, tutorials, feature explanations
-   ```
-
-3. **Add Unit Test Coverage**
+1. **Add Unit Test Coverage**
    - Create comprehensive unit tests for all models
    - Add algorithm validation tests
    - Implement service layer testing
    - Add widget testing for all components
 
-4. **Performance Optimization**
+2. **Performance Optimization**
    - Optimize for large automata handling
    - Implement memory management improvements
    - Add rendering performance enhancements
 
 ### Recommended Approach
-1. **Complete Remaining Pages** - Settings and Help pages first
-2. **Add Unit Tests** - Comprehensive test coverage for all components
-3. **Performance Testing** - Optimize for large datasets and complex simulations
-4. **Accessibility Features** - Screen reader support and keyboard navigation
-5. **Documentation** - Complete API docs and user guides
+1. **Add Unit Tests** - Comprehensive test coverage for all components
+2. **Performance Testing** - Optimize for large datasets and complex simulations
+3. **Accessibility Features** - Screen reader support and keyboard navigation
+4. **Documentation** - Complete API docs and user guides
 
 ## 📊 Progress Summary
-- **Completed**: Core UI implementation, mobile optimization, file operations, test suite
-- **Remaining**: Settings page, Help page, unit tests, performance optimization, accessibility
-- **Estimated Completion**: 85-90% of core functionality complete
-- **Critical Path**: Settings/Help pages → Unit tests → Performance optimization
+- **Completed**: Core UI implementation, navigation pages, mobile optimization, file operations, test suite
+- **Remaining**: Unit tests, performance optimization, accessibility, documentation polish
+- **Estimated Completion**: 90%+ of core functionality complete
+- **Critical Path**: Unit tests → Performance optimization → Accessibility improvements
 
 ## 🎯 Success Criteria
 - [x] Complete UI implementation for all core features
 - [x] Mobile-optimized touch interactions
 - [x] File operations with JFLAP format support
 - [x] Comprehensive test suite (contract and integration)
-- [ ] Settings and Help pages
+- [x] Settings and Help pages
 - [ ] Unit test coverage
 - [ ] Performance optimization
 - [ ] Accessibility features

--- a/DEVELOPMENT_LOG.md
+++ b/DEVELOPMENT_LOG.md
@@ -10,15 +10,15 @@
 ### ✅ Major UI Implementation Completed
 1. **Comprehensive Widget Library**
    - Touch gesture handler with mobile-optimized interactions
-   - Grammar editor with production rule management
-   - L-System controls, editor, and visualizer
-   - PDA and TM algorithm panels and canvases
+   - Grammar editor with production rule management and analysis panels
+   - PDA and TM algorithm panels, canvases, and simulators
    - Pumping lemma game with help and progress tracking
    - File operations panel with JFLAP format support
+   - Shared algorithm and simulation panels for regex and automata workflows
 
 2. **Complete Page Implementation**
    - All main pages now have full functionality
-   - FSA, PDA, TM, Grammar, L-System, and Pumping Lemma pages
+   - FSA, Grammar, PDA, TM, Regex, Pumping Lemma, Settings, and Help pages
    - Mobile-optimized controls and interactions
    - Integrated simulation and algorithm execution
 
@@ -30,9 +30,9 @@
 
 4. **Test Suite Expansion**
    - Contract tests for automaton service
-   - Integration tests for FSA creation, NFA to DFA conversion
+   - Integration tests for FSA creation and multiple NFA→DFA scenarios
    - Grammar parsing and file operations tests
-   - Mobile UI interaction tests
+   - Mobile UI and FAB interaction tests
    - Touch gesture handling tests
 
 ### 📊 Progress Metrics
@@ -45,28 +45,18 @@
 
 ## 🚧 Remaining Tasks
 
-### 1. Settings Page (MEDIUM PRIORITY)
-- User preferences and configuration interface
-- Theme selection, default settings
-- Export/import preferences
-
-### 2. Help Page (MEDIUM PRIORITY)
-- User documentation and tutorials
-- Interactive help system
-- Feature explanations and examples
-
-### 3. Unit Test Coverage (HIGH PRIORITY)
+### 1. Unit Test Coverage (HIGH PRIORITY)
 - Comprehensive unit tests for all models
 - Algorithm testing and validation
 - Service layer testing
 - Widget testing for all components
 
-### 4. Performance Optimization (MEDIUM PRIORITY)
+### 2. Performance Optimization (MEDIUM PRIORITY)
 - Handle large automata efficiently
 - Memory optimization for complex simulations
 - Rendering performance improvements
 
-### 5. Accessibility Features (LOW PRIORITY)
+### 3. Accessibility Features (LOW PRIORITY)
 - Screen reader support
 - Keyboard navigation
 - High contrast themes
@@ -74,35 +64,24 @@
 
 ## 🔧 Immediate Next Steps
 
-### Phase 1: Complete Remaining Pages (2-3 hours)
-1. **Settings Page Implementation**
-   - User preferences interface
-   - Theme and configuration options
-   - Export/import settings
-
-2. **Help Page Implementation**
-   - Interactive documentation
-   - Tutorial system
-   - Feature explanations
-
-### Phase 2: Testing and Quality (3-4 hours)
-3. **Unit Test Implementation**
+### Phase 1: Testing and Quality (3-4 hours)
+1. **Unit Test Implementation**
    - Model testing for all data structures
    - Algorithm validation tests
    - Service layer testing
 
-4. **Performance Testing**
+2. **Performance Testing**
    - Large automata handling
    - Memory usage optimization
    - Rendering performance
 
-### Phase 3: Polish and Documentation (2-3 hours)
-5. **Accessibility Features**
+### Phase 2: Polish and Documentation (2-3 hours)
+3. **Accessibility Features**
    - Screen reader support
    - Keyboard navigation
    - High contrast themes
 
-6. **Documentation Updates**
+4. **Documentation Updates**
    - API documentation
    - User guides
    - Developer documentation
@@ -110,35 +89,37 @@
 ## 📁 Files Created/Updated
 
 ### New UI Components
-- `lib/presentation/widgets/touch_gesture_handler.dart` - Mobile touch interactions
+- `lib/presentation/widgets/algorithm_panel.dart` - Shared algorithm controls
+- `lib/presentation/widgets/automaton_canvas.dart` - Core editing canvas
+- `lib/presentation/widgets/file_operations_panel.dart` - File management UI
+- `lib/presentation/widgets/grammar_algorithm_panel.dart` - Grammar algorithms
 - `lib/presentation/widgets/grammar_editor.dart` - Grammar production rule editor
-- `lib/presentation/widgets/l_system_controls.dart` - L-System control interface
-- `lib/presentation/widgets/l_system_editor.dart` - L-System rule editor
-- `lib/presentation/widgets/l_system_visualizer.dart` - L-System visualization
+- `lib/presentation/widgets/grammar_simulation_panel.dart` - Grammar simulation tools
 - `lib/presentation/widgets/mobile_automaton_controls.dart` - Mobile controls
+- `lib/presentation/widgets/mobile_navigation.dart` - Bottom navigation
 - `lib/presentation/widgets/pda_algorithm_panel.dart` - PDA algorithm interface
 - `lib/presentation/widgets/pda_canvas.dart` - PDA visualization canvas
 - `lib/presentation/widgets/pda_simulation_panel.dart` - PDA simulation controls
-- `lib/presentation/widgets/tm_algorithm_panel.dart` - TM algorithm interface
-- `lib/presentation/widgets/tm_canvas.dart` - TM visualization canvas
-- `lib/presentation/widgets/tm_simulation_panel.dart` - TM simulation controls
 - `lib/presentation/widgets/pumping_lemma_game.dart` - Pumping lemma game
 - `lib/presentation/widgets/pumping_lemma_help.dart` - Game help system
 - `lib/presentation/widgets/pumping_lemma_progress.dart` - Progress tracking
-- `lib/presentation/widgets/file_operations_panel.dart` - File management UI
-- `lib/presentation/widgets/grammar_algorithm_panel.dart` - Grammar algorithms
-- `lib/presentation/widgets/grammar_simulation_panel.dart` - Grammar simulation
+- `lib/presentation/widgets/simulation_panel.dart` - Automaton simulation controls
+- `lib/presentation/widgets/tm_algorithm_panel.dart` - TM algorithm interface
+- `lib/presentation/widgets/tm_canvas.dart` - TM visualization canvas
+- `lib/presentation/widgets/tm_simulation_panel.dart` - TM simulation controls
+- `lib/presentation/widgets/touch_gesture_handler.dart` - Mobile touch interactions
+- `lib/presentation/widgets/transition_geometry.dart` - Canvas geometry helpers
 
 ### New Services
 - `lib/data/services/file_operations_service.dart` - Complete file operations
 
-### New Tests
 - `test/contract/test_automaton_service.dart` - Service contract tests
-- `test/integration/test_fsa_creation.dart` - FSA creation tests
-- `test/integration/test_nfa_to_dfa.dart` - NFA to DFA conversion tests
-- `test/integration/test_grammar_parsing.dart` - Grammar parsing tests
+- `test/integration/home_fab_actions_test.dart` - Floating action button workflow tests
 - `test/integration/test_file_operations.dart` - File operations tests
+- `test/integration/test_fsa_creation.dart` - FSA creation tests
+- `test/integration/test_grammar_parsing.dart` - Grammar parsing tests
 - `test/integration/test_mobile_ui.dart` - Mobile UI tests
+- `test/integration/test_nfa_to_dfa.dart` - Comprehensive NFA to DFA conversion tests
 - `test/integration/test_simple_grammar.dart` - Simple grammar tests
 - `test/integration/test_simple_nfa_to_dfa.dart` - Simple NFA to DFA tests
 - `test/integration/test_touch_gestures.dart` - Touch gesture tests
@@ -149,7 +130,7 @@
 - [x] Mobile-optimized touch interactions
 - [x] File operations with JFLAP format support
 - [x] Comprehensive test suite
-- [ ] Settings and Help pages
+- [x] Settings and Help pages
 - [ ] Unit test coverage
 - [ ] Performance optimization
 - [ ] Accessibility features
@@ -162,11 +143,10 @@
 5. **Accessibility**: Add screen reader support and keyboard navigation
 
 ## 🔄 Next Session Goals
-1. Implement Settings page with user preferences
-2. Create Help page with documentation and tutorials
-3. Add comprehensive unit test coverage
-4. Optimize performance for large automata
-5. Implement accessibility features
+1. Add comprehensive unit test coverage
+2. Optimize performance for large automata
+3. Implement accessibility features
+4. Expand documentation and educational content
 
 ---
 *Session completed with major UI implementation progress - core functionality is now complete*

--- a/PROJECT_STRUCTURE.md
+++ b/PROJECT_STRUCTURE.md
@@ -177,10 +177,12 @@ Main application screens:
 pages/
 ├── fsa_page.dart                  # Finite state automata page
 ├── grammar_page.dart              # Context-free grammar page
+├── help_page.dart                 # In-app help center
 ├── home_page.dart                 # Main navigation page
 ├── pda_page.dart                  # Pushdown automata page
 ├── regex_page.dart                # Regular expression page
 ├── pumping_lemma_page.dart        # Pumping lemma game page
+├── settings_page.dart             # Application preferences page
 └── tm_page.dart                   # Turing machine page
 ```
 

--- a/USER_GUIDE.md
+++ b/USER_GUIDE.md
@@ -22,12 +22,26 @@
 
 JFlutter has 6 main sections accessible via bottom navigation (mobile) or tabs (desktop):
 
-- **FSA** - Finite State Automata
-- **Grammar** - Context-Free Grammars
-- **PDA** - Pushdown Automata
-- **TM** - Turing Machines
-- **L-Systems** - Lindenmayer Systems
-- **Pumping** - Pumping Lemma Game
+- **FSA** - Finite State Automata workspace
+- **Grammar** - Context-free grammar editor and analysis tools
+- **PDA** - Pushdown automata construction and simulation
+- **TM** - Turing machine design environment
+- **Regex** - Regular expression testing and conversions
+- **Pumping** - Pumping Lemma challenges and tutorials
+
+Additional icons in the app bar provide quick access to:
+
+- **Help** (question mark icon) - Opens the multi-section help center
+- **Settings** (gear icon) - Opens application preferences such as theme, canvas, and symbol defaults
+
+### Tab Highlights
+
+- **FSA** – Draw deterministic or non-deterministic automata, run simulations, and execute conversions such as NFA→DFA, DFA minimization, and FA→Regex.
+- **Grammar** – Manage productions with the grammar editor, parse example strings, and run conversions like FSA→Grammar from the algorithm panel.
+- **PDA** – Define stack-based transitions, simulate inputs with optional trace recording, and inspect execution steps.
+- **TM** – Configure tape alphabets and transitions, then run simulations with real-time tape visualization.
+- **Regex** – Test regular expressions, convert them to NFAs, and compare equivalent DFAs using shared algorithm tools.
+- **Pumping** – Practice the pumping lemma through interactive challenges, guided help, and progress tracking panels.
 
 ### Layout Modes
 
@@ -109,7 +123,7 @@ JFlutter has 6 main sections accessible via bottom navigation (mobile) or tabs (
 4. **See step count** and execution details
 
 #### Step-by-Step Simulation
-1. **Enable step-by-step mode** in settings
+1. **Toggle "Record step-by-step trace"** in the simulation panel when available
 2. **Watch states highlight** as the automaton processes
 3. **See transition paths** taken during execution
 4. **Understand the process** visually

--- a/specs/001-description-port-jflap/tasks.md
+++ b/specs/001-description-port-jflap/tasks.md
@@ -168,8 +168,8 @@
 - [x] T082 [P] Complete grammar editor functionality in lib/presentation/pages/grammar_page.dart
 - [x] T083 [P] Complete L-System functionality in lib/presentation/pages/l_system_page.dart
 - [x] T084 [P] Complete pumping lemma game in lib/presentation/pages/pumping_lemma_page.dart
-- [ ] T085 [P] Settings page in lib/presentation/pages/settings_page.dart
-- [ ] T086 [P] Help page in lib/presentation/pages/help_page.dart
+- [x] T085 [P] Settings page in lib/presentation/pages/settings_page.dart
+- [x] T086 [P] Help page in lib/presentation/pages/help_page.dart
 
 ## Phase 3.9: State Management 🔄 PARTIALLY COMPLETED
 - [x] T075 [P] Automaton provider in lib/presentation/providers/automaton_provider.dart
@@ -210,7 +210,7 @@
 - [ ] T104 [P] Widget tests for all widgets in test/widget/
 - [ ] T105 Performance tests for large automata
 - [ ] T106 [P] Update API documentation
-- [ ] T107 [P] Update user guide
+- [x] T107 [P] Update user guide
 - [ ] T108 Remove code duplication
 - [ ] T109 Run quickstart.md validation scenarios
 - [ ] T110 Final integration testing
@@ -262,18 +262,16 @@ Task: "Pumping lemma game implementation"
 - **Test Coverage**: Contract and integration test suite
 
 ### ❌ What Needs Immediate Attention:
-1. **Settings Page**: User preferences and configuration interface
-2. **Help Page**: User documentation and tutorial system
-3. **Unit Tests**: Comprehensive unit test coverage for all components
-4. **Performance**: Optimization for handling large automata
-5. **Accessibility**: Screen reader support and accessibility features
+1. **Unit Tests**: Comprehensive unit test coverage for all components
+2. **Performance**: Optimization for handling large automata
+3. **Accessibility**: Screen reader support and accessibility features
+4. **Documentation**: Continue refining API and developer guides
 
 ### 🎯 Recommended Next Steps:
-1. **Complete Remaining Pages** (T085-T086): Settings and Help pages
-2. **Add Unit Tests** (T097-T100): Comprehensive unit test coverage
-3. **Performance Optimization** (T101-T105): Handle large automata efficiently
-4. **Documentation** (T106-T107): API docs and user guides
-5. **Accessibility** (T108-T110): Screen reader support and accessibility features
+1. **Add Unit Tests** (T097-T100): Comprehensive unit test coverage
+2. **Performance Optimization** (T101-T105): Handle large automata efficiently
+3. **Documentation** (T106-T107): API docs and user guides
+4. **Accessibility** (T108-T110): Screen reader support and accessibility features
 
 ## Notes
 - [P] tasks = different files, no dependencies


### PR DESCRIPTION
## Summary
- refresh the changelog and project status docs to acknowledge the finished grammar, PDA, TM, settings, and help pages while removing stale L-system references
- update the user guide to match the actual navigation tabs, add quick summaries for each workspace, and clarify where to find help and settings
- sync supporting documentation and specs so remaining action items focus on testing, performance, accessibility, and documentation polish

## Testing
- `flutter test` *(fails: command not found `flutter`)*

------
https://chatgpt.com/codex/tasks/task_e_68ccc2b2adfc832ebe86ec015ec311fb