### PR TITLE
Adjust change detection for FIRST and FOLLOW sets

### DIFF
--- a/lib/core/algorithms/grammar_analyzer.dart
+++ b/lib/core/algorithms/grammar_analyzer.dart
@@ -275,7 +275,7 @@ class GrammarAnalyzer {
             final targetFirst = first[left]!;
             final previousLength = targetFirst.length;
             targetFirst.addAll(withoutEpsilon);
-            if (targetFirst.length != previousLength) {
+            if (targetFirst.length > previousLength) {
               changed = true;
               derivations.add(
                   "FIRST($left) absorbs FIRST($symbol) − {ε} via production $left → ${_formatSymbols(right)}");
@@ -349,7 +349,7 @@ class GrammarAnalyzer {
             final targetFollow = follow[symbol]!;
             final previousLength = targetFollow.length;
             targetFollow.addAll(withoutEpsilon);
-            if (targetFollow.length != previousLength) {
+            if (targetFollow.length > previousLength) {
               changed = true;
               derivations.add(
                   "FOLLOW($symbol) gains ${withoutEpsilon.join(', ')} from FIRST of suffix in $left → ${_formatSymbols(right)}");
@@ -358,7 +358,7 @@ class GrammarAnalyzer {
             if (suffix.isEmpty || firstOfSuffix.contains('ε')) {
               final previousFollowLength = targetFollow.length;
               targetFollow.addAll(follow[left]!);
-              if (targetFollow.length != previousFollowLength) {
+              if (targetFollow.length > previousFollowLength) {
                 changed = true;
                 derivations.add(
                     "FOLLOW($symbol) absorbs FOLLOW($left) because suffix can derive ε in $left → ${_formatSymbols(right)}");


### PR DESCRIPTION
## Summary
- guard FIRST set updates by checking the set size before and after merging
- apply the same length comparison refinement to FOLLOW set updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd670ab41c832e9afe1cf9906bdb0d