### PR TITLE
Fix TM analysis imports and duration fallback

### DIFF
--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/algorithms/algorithm_operations.dart';
-import '../../core/models/state.dart';
+import '../../core/algorithms/tm_simulator.dart';
+import '../../core/models/state.dart' as automaton_models;
 import '../../core/models/tm.dart';
 import '../../core/models/tm_transition.dart';
 import '../../core/models/tm_transition.dart' as tm_models show TapeDirection;
@@ -805,7 +806,7 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
     );
   }
 
-  List<String> _formatStates(Set<State> states) {
+  List<String> _formatStates(Set<automaton_models.State> states) {
     final labels = states
         .map((state) => state.label.isNotEmpty ? state.label : state.id)
         .toList();
@@ -826,7 +827,7 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
     if (duration.inMicroseconds >= 1) {
       return '${duration.inMicroseconds} μs';
     }
-    return '${duration.inNanoseconds} ns';
+    return '${duration.inMicroseconds * 1000} ns';
   }
 
   List<TMTransition> _findPotentialInfiniteLoops(TM tm) {


### PR DESCRIPTION
## Summary
- import the TM simulator to resolve TMAnalysis types and alias automaton states
- type the state formatting helper against automaton state models and keep List<String> output
- replace the nanosecond access with a microsecond-based fallback for duration formatting

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd571f8648832e8827ac1d1fd1befe