### PR TITLE
Make layout constants runtime-initialized

### DIFF
--- a/lib/features/layout/layout_repository_impl.dart
+++ b/lib/features/layout/layout_repository_impl.dart
@@ -7,10 +7,10 @@ import '../../core/repositories/automaton_repository.dart';
 import '../../core/result.dart';
 
 class LayoutRepositoryImpl implements LayoutRepository {
-  static const Vector2 _canvasSize = Vector2(800, 600);
+  static final Vector2 _canvasSize = Vector2(800, 600);
   static const double _canvasPadding = 60;
   static const double _minLayoutSize = 160;
-  static const double _goldenAngle = math.pi * (3 - math.sqrt(5));
+  static final double _goldenAngle = math.pi * (3 - math.sqrt(5));
 
   static Vector2 get _canvasCenter =>
       Vector2(_canvasSize.x / 2, _canvasSize.y / 2);


### PR DESCRIPTION
## Summary
- convert the canvas size and golden angle values in the layout repository to `static final` so they can leverage runtime expressions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd572805f0832eb6f36c2698e914ab