### PR TITLE
Refine transition preview exit handling

### DIFF
--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -391,7 +391,9 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
               _editTransition(transition);
             },
             child: MouseRegion(
-              onExit: (_) => _updateTransitionPreview(null),
+              onExit: (_) {
+                _updateTransitionPreview(null);
+              },
               child: Listener(
                 onPointerHover: (event) =>
                     _updateTransitionPreview(event.localPosition),


### PR DESCRIPTION
## Summary
- keep the canvas listener free of onPointerExit and rely on the surrounding MouseRegion instead
- ensure the transition preview reset still happens when the mouse leaves the canvas

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd671566c4832e8d0a6f0011932d18