### PR TITLE
refactor: extract TM analysis models

### DIFF
--- a/lib/core/algorithms/algorithm_operations.dart
+++ b/lib/core/algorithms/algorithm_operations.dart
@@ -5,6 +5,7 @@ import '../models/grammar.dart';
 import '../models/pumping_lemma_game.dart' as models;
 import '../models/pumping_attempt.dart';
 import '../models/simulation_result.dart';
+import '../models/tm_analysis.dart';
 import '../result.dart';
 import 'nfa_to_dfa_converter.dart';
 import 'dfa_minimizer.dart';

--- a/lib/core/algorithms/tm_simulator.dart
+++ b/lib/core/algorithms/tm_simulator.dart
@@ -1,9 +1,10 @@
-import '../models/tm.dart';
-import '../models/state.dart';
-import '../models/tm_transition.dart';
 import '../models/fsa_transition.dart';
 import '../models/simulation_result.dart';
 import '../models/simulation_step.dart';
+import '../models/state.dart';
+import '../models/tm.dart';
+import '../models/tm_analysis.dart';
+import '../models/tm_transition.dart';
 import '../result.dart';
 
 /// Simulates Turing Machines (TM) with input strings
@@ -596,89 +597,4 @@ class TMSimulationResult {
       executionTime: executionTime ?? this.executionTime,
     );
   }
-}
-
-/// Analysis result of a TM
-class TMAnalysis {
-  final TMStateAnalysis stateAnalysis;
-  final TMTransitionAnalysis transitionAnalysis;
-  final TapeAnalysis tapeAnalysis;
-  final TMReachabilityAnalysis reachabilityAnalysis;
-  final Duration executionTime;
-
-  const TMAnalysis({
-    required this.stateAnalysis,
-    required this.transitionAnalysis,
-    required this.tapeAnalysis,
-    required this.reachabilityAnalysis,
-    required this.executionTime,
-  });
-
-  TMAnalysis copyWith({
-    TMStateAnalysis? stateAnalysis,
-    TMTransitionAnalysis? transitionAnalysis,
-    TapeAnalysis? tapeAnalysis,
-    TMReachabilityAnalysis? reachabilityAnalysis,
-    Duration? executionTime,
-  }) {
-    return TMAnalysis(
-      stateAnalysis: stateAnalysis ?? this.stateAnalysis,
-      transitionAnalysis: transitionAnalysis ?? this.transitionAnalysis,
-      tapeAnalysis: tapeAnalysis ?? this.tapeAnalysis,
-      reachabilityAnalysis: reachabilityAnalysis ?? this.reachabilityAnalysis,
-      executionTime: executionTime ?? this.executionTime,
-    );
-  }
-}
-
-/// Analysis of states
-class TMStateAnalysis {
-  final int totalStates;
-  final int acceptingStates;
-  final int nonAcceptingStates;
-
-  const TMStateAnalysis({
-    required this.totalStates,
-    required this.acceptingStates,
-    required this.nonAcceptingStates,
-  });
-}
-
-/// Analysis of transitions
-class TMTransitionAnalysis {
-  final int totalTransitions;
-  final int tmTransitions;
-  final int fsaTransitions;
-
-  const TMTransitionAnalysis({
-    required this.totalTransitions,
-    required this.tmTransitions,
-    required this.fsaTransitions,
-  });
-}
-
-/// Analysis of tape operations
-class TapeAnalysis {
-  final Set<String> writeOperations;
-  final Set<String> readOperations;
-  final Set<String> moveDirections;
-  final Set<String> tapeSymbols;
-
-  const TapeAnalysis({
-    required this.writeOperations,
-    required this.readOperations,
-    required this.moveDirections,
-    required this.tapeSymbols,
-  });
-}
-
-/// Analysis of reachability
-class TMReachabilityAnalysis {
-  final Set<State> reachableStates;
-  final Set<State> unreachableStates;
-
-  const TMReachabilityAnalysis({
-    required this.reachableStates,
-    required this.unreachableStates,
-  });
 }

--- a/lib/core/models/tm_analysis.dart
+++ b/lib/core/models/tm_analysis.dart
@@ -1,0 +1,87 @@
+import 'state.dart';
+
+/// Analysis result of a TM
+class TMAnalysis {
+  final TMStateAnalysis stateAnalysis;
+  final TMTransitionAnalysis transitionAnalysis;
+  final TapeAnalysis tapeAnalysis;
+  final TMReachabilityAnalysis reachabilityAnalysis;
+  final Duration executionTime;
+
+  const TMAnalysis({
+    required this.stateAnalysis,
+    required this.transitionAnalysis,
+    required this.tapeAnalysis,
+    required this.reachabilityAnalysis,
+    required this.executionTime,
+  });
+
+  TMAnalysis copyWith({
+    TMStateAnalysis? stateAnalysis,
+    TMTransitionAnalysis? transitionAnalysis,
+    TapeAnalysis? tapeAnalysis,
+    TMReachabilityAnalysis? reachabilityAnalysis,
+    Duration? executionTime,
+  }) {
+    return TMAnalysis(
+      stateAnalysis: stateAnalysis ?? this.stateAnalysis,
+      transitionAnalysis: transitionAnalysis ?? this.transitionAnalysis,
+      tapeAnalysis: tapeAnalysis ?? this.tapeAnalysis,
+      reachabilityAnalysis:
+          reachabilityAnalysis ?? this.reachabilityAnalysis,
+      executionTime: executionTime ?? this.executionTime,
+    );
+  }
+}
+
+/// Analysis of states
+class TMStateAnalysis {
+  final int totalStates;
+  final int acceptingStates;
+  final int nonAcceptingStates;
+
+  const TMStateAnalysis({
+    required this.totalStates,
+    required this.acceptingStates,
+    required this.nonAcceptingStates,
+  });
+}
+
+/// Analysis of transitions
+class TMTransitionAnalysis {
+  final int totalTransitions;
+  final int tmTransitions;
+  final int fsaTransitions;
+
+  const TMTransitionAnalysis({
+    required this.totalTransitions,
+    required this.tmTransitions,
+    required this.fsaTransitions,
+  });
+}
+
+/// Analysis of tape operations
+class TapeAnalysis {
+  final Set<String> writeOperations;
+  final Set<String> readOperations;
+  final Set<String> moveDirections;
+  final Set<String> tapeSymbols;
+
+  const TapeAnalysis({
+    required this.writeOperations,
+    required this.readOperations,
+    required this.moveDirections,
+    required this.tapeSymbols,
+  });
+}
+
+/// Analysis of reachability
+class TMReachabilityAnalysis {
+  final Set<State> reachableStates;
+  final Set<State> unreachableStates;
+
+  const TMReachabilityAnalysis({
+    required this.reachableStates,
+    required this.unreachableStates,
+  });
+}

--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -2,9 +2,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/algorithms/algorithm_operations.dart';
-import '../../core/algorithms/tm_simulator.dart';
 import '../../core/models/state.dart' as automaton_models;
 import '../../core/models/tm.dart';
+import '../../core/models/tm_analysis.dart';
 import '../../core/models/tm_transition.dart';
 import '../../core/models/tm_transition.dart' as tm_models show TapeDirection;
 import '../../core/result.dart';


### PR DESCRIPTION
## Summary
- move TM analysis data classes into a dedicated core model file
- update the simulator and algorithm operations to consume the shared models
- adjust the TM algorithm panel to depend on the shared model definitions

## Testing
- flutter test *(fails: Flutter is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd66fe8978832ea2c2a5d3276d5015