### PR TITLE
Refactor automaton provider to use use cases

### DIFF
--- a/lib/core/use_cases/automaton_use_cases.dart
+++ b/lib/core/use_cases/automaton_use_cases.dart
@@ -273,3 +273,14 @@ class RemoveTransitionUseCase {
     }
   }
 }
+
+/// Use case for applying automatic layout to an automaton
+class ApplyAutoLayoutUseCase {
+  final LayoutRepository _repository;
+
+  ApplyAutoLayoutUseCase(this._repository);
+
+  Future<AutomatonResult> execute(AutomatonEntity automaton) async {
+    return await _repository.applyAutoLayout(automaton);
+  }
+}

--- a/lib/core/utils/automaton_entity_mapper.dart
+++ b/lib/core/utils/automaton_entity_mapper.dart
@@ -1,0 +1,180 @@
+import 'dart:math' as math;
+
+import 'package:vector_math/vector_math_64.dart';
+
+import '../entities/automaton_entity.dart';
+import '../models/fsa.dart';
+import '../models/fsa_transition.dart';
+import '../models/state.dart';
+
+/// Converts a [FSA] model into an [AutomatonEntity].
+AutomatonEntity fsaToAutomatonEntity(FSA automaton) {
+  final states = automaton.states
+      .map(
+        (state) => StateEntity(
+          id: state.id,
+          name: state.label,
+          x: state.position.x,
+          y: state.position.y,
+          isInitial: state.isInitial,
+          isFinal: state.isAccepting,
+        ),
+      )
+      .toList();
+
+  final transitions = <String, List<String>>{};
+  for (final transition in automaton.transitions.whereType<FSATransition>()) {
+    final symbols = <String>{};
+    if (transition.lambdaSymbol != null) {
+      symbols.add(transition.lambdaSymbol!);
+    } else {
+      symbols.addAll(transition.inputSymbols);
+    }
+
+    for (final symbol in symbols) {
+      final key = '${transition.fromState.id}|$symbol';
+      transitions.putIfAbsent(key, () => <String>[]).add(transition.toState.id);
+    }
+  }
+
+  final type = automaton.hasEpsilonTransitions
+      ? AutomatonType.nfaLambda
+      : automaton.isDeterministic
+          ? AutomatonType.dfa
+          : AutomatonType.nfa;
+
+  return AutomatonEntity(
+    id: automaton.id,
+    name: automaton.name,
+    alphabet: automaton.alphabet,
+    states: states,
+    transitions: transitions,
+    initialId: automaton.initialState?.id,
+    nextId: states.length,
+    type: type,
+  );
+}
+
+/// Converts an [AutomatonEntity] into a [FSA] model.
+FSA automatonEntityToFsa(
+  AutomatonEntity automaton, {
+  DateTime? created,
+  DateTime? modified,
+}) {
+  final states = automaton.states
+      .map(
+        (state) => State(
+          id: state.id,
+          label: state.name,
+          position: Vector2(state.x, state.y),
+          isInitial: state.isInitial || automaton.initialId == state.id,
+          isAccepting: state.isFinal,
+        ),
+      )
+      .toSet();
+
+  final stateById = {for (final state in states) state.id: state};
+
+  final transitions = <FSATransition>{};
+  var transitionIndex = 0;
+
+  automaton.transitions.forEach((key, destinations) {
+    final parts = key.split('|');
+    if (parts.length != 2) {
+      return;
+    }
+
+    final fromState = stateById[parts[0]];
+    if (fromState == null) {
+      throw StateError('Unknown from state ${parts[0]}');
+    }
+
+    final symbol = parts[1];
+    final normalized = symbol.toLowerCase();
+    final isLambda = symbol == 'λ' ||
+        symbol == 'ε' ||
+        normalized == 'lambda' ||
+        normalized == '£' ||
+        normalized == '€';
+
+    for (final destination in destinations) {
+      final toState = stateById[destination];
+      if (toState == null) {
+        throw StateError('Unknown to state $destination');
+      }
+
+      transitions.add(
+        FSATransition(
+          id: 't${automaton.id}_$transitionIndex',
+          fromState: fromState,
+          toState: toState,
+          label: symbol,
+          inputSymbols: isLambda ? <String>{} : {symbol},
+          lambdaSymbol: isLambda ? symbol : null,
+        ),
+      );
+      transitionIndex++;
+    }
+  });
+
+  State? initialState;
+  if (automaton.initialId != null) {
+    initialState = stateById[automaton.initialId!];
+  }
+
+  initialState ??= () {
+    try {
+      return states.firstWhere((state) => state.isInitial);
+    } catch (_) {
+      return null;
+    }
+  }();
+
+  final acceptingStates = states.where((state) => state.isAccepting).toSet();
+
+  final bounds = _calculateBounds(automaton.states);
+
+  return FSA(
+    id: automaton.id,
+    name: automaton.name,
+    states: states,
+    transitions: transitions,
+    alphabet: automaton.alphabet,
+    initialState: initialState,
+    acceptingStates: acceptingStates,
+    created: created ?? DateTime.now(),
+    modified: modified ?? DateTime.now(),
+    bounds: bounds,
+  );
+}
+
+math.Rectangle<double> _calculateBounds(List<StateEntity> states) {
+  if (states.isEmpty) {
+    return math.Rectangle<double>(0, 0, 800, 600);
+  }
+
+  var minX = states.first.x;
+  var minY = states.first.y;
+  var maxX = states.first.x;
+  var maxY = states.first.y;
+
+  for (final state in states.skip(1)) {
+    minX = math.min(minX, state.x);
+    minY = math.min(minY, state.y);
+    maxX = math.max(maxX, state.x);
+    maxY = math.max(maxY, state.y);
+  }
+
+  const padding = 50.0;
+  final left = minX - padding;
+  final top = minY - padding;
+  final right = maxX + padding;
+  final bottom = maxY + padding;
+
+  return math.Rectangle<double>(
+    left,
+    top,
+    right - left,
+    bottom - top,
+  );
+}

--- a/lib/injection/dependency_injection.dart
+++ b/lib/injection/dependency_injection.dart
@@ -104,6 +104,10 @@ Future<void> setupDependencyInjection() async {
     () => RemoveTransitionUseCase(getIt<AutomatonRepository>()),
   );
 
+  getIt.registerLazySingleton<ApplyAutoLayoutUseCase>(
+    () => ApplyAutoLayoutUseCase(getIt<LayoutRepository>()),
+  );
+
   // Algorithm Use Cases
   getIt.registerLazySingleton<NfaToDfaUseCase>(
     () => NfaToDfaUseCase(getIt<AlgorithmRepository>()),
@@ -172,10 +176,17 @@ Future<void> setupDependencyInjection() async {
   // Providers
   getIt.registerFactory<AutomatonProvider>(
     () => AutomatonProvider(
-      automatonService: getIt<AutomatonService>(),
-      simulationService: getIt<SimulationService>(),
-      conversionService: getIt<ConversionService>(),
-      layoutRepository: getIt<LayoutRepository>(),
+      createAutomatonUseCase: getIt<CreateAutomatonUseCase>(),
+      addStateUseCase: getIt<AddStateUseCase>(),
+      nfaToDfaUseCase: getIt<NfaToDfaUseCase>(),
+      minimizeDfaUseCase: getIt<MinimizeDfaUseCase>(),
+      completeDfaUseCase: getIt<CompleteDfaUseCase>(),
+      regexToNfaUseCase: getIt<RegexToNfaUseCase>(),
+      dfaToRegexUseCase: getIt<DfaToRegexUseCase>(),
+      fsaToGrammarUseCase: getIt<FsaToGrammarUseCase>(),
+      checkEquivalenceUseCase: getIt<CheckEquivalenceUseCase>(),
+      simulateWordUseCase: getIt<SimulateWordUseCase>(),
+      applyAutoLayoutUseCase: getIt<ApplyAutoLayoutUseCase>(),
     ),
   );
   

--- a/test/unit/presentation/automaton_provider_conversion_test.dart
+++ b/test/unit/presentation/automaton_provider_conversion_test.dart
@@ -3,10 +3,9 @@ import 'dart:math' as math;
 import 'package:jflutter/core/entities/automaton_entity.dart';
 import 'package:jflutter/core/repositories/automaton_repository.dart';
 import 'package:jflutter/core/result.dart';
+import 'package:jflutter/core/use_cases/algorithm_use_cases.dart';
 import 'package:jflutter/core/use_cases/automaton_use_cases.dart';
-import 'package:jflutter/data/services/automaton_service.dart';
-import 'package:jflutter/data/services/conversion_service.dart';
-import 'package:jflutter/data/services/simulation_service.dart';
+import 'package:jflutter/data/repositories/algorithm_repository_impl.dart';
 import 'package:jflutter/presentation/providers/automaton_provider.dart';
 import 'package:test/test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -68,7 +67,7 @@ class _FakeAutomatonRepository implements AutomatonRepository {
 
   @override
   Future<AutomatonResult> saveAutomaton(AutomatonEntity automaton) =>
-      throw UnimplementedError();
+      Future.value(Success(automaton));
 
   @override
   Future<BoolResult> validateAutomaton(AutomatonEntity automaton) =>
@@ -117,13 +116,20 @@ void main() {
       );
 
       final layoutRepository = _RecordingLayoutRepository();
+      final algorithmRepository = AlgorithmRepositoryImpl();
+      final automatonRepository = _FakeAutomatonRepository();
       final provider = AutomatonProvider(
-        automatonService: AutomatonService(),
-        simulationService: SimulationService(),
-        conversionService: ConversionService(),
-        createAutomatonUseCase: CreateAutomatonUseCase(_FakeAutomatonRepository()),
-        loadAutomatonUseCase: LoadAutomatonUseCase(_FakeAutomatonRepository()),
-        layoutRepository: layoutRepository,
+        createAutomatonUseCase: CreateAutomatonUseCase(automatonRepository),
+        addStateUseCase: AddStateUseCase(automatonRepository),
+        nfaToDfaUseCase: NfaToDfaUseCase(algorithmRepository),
+        minimizeDfaUseCase: MinimizeDfaUseCase(algorithmRepository),
+        completeDfaUseCase: CompleteDfaUseCase(algorithmRepository),
+        regexToNfaUseCase: RegexToNfaUseCase(algorithmRepository),
+        dfaToRegexUseCase: DfaToRegexUseCase(algorithmRepository),
+        fsaToGrammarUseCase: FsaToGrammarUseCase(algorithmRepository),
+        checkEquivalenceUseCase: CheckEquivalenceUseCase(algorithmRepository),
+        simulateWordUseCase: SimulateWordUseCase(algorithmRepository),
+        applyAutoLayoutUseCase: ApplyAutoLayoutUseCase(layoutRepository),
       );
 
       provider.updateAutomaton(fsa);

--- a/test/unit/presentation/automaton_provider_large_conversion_test.dart
+++ b/test/unit/presentation/automaton_provider_large_conversion_test.dart
@@ -9,11 +9,11 @@ import 'package:jflutter/core/models/fsa_transition.dart';
 import 'package:jflutter/core/models/state.dart';
 import 'package:jflutter/core/repositories/automaton_repository.dart';
 import 'package:jflutter/core/result.dart';
+import 'package:jflutter/core/use_cases/algorithm_use_cases.dart';
 import 'package:jflutter/core/use_cases/automaton_use_cases.dart';
+import 'package:jflutter/data/repositories/algorithm_repository_impl.dart';
 import 'package:jflutter/data/repositories/automaton_repository_impl.dart';
 import 'package:jflutter/data/services/automaton_service.dart';
-import 'package:jflutter/data/services/conversion_service.dart';
-import 'package:jflutter/data/services/simulation_service.dart';
 import 'package:jflutter/presentation/providers/automaton_provider.dart';
 
 class _StubLayoutRepository implements LayoutRepository {
@@ -129,13 +129,21 @@ void main() {
 
     final automatonService = AutomatonService();
     final repository = AutomatonRepositoryImpl(automatonService);
+    final algorithmRepository = AlgorithmRepositoryImpl();
     final provider = AutomatonProvider(
-      automatonService: automatonService,
-      simulationService: SimulationService(),
-      conversionService: ConversionService(),
       createAutomatonUseCase: CreateAutomatonUseCase(repository),
-      loadAutomatonUseCase: LoadAutomatonUseCase(repository),
-      layoutRepository: _StubLayoutRepository(layoutEntity),
+      addStateUseCase: AddStateUseCase(repository),
+      nfaToDfaUseCase: NfaToDfaUseCase(algorithmRepository),
+      minimizeDfaUseCase: MinimizeDfaUseCase(algorithmRepository),
+      completeDfaUseCase: CompleteDfaUseCase(algorithmRepository),
+      regexToNfaUseCase: RegexToNfaUseCase(algorithmRepository),
+      dfaToRegexUseCase: DfaToRegexUseCase(algorithmRepository),
+      fsaToGrammarUseCase: FsaToGrammarUseCase(algorithmRepository),
+      checkEquivalenceUseCase: CheckEquivalenceUseCase(algorithmRepository),
+      simulateWordUseCase: SimulateWordUseCase(algorithmRepository),
+      applyAutoLayoutUseCase: ApplyAutoLayoutUseCase(
+        _StubLayoutRepository(layoutEntity),
+      ),
     );
 
     provider.updateAutomaton(initialAutomaton);


### PR DESCRIPTION
## Summary
- refactored `AutomatonProvider` to depend on domain use cases and shared automaton mappers
- extracted reusable FSA <-> AutomatonEntity conversion helpers and integrated them into the repository
- wired new use case registrations and updated provider tests to exercise the use-case based flow

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d16a56d008832eaf826b8c2eb153cb