### PR TITLE
Support additional lambda aliases

### DIFF
--- a/lib/core/algorithms/dfa_operations.dart
+++ b/lib/core/algorithms/dfa_operations.dart
@@ -467,6 +467,10 @@ class FSAOperations {
 
   static bool _isLambdaSymbol(String symbol) {
     final normalized = symbol.trim().toLowerCase();
-    return normalized == 'ε' || normalized == 'λ' || normalized == 'lambda';
+    return normalized == 'ε' ||
+        normalized == 'λ' ||
+        normalized == 'lambda' ||
+        normalized == '£' ||
+        normalized == '€';
   }
 }

--- a/lib/core/algorithms/grammar_to_fsa_converter.dart
+++ b/lib/core/algorithms/grammar_to_fsa_converter.dart
@@ -207,7 +207,12 @@ class GrammarToFSAConverter {
   }
 
   static bool _isLambdaSymbol(String symbol) {
-    return symbol == 'ε' || symbol == 'λ' || symbol.toLowerCase() == 'lambda';
+    final normalized = symbol.toLowerCase();
+    return symbol == 'ε' ||
+        symbol == 'λ' ||
+        normalized == 'lambda' ||
+        normalized == '£' ||
+        normalized == '€';
   }
 
   static bool _isTerminalSymbol(String symbol, Grammar grammar) {

--- a/lib/data/repositories/algorithm_repository_impl.dart
+++ b/lib/data/repositories/algorithm_repository_impl.dart
@@ -393,7 +393,11 @@ class AlgorithmRepositoryImpl implements AlgorithmRepository {
 
   bool _isLambdaSymbol(String symbol) {
     final normalized = symbol.trim().toLowerCase();
-    return normalized == 'ε' || normalized == 'lambda' || normalized == 'λ';
+    return normalized == 'ε' ||
+        normalized == 'lambda' ||
+        normalized == 'λ' ||
+        normalized == '£' ||
+        normalized == '€';
   }
 
   GrammarEntity _grammarToEntity(model_grammar.Grammar grammar) {

--- a/lib/data/repositories/automaton_repository_impl.dart
+++ b/lib/data/repositories/automaton_repository_impl.dart
@@ -235,7 +235,12 @@ class AutomatonRepositoryImpl implements AutomatonRepository {
       }
 
       final symbol = parts[1];
-      final isLambda = symbol == 'λ' || symbol == 'ε' || symbol.toLowerCase() == 'lambda';
+      final normalized = symbol.toLowerCase();
+      final isLambda = symbol == 'λ' ||
+          symbol == 'ε' ||
+          normalized == 'lambda' ||
+          normalized == '£' ||
+          normalized == '€';
 
       for (final destination in destinations) {
         final toState = stateById[destination];

--- a/lib/data/services/automaton_service.dart
+++ b/lib/data/services/automaton_service.dart
@@ -47,7 +47,12 @@ class AutomatonService {
       }
 
       final symbol = transitionData.symbol;
-      final isLambda = symbol == 'λ' || symbol == 'ε' || symbol.toLowerCase() == 'lambda';
+      final lowerSymbol = symbol.toLowerCase();
+      final isLambda = symbol == 'λ' ||
+          symbol == 'ε' ||
+          lowerSymbol == 'lambda' ||
+          lowerSymbol == '£' ||
+          lowerSymbol == '€';
 
       transitions.add(FSATransition(
         id: 't${id}_$transitionIndex',

--- a/lib/presentation/providers/automaton_provider.dart
+++ b/lib/presentation/providers/automaton_provider.dart
@@ -485,8 +485,12 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
           throw StateError('State $fromStateId not found');
         }
         
-        final isLambda =
-            symbol == 'λ' || symbol == 'ε' || symbol.toLowerCase() == 'lambda';
+        final normalized = symbol.toLowerCase();
+        final isLambda = symbol == 'λ' ||
+            symbol == 'ε' ||
+            normalized == 'lambda' ||
+            normalized == '£' ||
+            normalized == '€';
             
         for (final toStateId in entry.value) {
           final toState = stateById[toStateId];

--- a/lib/presentation/providers/grammar_provider.dart
+++ b/lib/presentation/providers/grammar_provider.dart
@@ -232,8 +232,14 @@ class GrammarProvider extends StateNotifier<GrammarState> {
     return result;
   }
 
-  bool _isLambda(String symbol) =>
-      symbol == 'ε' || symbol == 'λ' || symbol.toLowerCase() == 'lambda';
+  bool _isLambda(String symbol) {
+    final normalized = symbol.toLowerCase();
+    return symbol == 'ε' ||
+        symbol == 'λ' ||
+        normalized == 'lambda' ||
+        normalized == '£' ||
+        normalized == '€';
+  }
 
   bool _looksLikeNonTerminal(String symbol) {
     final uppercaseRegex = RegExp(r'^[A-Z]$');

--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -1026,13 +1026,19 @@ class _TransitionSymbolInput {
       return null;
     }
 
-    if (parts.length == 1 &&
-        (parts.first == 'ε' || parts.first.toLowerCase() == 'epsilon' || parts.first.toLowerCase() == 'lambda')) {
-      return _TransitionSymbolInput(
-        inputSymbols: {},
-        lambdaSymbol: 'ε',
-        label: 'ε',
-      );
+    if (parts.length == 1) {
+      final normalized = parts.first.toLowerCase();
+      if (parts.first == 'ε' ||
+          normalized == 'epsilon' ||
+          normalized == 'lambda' ||
+          normalized == '£' ||
+          normalized == '€') {
+        return _TransitionSymbolInput(
+          inputSymbols: {},
+          lambdaSymbol: 'ε',
+          label: 'ε',
+        );
+      }
     }
 
     final symbols = parts.toSet();

--- a/lib/presentation/widgets/grammar_editor.dart
+++ b/lib/presentation/widgets/grammar_editor.dart
@@ -666,8 +666,14 @@ class _GrammarEditorState extends ConsumerState<GrammarEditor> {
     return trimmed.split('');
   }
 
-  bool _isLambdaSymbol(String symbol) =>
-      symbol == 'ε' || symbol == 'λ' || symbol.toLowerCase() == 'lambda';
+  bool _isLambdaSymbol(String symbol) {
+    final normalized = symbol.toLowerCase();
+    return symbol == 'ε' ||
+        symbol == 'λ' ||
+        normalized == 'lambda' ||
+        normalized == '£' ||
+        normalized == '€';
+  }
 
   String _formatSymbols(List<String> symbols) {
     if (symbols.isEmpty) {


### PR DESCRIPTION
## Summary
- recognize the £ and € symbols as epsilon in the automaton transition dialog parser and grammar editor
- extend lambda-detection helpers across providers, repositories, and algorithms so the new aliases are handled consistently

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d15d27a608832e9537dd31f1e0330c