### PR TITLE
Refactor settings storage and add repository tests

### DIFF
--- a/lib/data/repositories/settings_repository_impl.dart
+++ b/lib/data/repositories/settings_repository_impl.dart
@@ -1,13 +1,12 @@
-import 'package:shared_preferences/shared_preferences.dart';
-
 import '../../core/models/settings_model.dart';
 import '../../core/repositories/settings_repository.dart';
+import '../storage/settings_storage.dart';
 
 /// Settings repository backed by [SharedPreferences].
 class SharedPreferencesSettingsRepository implements SettingsRepository {
   const SharedPreferencesSettingsRepository({
-    Future<SharedPreferences> Function()? preferencesProvider,
-  }) : _preferencesProvider = preferencesProvider;
+    SettingsStorage? storage,
+  }) : _storage = storage ?? const SharedPreferencesSettingsStorage();
 
   static const String _emptyStringSymbolKey = 'settings_empty_string_symbol';
   static const String _epsilonSymbolKey = 'settings_epsilon_symbol';
@@ -20,50 +19,39 @@ class SharedPreferencesSettingsRepository implements SettingsRepository {
   static const String _nodeSizeKey = 'settings_node_size';
   static const String _fontSizeKey = 'settings_font_size';
 
-  final Future<SharedPreferences> Function()? _preferencesProvider;
-
-  Future<SharedPreferences> _getPreferences() {
-    final provider = _preferencesProvider;
-    if (provider != null) {
-      return provider();
-    }
-    return SharedPreferences.getInstance();
-  }
+  final SettingsStorage _storage;
 
   @override
   Future<SettingsModel> loadSettings() async {
-    final prefs = await _getPreferences();
     const defaults = SettingsModel();
 
     return SettingsModel(
-      emptyStringSymbol: prefs.getString(_emptyStringSymbolKey) ?? defaults.emptyStringSymbol,
-      epsilonSymbol: prefs.getString(_epsilonSymbolKey) ?? defaults.epsilonSymbol,
-      themeMode: prefs.getString(_themeModeKey) ?? defaults.themeMode,
-      showGrid: prefs.getBool(_showGridKey) ?? defaults.showGrid,
-      showCoordinates: prefs.getBool(_showCoordinatesKey) ?? defaults.showCoordinates,
-      autoSave: prefs.getBool(_autoSaveKey) ?? defaults.autoSave,
-      showTooltips: prefs.getBool(_showTooltipsKey) ?? defaults.showTooltips,
-      gridSize: prefs.getDouble(_gridSizeKey) ?? defaults.gridSize,
-      nodeSize: prefs.getDouble(_nodeSizeKey) ?? defaults.nodeSize,
-      fontSize: prefs.getDouble(_fontSizeKey) ?? defaults.fontSize,
+      emptyStringSymbol: await _storage.readString(_emptyStringSymbolKey) ?? defaults.emptyStringSymbol,
+      epsilonSymbol: await _storage.readString(_epsilonSymbolKey) ?? defaults.epsilonSymbol,
+      themeMode: await _storage.readString(_themeModeKey) ?? defaults.themeMode,
+      showGrid: await _storage.readBool(_showGridKey) ?? defaults.showGrid,
+      showCoordinates: await _storage.readBool(_showCoordinatesKey) ?? defaults.showCoordinates,
+      autoSave: await _storage.readBool(_autoSaveKey) ?? defaults.autoSave,
+      showTooltips: await _storage.readBool(_showTooltipsKey) ?? defaults.showTooltips,
+      gridSize: await _storage.readDouble(_gridSizeKey) ?? defaults.gridSize,
+      nodeSize: await _storage.readDouble(_nodeSizeKey) ?? defaults.nodeSize,
+      fontSize: await _storage.readDouble(_fontSizeKey) ?? defaults.fontSize,
     );
   }
 
   @override
   Future<void> saveSettings(SettingsModel settings) async {
-    final prefs = await _getPreferences();
-
     final results = await Future.wait<bool>([
-      prefs.setString(_emptyStringSymbolKey, settings.emptyStringSymbol),
-      prefs.setString(_epsilonSymbolKey, settings.epsilonSymbol),
-      prefs.setString(_themeModeKey, settings.themeMode),
-      prefs.setBool(_showGridKey, settings.showGrid),
-      prefs.setBool(_showCoordinatesKey, settings.showCoordinates),
-      prefs.setBool(_autoSaveKey, settings.autoSave),
-      prefs.setBool(_showTooltipsKey, settings.showTooltips),
-      prefs.setDouble(_gridSizeKey, settings.gridSize),
-      prefs.setDouble(_nodeSizeKey, settings.nodeSize),
-      prefs.setDouble(_fontSizeKey, settings.fontSize),
+      _storage.writeString(_emptyStringSymbolKey, settings.emptyStringSymbol),
+      _storage.writeString(_epsilonSymbolKey, settings.epsilonSymbol),
+      _storage.writeString(_themeModeKey, settings.themeMode),
+      _storage.writeBool(_showGridKey, settings.showGrid),
+      _storage.writeBool(_showCoordinatesKey, settings.showCoordinates),
+      _storage.writeBool(_autoSaveKey, settings.autoSave),
+      _storage.writeBool(_showTooltipsKey, settings.showTooltips),
+      _storage.writeDouble(_gridSizeKey, settings.gridSize),
+      _storage.writeDouble(_nodeSizeKey, settings.nodeSize),
+      _storage.writeDouble(_fontSizeKey, settings.fontSize),
     ]);
 
     if (results.any((success) => !success)) {

--- a/lib/data/storage/settings_storage.dart
+++ b/lib/data/storage/settings_storage.dart
@@ -1,0 +1,101 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Key-value storage interface used by the settings repository.
+abstract class SettingsStorage {
+  Future<String?> readString(String key);
+  Future<bool?> readBool(String key);
+  Future<double?> readDouble(String key);
+
+  Future<bool> writeString(String key, String value);
+  Future<bool> writeBool(String key, bool value);
+  Future<bool> writeDouble(String key, double value);
+}
+
+/// [SettingsStorage] backed by [SharedPreferences].
+class SharedPreferencesSettingsStorage implements SettingsStorage {
+  const SharedPreferencesSettingsStorage({
+    Future<SharedPreferences> Function()? preferencesProvider,
+  }) : _preferencesProvider = preferencesProvider;
+
+  final Future<SharedPreferences> Function()? _preferencesProvider;
+
+  Future<SharedPreferences> _getPreferences() {
+    final provider = _preferencesProvider;
+    if (provider != null) {
+      return provider();
+    }
+    return SharedPreferences.getInstance();
+  }
+
+  @override
+  Future<String?> readString(String key) async {
+    final prefs = await _getPreferences();
+    return prefs.getString(key);
+  }
+
+  @override
+  Future<bool?> readBool(String key) async {
+    final prefs = await _getPreferences();
+    return prefs.getBool(key);
+  }
+
+  @override
+  Future<double?> readDouble(String key) async {
+    final prefs = await _getPreferences();
+    return prefs.getDouble(key);
+  }
+
+  @override
+  Future<bool> writeString(String key, String value) async {
+    final prefs = await _getPreferences();
+    return prefs.setString(key, value);
+  }
+
+  @override
+  Future<bool> writeBool(String key, bool value) async {
+    final prefs = await _getPreferences();
+    return prefs.setBool(key, value);
+  }
+
+  @override
+  Future<bool> writeDouble(String key, double value) async {
+    final prefs = await _getPreferences();
+    return prefs.setDouble(key, value);
+  }
+}
+
+/// In-memory implementation of [SettingsStorage] used in tests.
+class InMemorySettingsStorage implements SettingsStorage {
+  InMemorySettingsStorage([Map<String, Object?>? initialValues])
+      : _values = Map<String, Object?>.from(initialValues ?? const {});
+
+  final Map<String, Object?> _values;
+
+  @override
+  Future<String?> readString(String key) async => _values[key] as String?;
+
+  @override
+  Future<bool?> readBool(String key) async => _values[key] as bool?;
+
+  @override
+  Future<double?> readDouble(String key) async =>
+      (_values[key] as num?)?.toDouble();
+
+  @override
+  Future<bool> writeString(String key, String value) async {
+    _values[key] = value;
+    return true;
+  }
+
+  @override
+  Future<bool> writeBool(String key, bool value) async {
+    _values[key] = value;
+    return true;
+  }
+
+  @override
+  Future<bool> writeDouble(String key, double value) async {
+    _values[key] = value;
+    return true;
+  }
+}

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -3,12 +3,17 @@ import 'package:flutter/material.dart';
 import 'package:jflutter/core/models/settings_model.dart';
 import 'package:jflutter/core/repositories/settings_repository.dart';
 import 'package:jflutter/data/repositories/settings_repository_impl.dart';
+import 'package:jflutter/data/storage/settings_storage.dart';
 
 class SettingsPage extends StatefulWidget {
   const SettingsPage({
     super.key,
     SettingsRepository? repository,
-  }) : repository = repository ?? const SharedPreferencesSettingsRepository();
+    SettingsStorage? storage,
+  }) : repository = repository ??
+            SharedPreferencesSettingsRepository(
+              storage: storage ?? const SharedPreferencesSettingsStorage(),
+            );
 
   final SettingsRepository repository;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   test: ^1.24.0
+  shared_preferences_platform_interface: ^2.4.1
 
   # The "flutter_lints" package below contains a set of recommended lints to
   # encourage good coding practices. The lint set provided by the package is

--- a/test/data/repositories/shared_preferences_settings_repository_test.dart
+++ b/test/data/repositories/shared_preferences_settings_repository_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:shared_preferences_platform_interface/shared_preferences_platform_interface.dart';
+
+import 'package:jflutter/core/models/settings_model.dart';
+import 'package:jflutter/data/repositories/settings_repository_impl.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SharedPreferencesStorePlatform originalStore;
+
+  setUp(() async {
+    originalStore = SharedPreferencesStorePlatform.instance;
+    SharedPreferencesStorePlatform.instance = InMemorySharedPreferencesStore.empty();
+    await SharedPreferences.resetStatic();
+  });
+
+  tearDown(() async {
+    SharedPreferencesStorePlatform.instance = originalStore;
+    await SharedPreferences.resetStatic();
+  });
+
+  test('loadSettings returns defaults when storage is empty', () async {
+    const repository = SharedPreferencesSettingsRepository();
+
+    final settings = await repository.loadSettings();
+
+    expect(settings, equals(const SettingsModel()));
+  });
+
+  test('saveSettings persists values that can be reloaded', () async {
+    const savedSettings = SettingsModel(
+      emptyStringSymbol: 'ε',
+      epsilonSymbol: 'λ',
+      themeMode: 'dark',
+      showGrid: false,
+      showCoordinates: true,
+      autoSave: false,
+      showTooltips: false,
+      gridSize: 42.0,
+      nodeSize: 25.0,
+      fontSize: 16.0,
+    );
+
+    const repository = SharedPreferencesSettingsRepository();
+    await repository.saveSettings(savedSettings);
+
+    const reloadedRepository = SharedPreferencesSettingsRepository();
+    final reloadedSettings = await reloadedRepository.loadSettings();
+
+    expect(reloadedSettings, equals(savedSettings));
+  });
+}

--- a/test/widget/settings_page_test.dart
+++ b/test/widget/settings_page_test.dart
@@ -1,16 +1,12 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:shared_preferences/shared_preferences.dart';
 
+import 'package:jflutter/data/storage/settings_storage.dart';
 import 'package:jflutter/presentation/pages/settings_page.dart';
 
 void main() {
-  setUp(() {
-    SharedPreferences.setMockInitialValues({});
-  });
-
   testWidgets('loads settings from stored preferences', (WidgetTester tester) async {
-    SharedPreferences.setMockInitialValues({
+    final storage = InMemorySettingsStorage({
       'settings_empty_string_symbol': 'ε',
       'settings_epsilon_symbol': 'λ',
       'settings_theme_mode': 'dark',
@@ -23,7 +19,7 @@ void main() {
       'settings_font_size': 16.0,
     });
 
-    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpWidget(MaterialApp(home: SettingsPage(storage: storage)));
     await tester.pumpAndSettle();
 
     final emptyStringChip = tester.widget<FilterChip>(
@@ -53,7 +49,9 @@ void main() {
   });
 
   testWidgets('saves settings and restores them on next load', (WidgetTester tester) async {
-    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    final storage = InMemorySettingsStorage();
+
+    await tester.pumpWidget(MaterialApp(home: SettingsPage(storage: storage)));
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('settings_show_grid_switch')));
@@ -75,7 +73,7 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
 
-    await tester.pumpWidget(const MaterialApp(home: SettingsPage()));
+    await tester.pumpWidget(MaterialApp(home: SettingsPage(storage: storage)));
     await tester.pumpAndSettle();
 
     final reloadedGridSwitch = tester.widget<Switch>(


### PR DESCRIPTION
## Summary
- introduce a SettingsStorage abstraction with shared_preferences and in-memory implementations
- inject the storage into SettingsPage so tests can provide an in-memory store
- update widget tests to use the in-memory storage and add repository tests covering the shared_preferences path
- declare shared_preferences_platform_interface as a dev dependency for the new tests

## Testing
- flutter test *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cda68c66c4832eb9178c00fa8deeb2