### PR TITLE
Handle non-adjacent navigation jumps

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -96,13 +96,19 @@ class _HomePageState extends ConsumerState<HomePage> {
 
     // Handle navigation changes
     if (_lastNavigationIndex != currentIndex) {
+      final previousIndex = _lastNavigationIndex;
       WidgetsBinding.instance.addPostFrameCallback((_) {
         if (mounted && _pageController.hasClients) {
-          _pageController.animateToPage(
-            currentIndex,
-            duration: const Duration(milliseconds: 300),
-            curve: Curves.easeInOut,
-          );
+          if (previousIndex != null &&
+              (currentIndex - previousIndex).abs() > 1) {
+            _pageController.jumpToPage(currentIndex);
+          } else {
+            _pageController.animateToPage(
+              currentIndex,
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+            );
+          }
         }
       });
       _lastNavigationIndex = currentIndex;


### PR DESCRIPTION
## Summary
- ensure the home page detects non-adjacent navigation index changes
- jump directly to distant pages to avoid unnecessary animations
- retain smooth animations for adjacent tab transitions

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d15d3413a4832e8bf251ee9e015ae5