### PR TITLE
Refine first and follow set updates

### DIFF
--- a/lib/core/algorithms/grammar_analyzer.dart
+++ b/lib/core/algorithms/grammar_analyzer.dart
@@ -272,7 +272,10 @@ class GrammarAnalyzer {
 
             final source = first[symbol]!;
             final withoutEpsilon = source.where((s) => s != 'ε').toSet();
-            if (first[left]!.addAll(withoutEpsilon)) {
+            final targetFirst = first[left]!;
+            final previousLength = targetFirst.length;
+            targetFirst.addAll(withoutEpsilon);
+            if (targetFirst.length != previousLength) {
               changed = true;
               derivations.add(
                   "FIRST($left) absorbs FIRST($symbol) − {ε} via production $left → ${_formatSymbols(right)}");
@@ -343,14 +346,19 @@ class GrammarAnalyzer {
             final suffix = right.sublist(i + 1);
             final firstOfSuffix = _firstOfSequence(suffix, first);
             final withoutEpsilon = firstOfSuffix.where((s) => s != 'ε').toSet();
-            if (follow[symbol]!.addAll(withoutEpsilon)) {
+            final targetFollow = follow[symbol]!;
+            final previousLength = targetFollow.length;
+            targetFollow.addAll(withoutEpsilon);
+            if (targetFollow.length != previousLength) {
               changed = true;
               derivations.add(
                   "FOLLOW($symbol) gains ${withoutEpsilon.join(', ')} from FIRST of suffix in $left → ${_formatSymbols(right)}");
             }
 
             if (suffix.isEmpty || firstOfSuffix.contains('ε')) {
-              if (follow[symbol]!.addAll(follow[left]!)) {
+              final previousFollowLength = targetFollow.length;
+              targetFollow.addAll(follow[left]!);
+              if (targetFollow.length != previousFollowLength) {
                 changed = true;
                 derivations.add(
                     "FOLLOW($symbol) absorbs FOLLOW($left) because suffix can derive ε in $left → ${_formatSymbols(right)}");


### PR DESCRIPTION
## Summary
- detect FIRST set changes by comparing set length before and after updates
- ensure FOLLOW set propagation only toggles when new symbols are inserted

## Testing
- Not run (dart CLI unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68cd5736d650832e95c1858aa9a6b49b