### PR TITLE
Refactor regex page with view model and modular widgets

### DIFF
--- a/lib/presentation/providers/regex_page_view_model.dart
+++ b/lib/presentation/providers/regex_page_view_model.dart
@@ -1,0 +1,382 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/algorithms/automaton_simulator.dart';
+import '../../core/algorithms/dfa_completer.dart';
+import '../../core/algorithms/equivalence_checker.dart';
+import '../../core/algorithms/nfa_to_dfa_converter.dart';
+import '../../core/algorithms/regex_to_nfa_converter.dart';
+import '../../core/models/fsa.dart';
+import '../../core/models/simulation_result.dart';
+import '../../core/result.dart';
+import 'automaton_provider.dart';
+
+@immutable
+class RegexPageState {
+  final String regexInput;
+  final bool isValid;
+  final String? validationMessage;
+  final FSA? lastGeneratedNfa;
+  final String testString;
+  final bool? matchResult;
+  final String? matchMessage;
+  final SimulationResult? simulationResult;
+  final String comparisonRegex;
+  final bool? equivalenceResult;
+  final String? equivalenceMessage;
+
+  const RegexPageState({
+    this.regexInput = '',
+    this.isValid = false,
+    this.validationMessage,
+    this.lastGeneratedNfa,
+    this.testString = '',
+    this.matchResult,
+    this.matchMessage,
+    this.simulationResult,
+    this.comparisonRegex = '',
+    this.equivalenceResult,
+    this.equivalenceMessage,
+  });
+
+  RegexPageState copyWith({
+    String? regexInput,
+    bool? isValid,
+    String? validationMessage,
+    FSA? lastGeneratedNfa,
+    bool clearCachedNfa = false,
+    String? testString,
+    bool? matchResult,
+    String? matchMessage,
+    SimulationResult? simulationResult,
+    bool clearSimulationResult = false,
+    String? comparisonRegex,
+    bool? equivalenceResult,
+    String? equivalenceMessage,
+  }) {
+    return RegexPageState(
+      regexInput: regexInput ?? this.regexInput,
+      isValid: isValid ?? this.isValid,
+      validationMessage: validationMessage,
+      lastGeneratedNfa: clearCachedNfa
+          ? null
+          : (lastGeneratedNfa ?? this.lastGeneratedNfa),
+      testString: testString ?? this.testString,
+      matchResult: matchResult,
+      matchMessage: matchMessage,
+      simulationResult: clearSimulationResult
+          ? null
+          : (simulationResult ?? this.simulationResult),
+      comparisonRegex: comparisonRegex ?? this.comparisonRegex,
+      equivalenceResult: equivalenceResult,
+      equivalenceMessage: equivalenceMessage,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+    return other is RegexPageState &&
+        other.regexInput == regexInput &&
+        other.isValid == isValid &&
+        other.validationMessage == validationMessage &&
+        other.lastGeneratedNfa == lastGeneratedNfa &&
+        other.testString == testString &&
+        other.matchResult == matchResult &&
+        other.matchMessage == matchMessage &&
+        other.simulationResult == simulationResult &&
+        other.comparisonRegex == comparisonRegex &&
+        other.equivalenceResult == equivalenceResult &&
+        other.equivalenceMessage == equivalenceMessage;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        regexInput,
+        isValid,
+        validationMessage,
+        lastGeneratedNfa,
+        testString,
+        matchResult,
+        matchMessage,
+        simulationResult,
+        comparisonRegex,
+        equivalenceResult,
+        equivalenceMessage,
+      );
+}
+
+class RegexPageViewModel extends StateNotifier<RegexPageState> {
+  RegexPageViewModel(this._ref) : super(const RegexPageState());
+
+  final Ref _ref;
+
+  void updateRegexInput(String value) {
+    state = state.copyWith(
+      regexInput: value,
+      isValid: false,
+      validationMessage: null,
+      matchResult: null,
+      matchMessage: null,
+      clearCachedNfa: true,
+      clearSimulationResult: true,
+      equivalenceResult: null,
+      equivalenceMessage: null,
+    );
+  }
+
+  void updateTestString(String value) {
+    state = state.copyWith(
+      testString: value,
+      matchResult: null,
+      matchMessage: null,
+      clearSimulationResult: true,
+    );
+  }
+
+  void updateComparisonRegex(String value) {
+    state = state.copyWith(
+      comparisonRegex: value,
+      equivalenceResult: null,
+      equivalenceMessage: null,
+    );
+  }
+
+  void clearAll() {
+    state = const RegexPageState();
+  }
+
+  Result<FSA> validateRegex() {
+    final regex = state.regexInput.trim();
+    if (regex.isEmpty) {
+      state = state.copyWith(
+        isValid: false,
+        validationMessage: 'Regular expression cannot be empty',
+        clearCachedNfa: true,
+      );
+      return ResultFactory.failure('Regular expression cannot be empty');
+    }
+
+    final result = RegexToNFAConverter.convert(regex);
+    if (result.isSuccess && result.data != null) {
+      state = state.copyWith(
+        regexInput: regex,
+        isValid: true,
+        validationMessage: null,
+        lastGeneratedNfa: result.data,
+        clearSimulationResult: true,
+      );
+    } else {
+      state = state.copyWith(
+        isValid: false,
+        validationMessage: result.error ?? 'Invalid regular expression',
+        clearCachedNfa: true,
+        clearSimulationResult: true,
+      );
+    }
+
+    return result;
+  }
+
+  Result<bool> testStringMatch() {
+    final testString = state.testString;
+    if (testString.isEmpty) {
+      state = state.copyWith(
+        matchResult: null,
+        matchMessage: null,
+        clearSimulationResult: true,
+      );
+      return ResultFactory.failure('Test string cannot be empty');
+    }
+
+    final nfa = state.lastGeneratedNfa ?? _ensureNfa();
+    if (nfa == null) {
+      final message = state.validationMessage ??
+          'Please validate the regular expression before testing.';
+      state = state.copyWith(
+        matchResult: null,
+        matchMessage: message,
+        clearSimulationResult: true,
+      );
+      return ResultFactory.failure(message);
+    }
+
+    final simulation = AutomatonSimulator.simulateNFA(nfa, testString);
+    if (simulation.isSuccess && simulation.data != null) {
+      final result = simulation.data!;
+      state = state.copyWith(
+        matchResult: result.isAccepted,
+        matchMessage: result.errorMessage.isNotEmpty ? result.errorMessage : null,
+        simulationResult: result,
+      );
+      return ResultFactory.success(result.isAccepted);
+    } else {
+      final message =
+          simulation.error ?? 'Failed to simulate automaton for the test string';
+      state = state.copyWith(
+        matchResult: false,
+        matchMessage: message,
+        clearSimulationResult: true,
+      );
+      return ResultFactory.failure(message);
+    }
+  }
+
+  Result<FSA> convertToNfa() {
+    final regex = state.regexInput.trim();
+    if (regex.isEmpty) {
+      return ResultFactory.failure('Please enter a regular expression first');
+    }
+
+    final conversion = RegexToNFAConverter.convert(regex);
+    if (conversion.isSuccess && conversion.data != null) {
+      final nfa = conversion.data!;
+      state = state.copyWith(
+        regexInput: regex,
+        isValid: true,
+        validationMessage: null,
+        lastGeneratedNfa: nfa,
+      );
+      _pushAutomaton(nfa);
+    } else {
+      state = state.copyWith(
+        isValid: false,
+        validationMessage:
+            conversion.error ?? 'Failed to convert regex to automaton',
+        clearCachedNfa: true,
+      );
+    }
+    return conversion;
+  }
+
+  Result<FSA> convertToDfa() {
+    final nfaResult = convertToNfa();
+    if (!nfaResult.isSuccess || nfaResult.data == null) {
+      return ResultFactory.failure(
+          nfaResult.error ?? 'Failed to convert regex to NFA');
+    }
+
+    final nfa = nfaResult.data!;
+    final dfaResult = NFAToDFAConverter.convert(nfa);
+    if (!dfaResult.isSuccess || dfaResult.data == null) {
+      final message = dfaResult.error ?? 'Failed to convert NFA to DFA';
+      return ResultFactory.failure(message);
+    }
+
+    final completedDfa = DFACompleter.complete(dfaResult.data!);
+    _pushAutomaton(completedDfa);
+    return ResultFactory.success(completedDfa);
+  }
+
+  Result<bool> compareEquivalence() {
+    final primary = state.regexInput.trim();
+    final secondary = state.comparisonRegex.trim();
+
+    if (primary.isEmpty || secondary.isEmpty) {
+      const message = 'Enter both regular expressions to compare.';
+      state = state.copyWith(
+        equivalenceResult: false,
+        equivalenceMessage: message,
+      );
+      return ResultFactory.failure(message);
+    }
+
+    final firstConversion = RegexToNFAConverter.convert(primary);
+    if (!firstConversion.isSuccess || firstConversion.data == null) {
+      final message =
+          firstConversion.error ?? 'Unable to convert first regex to NFA';
+      state = state.copyWith(
+        equivalenceResult: false,
+        equivalenceMessage: message,
+      );
+      return ResultFactory.failure(message);
+    }
+
+    final secondConversion = RegexToNFAConverter.convert(secondary);
+    if (!secondConversion.isSuccess || secondConversion.data == null) {
+      final message =
+          secondConversion.error ?? 'Unable to convert second regex to NFA';
+      state = state.copyWith(
+        equivalenceResult: false,
+        equivalenceMessage: message,
+      );
+      return ResultFactory.failure(message);
+    }
+
+    final firstDfaResult = NFAToDFAConverter.convert(firstConversion.data!);
+    if (!firstDfaResult.isSuccess || firstDfaResult.data == null) {
+      final message =
+          firstDfaResult.error ?? 'Unable to convert first regex to DFA';
+      state = state.copyWith(
+        equivalenceResult: false,
+        equivalenceMessage: message,
+      );
+      return ResultFactory.failure(message);
+    }
+
+    final secondDfaResult = NFAToDFAConverter.convert(secondConversion.data!);
+    if (!secondDfaResult.isSuccess || secondDfaResult.data == null) {
+      final message =
+          secondDfaResult.error ?? 'Unable to convert second regex to DFA';
+      state = state.copyWith(
+        equivalenceResult: false,
+        equivalenceMessage: message,
+      );
+      return ResultFactory.failure(message);
+    }
+
+    final completedFirst = DFACompleter.complete(firstDfaResult.data!);
+    final completedSecond = DFACompleter.complete(secondDfaResult.data!);
+
+    final equivalent =
+        EquivalenceChecker.areEquivalent(completedFirst, completedSecond);
+    state = state.copyWith(
+      equivalenceResult: equivalent,
+      equivalenceMessage: equivalent
+          ? 'The regular expressions are equivalent.'
+          : 'The regular expressions are not equivalent.',
+    );
+
+    return ResultFactory.success(equivalent);
+  }
+
+  FSA? _ensureNfa() {
+    final regex = state.regexInput.trim();
+    if (regex.isEmpty) {
+      return null;
+    }
+
+    final conversion = RegexToNFAConverter.convert(regex);
+    if (conversion.isSuccess && conversion.data != null) {
+      state = state.copyWith(
+        regexInput: regex,
+        isValid: true,
+        validationMessage: null,
+        lastGeneratedNfa: conversion.data,
+      );
+      return conversion.data;
+    }
+
+    state = state.copyWith(
+      isValid: false,
+      validationMessage:
+          conversion.error ?? 'Unable to convert regex to automaton',
+      clearCachedNfa: true,
+    );
+    return null;
+  }
+
+  void _pushAutomaton(FSA automaton) {
+    try {
+      final notifier = _ref.read(automatonProvider.notifier);
+      notifier.updateAutomaton(automaton);
+    } catch (_) {
+      // In testing scenarios the provider may not be available.
+    }
+  }
+}
+
+final regexPageViewModelProvider =
+    StateNotifierProvider<RegexPageViewModel, RegexPageState>((ref) {
+  return RegexPageViewModel(ref);
+});

--- a/lib/presentation/widgets/regex/regex_conversion_actions.dart
+++ b/lib/presentation/widgets/regex/regex_conversion_actions.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+class RegexConversionActions extends StatelessWidget {
+  const RegexConversionActions({
+    super.key,
+    required this.enableConversion,
+    required this.onConvertToNfa,
+    required this.onConvertToDfa,
+  });
+
+  final bool enableConversion;
+  final VoidCallback onConvertToNfa;
+  final VoidCallback onConvertToDfa;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Convert to Automaton:',
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 12),
+        Row(
+          children: [
+            Expanded(
+              child: ElevatedButton.icon(
+                onPressed: enableConversion ? onConvertToNfa : null,
+                icon: const Icon(Icons.account_tree),
+                label: const Text('Convert to NFA'),
+              ),
+            ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: ElevatedButton.icon(
+                onPressed: enableConversion ? onConvertToDfa : null,
+                icon: const Icon(Icons.account_tree_outlined),
+                label: const Text('Convert to DFA'),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/regex/regex_equivalence_section.dart
+++ b/lib/presentation/widgets/regex/regex_equivalence_section.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+
+class RegexEquivalenceSection extends StatelessWidget {
+  const RegexEquivalenceSection({
+    super.key,
+    required this.controller,
+    required this.equivalenceResult,
+    required this.equivalenceMessage,
+    required this.onChanged,
+    required this.onCompare,
+  });
+
+  final TextEditingController controller;
+  final bool? equivalenceResult;
+  final String? equivalenceMessage;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onCompare;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasMessage = equivalenceMessage?.isNotEmpty == true;
+    final isEquivalent = equivalenceResult == true;
+    final messageColor = isEquivalent ? Colors.green : Colors.orange;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Compare Regular Expressions:',
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: controller,
+          decoration: const InputDecoration(
+            hintText: 'Enter second regular expression',
+            border: OutlineInputBorder(),
+          ),
+          onChanged: onChanged,
+        ),
+        const SizedBox(height: 12),
+        Align(
+          alignment: Alignment.centerRight,
+          child: ElevatedButton.icon(
+            onPressed: onCompare,
+            icon: const Icon(Icons.compare_arrows),
+            label: const Text('Compare Equivalence'),
+          ),
+        ),
+        if (hasMessage) ...[
+          const SizedBox(height: 8),
+          Row(
+            children: [
+              Icon(
+                isEquivalent ? Icons.check_circle : Icons.error_outline,
+                color: messageColor,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  equivalenceMessage!,
+                  style: theme.textTheme.bodySmall?.copyWith(
+                    color: messageColor,
+                    fontWeight: isEquivalent ? FontWeight.bold : null,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/regex/regex_help_card.dart
+++ b/lib/presentation/widgets/regex/regex_help_card.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+
+class RegexHelpCard extends StatelessWidget {
+  const RegexHelpCard({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Text(
+              'Regex Help',
+              style: theme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Common patterns:\n'
+              '• a* - zero or more a\'s\n'
+              '• a+ - one or more a\'s\n'
+              '• a? - zero or one a\n'
+              '• a|b - a or b\n'
+              '• (ab)* - zero or more ab\'s\n'
+              '• [abc] - any of a, b, or c',
+              style: TextStyle(fontSize: 12),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/regex/regex_input_form.dart
+++ b/lib/presentation/widgets/regex/regex_input_form.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+
+class RegexInputForm extends StatelessWidget {
+  const RegexInputForm({
+    super.key,
+    required this.controller,
+    required this.isValid,
+    required this.validationMessage,
+    required this.onChanged,
+    required this.onValidate,
+  });
+
+  final TextEditingController controller;
+  final bool isValid;
+  final String? validationMessage;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onValidate;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final statusColor = isValid ? Colors.green : Colors.red;
+    final statusMessage = isValid
+        ? 'Valid regex'
+        : (validationMessage?.isNotEmpty == true
+            ? validationMessage!
+            : 'Invalid regex');
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Regular Expression:',
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            hintText: 'Enter regular expression (e.g., a*b+)',
+            border: const OutlineInputBorder(),
+            suffixIcon: IconButton(
+              onPressed: onValidate,
+              icon: const Icon(Icons.check),
+              tooltip: 'Validate Regex',
+            ),
+          ),
+          onChanged: onChanged,
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Icon(
+              isValid ? Icons.check_circle : Icons.error,
+              color: statusColor,
+              size: 20,
+            ),
+            const SizedBox(width: 8),
+            Expanded(
+              child: Text(
+                statusMessage,
+                style: theme.textTheme.bodySmall?.copyWith(
+                  color: statusColor,
+                  fontWeight: isValid ? FontWeight.bold : null,
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/regex/regex_test_section.dart
+++ b/lib/presentation/widgets/regex/regex_test_section.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+
+class RegexTestSection extends StatelessWidget {
+  const RegexTestSection({
+    super.key,
+    required this.controller,
+    required this.matchResult,
+    required this.matchMessage,
+    required this.onChanged,
+    required this.onTest,
+  });
+
+  final TextEditingController controller;
+  final bool? matchResult;
+  final String? matchMessage;
+  final ValueChanged<String> onChanged;
+  final VoidCallback onTest;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final hasResult =
+        matchResult != null || (matchMessage != null && matchMessage!.isNotEmpty);
+    final isMatch = matchResult == true;
+    final messageColor = isMatch ? Colors.green : Colors.red;
+    final messageText = matchMessage?.isNotEmpty == true
+        ? matchMessage!
+        : isMatch
+            ? 'Matches!'
+            : 'Does not match';
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          'Test String:',
+          style: theme.textTheme.titleMedium,
+        ),
+        const SizedBox(height: 8),
+        TextField(
+          controller: controller,
+          decoration: InputDecoration(
+            hintText: 'Enter string to test',
+            border: const OutlineInputBorder(),
+            suffixIcon: IconButton(
+              onPressed: onTest,
+              icon: const Icon(Icons.play_arrow),
+              tooltip: 'Test String',
+            ),
+          ),
+          onChanged: onChanged,
+        ),
+        if (hasResult) ...[
+          const SizedBox(height: 8),
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(
+                isMatch ? Icons.check_circle : Icons.cancel,
+                color: messageColor,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Expanded(
+                child: Text(
+                  messageText,
+                  style: theme.textTheme.bodyMedium?.copyWith(
+                    color: messageColor,
+                    fontWeight: isMatch ? FontWeight.bold : FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+        ],
+      ],
+    );
+  }
+}

--- a/test/presentation/providers/regex_page_view_model_test.dart
+++ b/test/presentation/providers/regex_page_view_model_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:jflutter/presentation/providers/regex_page_view_model.dart';
+
+void main() {
+  late ProviderContainer container;
+
+  setUp(() {
+    container = ProviderContainer();
+    addTearDown(container.dispose);
+  });
+
+  test('initial state is empty and invalid', () {
+    final state = container.read(regexPageViewModelProvider);
+    expect(state.regexInput, isEmpty);
+    expect(state.isValid, isFalse);
+    expect(state.lastGeneratedNfa, isNull);
+  });
+
+  test('validateRegex marks valid expression and caches NFA', () {
+    final notifier = container.read(regexPageViewModelProvider.notifier);
+    notifier.updateRegexInput('a*');
+
+    final result = notifier.validateRegex();
+
+    expect(result.isSuccess, isTrue);
+    final state = container.read(regexPageViewModelProvider);
+    expect(state.isValid, isTrue);
+    expect(state.validationMessage, isNull);
+    expect(state.lastGeneratedNfa, isNotNull);
+  });
+
+  test('testStringMatch accepts valid input for cached regex', () {
+    final notifier = container.read(regexPageViewModelProvider.notifier);
+    notifier.updateRegexInput('ab');
+    notifier.validateRegex();
+
+    notifier.updateTestString('ab');
+    final result = notifier.testStringMatch();
+
+    expect(result.isSuccess, isTrue);
+    final state = container.read(regexPageViewModelProvider);
+    expect(state.matchResult, isTrue);
+    expect(state.simulationResult, isNotNull);
+  });
+
+  test('convertToDfa pushes automaton to automatonProvider', () {
+    final notifier = container.read(regexPageViewModelProvider.notifier);
+    notifier.updateRegexInput('a|b');
+
+    final result = notifier.convertToDfa();
+
+    expect(result.isSuccess, isTrue);
+    final automatonState = container.read(automatonProvider);
+    expect(automatonState.currentAutomaton, isNotNull);
+  });
+
+  test('compareEquivalence returns true for identical expressions', () {
+    final notifier = container.read(regexPageViewModelProvider.notifier);
+    notifier.updateRegexInput('a*');
+    notifier.updateComparisonRegex('a*');
+
+    final result = notifier.compareEquivalence();
+
+    expect(result.isSuccess, isTrue);
+    final state = container.read(regexPageViewModelProvider);
+    expect(state.equivalenceResult, isTrue);
+    expect(state.equivalenceMessage, isNotEmpty);
+  });
+}

--- a/test/presentation/widgets/regex/regex_widgets_test.dart
+++ b/test/presentation/widgets/regex/regex_widgets_test.dart
@@ -1,0 +1,144 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/presentation/widgets/regex/regex_conversion_actions.dart';
+import 'package:jflutter/presentation/widgets/regex/regex_equivalence_section.dart';
+import 'package:jflutter/presentation/widgets/regex/regex_help_card.dart';
+import 'package:jflutter/presentation/widgets/regex/regex_input_form.dart';
+import 'package:jflutter/presentation/widgets/regex/regex_test_section.dart';
+
+void main() {
+  group('RegexInputForm', () {
+    testWidgets('shows validation feedback and triggers callbacks',
+        (tester) async {
+      bool validateCalled = false;
+      String? latestChange;
+      final controller = TextEditingController(text: 'a*');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RegexInputForm(
+              controller: controller,
+              isValid: false,
+              validationMessage: 'Invalid regular expression',
+              onChanged: (value) => latestChange = value,
+              onValidate: () => validateCalled = true,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Invalid regular expression'), findsOneWidget);
+
+      await tester.enterText(find.byType(TextField), 'ab');
+      expect(latestChange, 'ab');
+
+      await tester.tap(find.byIcon(Icons.check));
+      await tester.pump();
+
+      expect(validateCalled, isTrue);
+    });
+  });
+
+  group('RegexTestSection', () {
+    testWidgets('displays match result', (tester) async {
+      final controller = TextEditingController(text: 'ab');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RegexTestSection(
+              controller: controller,
+              matchResult: true,
+              matchMessage: null,
+              onChanged: (_) {},
+              onTest: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Matches!'), findsOneWidget);
+    });
+
+    testWidgets('displays custom message when provided', (tester) async {
+      final controller = TextEditingController(text: 'ab');
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RegexTestSection(
+              controller: controller,
+              matchResult: null,
+              matchMessage: 'Please validate the regex',
+              onChanged: (_) {},
+              onTest: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Please validate the regex'), findsOneWidget);
+    });
+  });
+
+  group('RegexConversionActions', () {
+    testWidgets('disables buttons when conversion is not allowed',
+        (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RegexConversionActions(
+              enableConversion: false,
+              onConvertToNfa: () {},
+              onConvertToDfa: () {},
+            ),
+          ),
+        ),
+      );
+
+      final buttons =
+          tester.widgetList<ElevatedButton>(find.byType(ElevatedButton));
+      for (final button in buttons) {
+        expect(button.onPressed, isNull);
+      }
+    });
+  });
+
+  group('RegexEquivalenceSection', () {
+    testWidgets('renders equivalence feedback', (tester) async {
+      final controller = TextEditingController();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: RegexEquivalenceSection(
+              controller: controller,
+              equivalenceResult: true,
+              equivalenceMessage: 'The regular expressions are equivalent.',
+              onChanged: (_) {},
+              onCompare: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('The regular expressions are equivalent.'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+    });
+  });
+
+  testWidgets('RegexHelpCard shows helpful patterns', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: RegexHelpCard(),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('Common patterns'), findsOneWidget);
+    expect(find.textContaining('a*'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- add a RegexPageViewModel that centralizes validation, conversions, simulations, and exposes Riverpod state
- refactor RegexPage to rely on the view model and split the UI into dedicated regex widgets
- add focused unit and widget tests covering the new view model and UI components

## Testing
- flutter test *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d16a618dcc832ea82caf99eea481ab