### PR TITLE
Close context menu when interacting with canvas

### DIFF
--- a/lib/presentation/widgets/touch_gesture_handler.dart
+++ b/lib/presentation/widgets/touch_gesture_handler.dart
@@ -92,6 +92,11 @@ class _TouchGestureHandlerState<T extends Transition>
 
   /// Handles tap gestures
   void _handleTap(TapDownDetails details) {
+    if (_showContextMenu) {
+      _closeContextMenu();
+      return;
+    }
+
     final position = details.localPosition;
     final canvasPosition = _toCanvasCoordinates(position);
     final now = DateTime.now();
@@ -166,6 +171,8 @@ class _TouchGestureHandlerState<T extends Transition>
 
   /// Handles scale start for zooming and panning
   void _handleScaleStart(ScaleStartDetails details) {
+    _closeContextMenu();
+
     _isZooming = true;
 
     // Check if this is a single finger drag (pan)


### PR DESCRIPTION
## Summary
- close the context menu when a tap occurs while it is visible instead of selecting canvas elements
- dismiss the context menu as soon as a scale/drag gesture starts so it does not remain open during interactions

## Testing
- flutter analyze *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d15d4d5cf8832eae88c2095cd3f2df