### PR TITLE
Refactor regex parser to use token iterator

### DIFF
--- a/test/unit/algorithms/regex_to_nfa_converter_test.dart
+++ b/test/unit/algorithms/regex_to_nfa_converter_test.dart
@@ -69,4 +69,34 @@ void main() {
       );
     });
   });
+
+  group('RegexToNFAConverter long expressions', () {
+    test('handles long concatenation chains efficiently', () {
+      final regex = 'a' * 5000;
+
+      final result = RegexToNFAConverter.convert(regex);
+
+      expect(result.isSuccess, isTrue);
+      expect(result.data!.states, isNotEmpty);
+    });
+
+    test('handles extensive unions without degradation', () {
+      final regex = List.filled(2000, 'a').join('|');
+
+      final result = RegexToNFAConverter.convert(regex);
+
+      expect(result.isSuccess, isTrue);
+    });
+
+    test('handles repeated grouped expressions with unary operators', () {
+      final buffer = StringBuffer();
+      for (int i = 0; i < 1000; i++) {
+        buffer.write('(ab)+');
+      }
+
+      final result = RegexToNFAConverter.convert(buffer.toString());
+
+      expect(result.isSuccess, isTrue);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- replace the parser's list mutation with a token stream iterator to avoid quadratic behavior
- ensure parentheses parsing consumes closing tokens and validates full expressions
- add unit tests that cover long concatenations, unions, and unary operator chains

## Testing
- not run (flutter command unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d16a5baf18832ebfcf21a66d538c50