### PR TITLE
Compute nanoseconds manually in duration formatting

### DIFF
--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -827,7 +827,8 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
     if (duration.inMicroseconds >= 1) {
       return '${duration.inMicroseconds} μs';
     }
-    return '${duration.inMicroseconds * 1000} ns';
+    final nanoseconds = duration.inMicroseconds * 1000;
+    return '$nanoseconds ns';
   }
 
   List<TMTransition> _findPotentialInfiniteLoops(TM tm) {


### PR DESCRIPTION
## Summary
- retain the millisecond and microsecond handling in `_formatDuration`
- compute nanoseconds manually from microseconds for the fallback branch

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd67060590832eaa718db7909eccb0