### PR TITLE
Use foundation prefix for FlutterError handling

### DIFF
--- a/lib/data/data_sources/examples_data_source.dart
+++ b/lib/data/data_sources/examples_data_source.dart
@@ -1,5 +1,5 @@
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
+import 'package:flutter/foundation.dart' as foundation;
 import 'package:flutter/services.dart';
 import '../models/automaton_model.dart';
 import '../../core/result.dart';
@@ -56,7 +56,7 @@ class ExamplesDataSource {
       );
 
       return Success(example);
-    } on FlutterError catch (e) {
+    } on foundation.FlutterError catch (e) {
       final message = e.message ?? e.toString();
       if (message.contains('Unable to load asset')) {
         return Failure(


### PR DESCRIPTION
## Summary
- import the Flutter foundation package with a prefix
- reference FlutterError via the new foundation prefix in the examples data source

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cd67101e30832eb389cb71479a343c