### PR TITLE
Strongly type labels list in _formatStates

### DIFF
--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -807,7 +807,7 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
   }
 
   List<String> _formatStates(Set<automaton_models.State> states) {
-    final labels = states
+    final List<String> labels = states
         .map((state) => state.label.isNotEmpty ? state.label : state.id)
         .toList();
     labels.sort();


### PR DESCRIPTION
## Summary
- declare the intermediate labels collection in `_formatStates` as a strongly typed `List<String>`
- keep existing sorting logic and return value intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd67023338832e8dbb9d3daee27272