### PR TITLE
Fix automaton canvas pointer exit handling

### DIFF
--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -390,25 +390,27 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
             onTransitionEdited: (transition) {
               _editTransition(transition);
             },
-            child: Listener(
-              onPointerHover: (event) =>
-                  _updateTransitionPreview(event.localPosition),
-              onPointerMove: (event) =>
-                  _updateTransitionPreview(event.localPosition),
-              onPointerDown: (event) =>
-                  _updateTransitionPreview(event.localPosition),
-              onPointerUp: (_) => _updateTransitionPreview(null),
-              onPointerCancel: (_) => _updateTransitionPreview(null),
-              onPointerExit: (_) => _updateTransitionPreview(null),
-              child: CustomPaint(
-                painter: AutomatonPainter(
-                  states: _states,
-                  transitions: _transitions,
-                  selectedState: _selectedState,
-                  transitionStart: _transitionStart,
-                  transitionPreviewPosition: _transitionPreviewPosition,
+            child: MouseRegion(
+              onExit: (_) => _updateTransitionPreview(null),
+              child: Listener(
+                onPointerHover: (event) =>
+                    _updateTransitionPreview(event.localPosition),
+                onPointerMove: (event) =>
+                    _updateTransitionPreview(event.localPosition),
+                onPointerDown: (event) =>
+                    _updateTransitionPreview(event.localPosition),
+                onPointerUp: (_) => _updateTransitionPreview(null),
+                onPointerCancel: (_) => _updateTransitionPreview(null),
+                child: CustomPaint(
+                  painter: AutomatonPainter(
+                    states: _states,
+                    transitions: _transitions,
+                    selectedState: _selectedState,
+                    transitionStart: _transitionStart,
+                    transitionPreviewPosition: _transitionPreviewPosition,
+                  ),
+                  size: Size.infinite,
                 ),
-                size: Size.infinite,
               ),
             ),
           ),


### PR DESCRIPTION
## Summary
- wrap the automaton canvas listener with a MouseRegion to support pointer exit handling
- remove use of the unsupported `onPointerExit` argument from the Listener widget while keeping the preview reset behavior

## Testing
- Not run (tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd5731e658832e8c6a45704e66cb9b