### PR TITLE
Refactor gesture handling into dedicated controllers

### DIFF
--- a/lib/presentation/widgets/gestures/canvas_transform_controller.dart
+++ b/lib/presentation/widgets/gestures/canvas_transform_controller.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+
+/// Manages pan and zoom transformations applied to the canvas.
+class CanvasTransformController {
+  CanvasTransformController({
+    this.minScale = 0.5,
+    this.maxScale = 3.0,
+    double initialScale = 1.0,
+    Offset initialPanOffset = Offset.zero,
+  })  : _scale = initialScale,
+        _panOffset = initialPanOffset,
+        _initialScale = initialScale,
+        _initialPanOffset = initialPanOffset;
+
+  final double minScale;
+  final double maxScale;
+
+  double _scale;
+  double _initialScale;
+  Offset _panOffset;
+  Offset _initialPanOffset;
+  bool _isPanning = false;
+  bool _isZooming = false;
+
+  double get scale => _scale;
+  Offset get panOffset => _panOffset;
+  bool get isPanning => _isPanning;
+  bool get isZooming => _isZooming;
+
+  /// Converts a position from the local widget coordinates to canvas coordinates
+  /// taking current pan and zoom into account.
+  Offset toCanvasCoordinates(Offset position) {
+    final translated = position - _panOffset;
+    if (_scale == 0) {
+      return translated;
+    }
+    return Offset(translated.dx / _scale, translated.dy / _scale);
+  }
+
+  /// Starts a panning gesture.
+  void beginPan() {
+    _isPanning = true;
+    _isZooming = false;
+  }
+
+  /// Starts a zooming gesture, preserving the initial scale and offset
+  /// so that deltas can be accumulated during the gesture.
+  void beginZoom() {
+    _isZooming = true;
+    _isPanning = false;
+    _initialScale = _scale;
+    _initialPanOffset = _panOffset;
+  }
+
+  /// Applies a pan delta.
+  void updatePan(Offset focalPointDelta) {
+    if (!_isPanning) {
+      return;
+    }
+    _panOffset += focalPointDelta;
+  }
+
+  /// Applies zoom and pan deltas when performing a multi-touch interaction.
+  void updateZoom(double scaleDelta, Offset focalPointDelta) {
+    if (!_isZooming) {
+      return;
+    }
+    final newScale = _initialScale * scaleDelta;
+    _scale = newScale.clamp(minScale, maxScale);
+    _panOffset = _initialPanOffset + focalPointDelta;
+  }
+
+  /// Ends the current gesture interaction, clearing transient state.
+  void endInteraction() {
+    _isPanning = false;
+    _isZooming = false;
+  }
+}

--- a/lib/presentation/widgets/gestures/transition_hit_tester.dart
+++ b/lib/presentation/widgets/gestures/transition_hit_tester.dart
@@ -1,0 +1,107 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+
+import '../../../core/models/transition.dart';
+import '../transition_geometry.dart';
+
+/// Provides hit testing utilities for automaton transitions and self-loops.
+class TransitionHitTester<T extends Transition> {
+  const TransitionHitTester({
+    required this.stateRadius,
+    required this.selfLoopBaseRadius,
+    required this.selfLoopSpacing,
+    this.hitTolerance = 18.0,
+  });
+
+  final double stateRadius;
+  final double selfLoopBaseRadius;
+  final double selfLoopSpacing;
+  final double hitTolerance;
+
+  /// Finds the first transition intersecting the provided [point].
+  T? findTransitionAt(Offset point, List<T> transitions) {
+    for (final transition in transitions) {
+      if (isPointOnTransition(point, transition, transitions)) {
+        return transition;
+      }
+    }
+    return null;
+  }
+
+  /// Determines if [point] lies on [transition].
+  bool isPointOnTransition(Offset point, T transition, List<T> transitions) {
+    if (transition.fromState == transition.toState) {
+      return isPointOnSelfLoop(point, transition, transitions);
+    }
+
+    final curve = TransitionCurve.compute(
+      transitions,
+      transition,
+      stateRadius: stateRadius,
+      curvatureStrength: 45,
+      labelOffset: 16,
+    );
+
+    return _distanceToQuadratic(point, curve.start, curve.control, curve.end) <=
+        hitTolerance;
+  }
+
+  /// Determines if [point] lies on the self-loop represented by [transition].
+  bool isPointOnSelfLoop(Offset point, T transition, List<T> transitions) {
+    final center = Offset(
+      transition.fromState.position.x,
+      transition.fromState.position.y,
+    );
+    final loops = transitions
+        .where((t) =>
+            t.fromState.id == transition.fromState.id &&
+            t.fromState == t.toState)
+        .toList();
+    final index = loops.indexOf(transition);
+    final radius = selfLoopBaseRadius + index * selfLoopSpacing;
+    final loopCenter = Offset(center.dx, center.dy - radius);
+
+    final distance = (point - loopCenter).distance;
+    if ((distance - radius).abs() > hitTolerance) {
+      return false;
+    }
+
+    final angle = math.atan2(point.dy - loopCenter.dy, point.dx - loopCenter.dx);
+    final normalized = _normalizeAngle(angle);
+    final start = _normalizeAngle(1.1 * math.pi);
+    final end = start + 1.6 * math.pi;
+    final adjusted = normalized < start ? normalized + 2 * math.pi : normalized;
+    return adjusted >= start && adjusted <= end;
+  }
+
+  double _distanceToQuadratic(
+    Offset point,
+    Offset start,
+    Offset control,
+    Offset end,
+  ) {
+    double minDistance = double.infinity;
+    const segments = 24;
+    for (var i = 0; i <= segments; i++) {
+      final t = i / segments;
+      final sample = TransitionCurve.pointAt(start, control, end, t);
+      final distance = (point - sample).distance;
+      if (distance < minDistance) {
+        minDistance = distance;
+      }
+    }
+    return minDistance;
+  }
+
+  double _normalizeAngle(double angle) {
+    var a = angle;
+    while (a < 0) {
+      a += 2 * math.pi;
+    }
+    while (a >= 2 * math.pi) {
+      a -= 2 * math.pi;
+    }
+    return a;
+  }
+}

--- a/lib/presentation/widgets/touch_gesture_handler.dart
+++ b/lib/presentation/widgets/touch_gesture_handler.dart
@@ -1,10 +1,10 @@
 import 'dart:async';
-import 'dart:math' as math;
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart';
 import '../../core/models/state.dart' as automaton_state;
 import '../../core/models/transition.dart';
-import 'transition_geometry.dart';
+import 'gestures/canvas_transform_controller.dart';
+import 'gestures/transition_hit_tester.dart';
 
 /// Comprehensive touch gesture handler for mobile automaton editing
 class TouchGestureHandler<T extends Transition> extends StatefulWidget {
@@ -56,24 +56,20 @@ class TouchGestureHandler<T extends Transition> extends StatefulWidget {
 
 class _TouchGestureHandlerState<T extends Transition>
     extends State<TouchGestureHandler<T>> {
+  late final CanvasTransformController _transformController;
+  late TransitionHitTester<T> _transitionHitTester;
+
   // Gesture state
   automaton_state.State? _draggedState;
   Offset? _dragStartPosition;
   Offset? _dragStartCanvasPosition;
   bool _isDragging = false;
-  bool _isZooming = false;
-  double _scale = 1.0;
-  double _initialScale = 1.0;
-  Offset _panOffset = Offset.zero;
-  Offset _initialPanOffset = Offset.zero;
-  bool _isPanning = false;
   bool _isTransitionDrag = false;
   automaton_state.State? _transitionDragStart;
   Offset? _transitionDragPosition;
 
   // Long press handling
   Timer? _longPressTimer;
-  Offset? _longPressPosition;
 
   // Double tap handling
   DateTime? _lastTapTime;
@@ -86,18 +82,34 @@ class _TouchGestureHandlerState<T extends Transition>
   T? _contextMenuTransition;
 
   @override
+  void initState() {
+    super.initState();
+    _transformController = CanvasTransformController();
+    _transitionHitTester = _createTransitionHitTester();
+  }
+
+  @override
+  void didUpdateWidget(covariant TouchGestureHandler<T> oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.stateRadius != widget.stateRadius ||
+        oldWidget.selfLoopBaseRadius != widget.selfLoopBaseRadius ||
+        oldWidget.selfLoopSpacing != widget.selfLoopSpacing) {
+      _transitionHitTester = _createTransitionHitTester();
+    }
+  }
+
+  @override
   void dispose() {
     _longPressTimer?.cancel();
     super.dispose();
   }
 
-  /// Converts a local position (affected by current pan/zoom) to canvas coordinates
-  Offset _toCanvasCoordinates(Offset position) {
-    final translated = position - _panOffset;
-    if (_scale == 0) {
-      return translated;
-    }
-    return Offset(translated.dx / _scale, translated.dy / _scale);
+  TransitionHitTester<T> _createTransitionHitTester() {
+    return TransitionHitTester<T>(
+      stateRadius: widget.stateRadius,
+      selfLoopBaseRadius: widget.selfLoopBaseRadius,
+      selfLoopSpacing: widget.selfLoopSpacing,
+    );
   }
 
   /// Handles tap gestures
@@ -108,7 +120,7 @@ class _TouchGestureHandlerState<T extends Transition>
     }
 
     final position = details.localPosition;
-    final canvasPosition = _toCanvasCoordinates(position);
+    final canvasPosition = _transformController.toCanvasCoordinates(position);
     final now = DateTime.now();
 
     if (widget.isAddingTransition) {
@@ -161,7 +173,6 @@ class _TouchGestureHandlerState<T extends Transition>
     if (widget.isAddingTransition) {
       return;
     }
-    _longPressPosition = details.localPosition;
     _longPressTimer = Timer(const Duration(milliseconds: 500), () {
       _showContextMenuAt(details.localPosition);
     });
@@ -174,7 +185,7 @@ class _TouchGestureHandlerState<T extends Transition>
 
   /// Shows context menu at position
   void _showContextMenuAt(Offset position) {
-    final canvasPosition = _toCanvasCoordinates(position);
+    final canvasPosition = _transformController.toCanvasCoordinates(position);
     final state = _findStateAt(canvasPosition);
     final transition = _findTransitionAt(canvasPosition);
 
@@ -190,10 +201,9 @@ class _TouchGestureHandlerState<T extends Transition>
   void _handleScaleStart(ScaleStartDetails details) {
     _closeContextMenu();
 
-    _isZooming = true;
-
     if (widget.isAddingTransition && details.pointerCount == 1) {
-      final canvasPoint = _toCanvasCoordinates(details.localFocalPoint);
+      final canvasPoint =
+          _transformController.toCanvasCoordinates(details.localFocalPoint);
       final state = _findStateAt(canvasPoint);
       if (state != null) {
         _isTransitionDrag = true;
@@ -207,31 +217,29 @@ class _TouchGestureHandlerState<T extends Transition>
 
     // Check if this is a single finger drag (pan)
     if (details.pointerCount == 1) {
-      final canvasPoint = _toCanvasCoordinates(details.localFocalPoint);
+      final canvasPoint =
+          _transformController.toCanvasCoordinates(details.localFocalPoint);
       final state = _findStateAt(canvasPoint);
       if (state != null) {
         _draggedState = state;
         _dragStartPosition = details.localFocalPoint;
         _dragStartCanvasPosition = Offset(state.position.x, state.position.y);
         _isDragging = true;
-        _isPanning = false;
       }
       if (!_isDragging) {
-        _isPanning = true;
+        _transformController.beginPan();
         _draggedState = null;
-        _dragStartPosition = details.localFocalPoint;
       }
     } else {
-      _initialScale = _scale;
-      _initialPanOffset = _panOffset;
-      _isPanning = false;
+      _transformController.beginZoom();
     }
   }
 
   /// Handles scale update for zooming and panning
   void _handleScaleUpdate(ScaleUpdateDetails details) {
     if (_isTransitionDrag && details.pointerCount == 1) {
-      final canvasPoint = _toCanvasCoordinates(details.localFocalPoint);
+      final canvasPoint =
+          _transformController.toCanvasCoordinates(details.localFocalPoint);
       _transitionDragPosition = canvasPoint;
       widget.onTransitionPreviewChanged?.call(canvasPoint);
       return;
@@ -240,21 +248,25 @@ class _TouchGestureHandlerState<T extends Transition>
     if (_isDragging && _draggedState != null && details.pointerCount == 1) {
       // Handle single finger drag
       final deltaLocal = details.localFocalPoint - _dragStartPosition!;
-      final deltaCanvas = Offset(deltaLocal.dx / _scale, deltaLocal.dy / _scale);
+      final scale = _transformController.scale;
+      final deltaCanvas =
+          Offset(deltaLocal.dx / scale, deltaLocal.dy / scale);
       final startCanvas = _dragStartCanvasPosition!;
       final newPosition = startCanvas + deltaCanvas;
       widget.onStateMoved(_draggedState!.copyWith(
         position: Vector2(newPosition.dx, newPosition.dy),
       ));
-    } else if (_isPanning && details.pointerCount == 1) {
+    } else if (_transformController.isPanning && details.pointerCount == 1) {
       setState(() {
-        _panOffset += details.focalPointDelta;
+        _transformController.updatePan(details.focalPointDelta);
       });
     } else if (details.pointerCount > 1) {
       // Handle multi-finger zoom and pan
       setState(() {
-        _scale = math.max(0.5, math.min(3.0, _initialScale * details.scale));
-        _panOffset = _initialPanOffset + details.focalPointDelta;
+        _transformController.updateZoom(
+          details.scale,
+          details.focalPointDelta,
+        );
       });
     }
   }
@@ -273,15 +285,14 @@ class _TouchGestureHandlerState<T extends Transition>
       widget.onTransitionOriginChanged?.call(null);
     }
 
-    _isZooming = false;
     _isDragging = false;
-    _isPanning = false;
     _draggedState = null;
     _dragStartPosition = null;
     _dragStartCanvasPosition = null;
     _isTransitionDrag = false;
     _transitionDragStart = null;
     _transitionDragPosition = null;
+    _transformController.endInteraction();
   }
 
   /// Finds state at given position
@@ -296,12 +307,10 @@ class _TouchGestureHandlerState<T extends Transition>
 
   /// Finds transition at given position
   T? _findTransitionAt(Offset position) {
-    for (final transition in widget.transitions) {
-      if (_isPointOnTransition(position, transition)) {
-        return transition;
-      }
-    }
-    return null;
+    return _transitionHitTester.findTransitionAt(
+      position,
+      widget.transitions,
+    );
   }
 
   /// Checks if point is inside a state
@@ -309,78 +318,6 @@ class _TouchGestureHandlerState<T extends Transition>
     final statePosition = Offset(state.position.x, state.position.y);
     final distance = (point - statePosition).distance;
     return distance <= widget.stateRadius;
-  }
-
-  /// Checks if point is on a transition line
-  bool _isPointOnTransition(Offset point, T transition) {
-    if (transition.fromState == transition.toState) {
-      return _isPointOnSelfLoop(point, transition);
-    }
-
-    final curve = TransitionCurve.compute(
-      widget.transitions,
-      transition,
-      stateRadius: widget.stateRadius,
-      curvatureStrength: 45,
-      labelOffset: 16,
-    );
-
-    return _distanceToQuadratic(point, curve.start, curve.control, curve.end) <= 18;
-  }
-
-  bool _isPointOnSelfLoop(Offset point, T transition) {
-    final center = Offset(
-      transition.fromState.position.x,
-      transition.fromState.position.y,
-    );
-    final loops = widget.transitions
-        .where((t) => t.fromState.id == transition.fromState.id && t.fromState == t.toState)
-        .toList();
-    final index = loops.indexOf(transition);
-    final radius = widget.selfLoopBaseRadius + index * widget.selfLoopSpacing;
-    final loopCenter = Offset(center.dx, center.dy - radius);
-
-    final distance = (point - loopCenter).distance;
-    if ((distance - radius).abs() > 18) {
-      return false;
-    }
-
-    final angle = math.atan2(point.dy - loopCenter.dy, point.dx - loopCenter.dx);
-    final normalized = _normalizeAngle(angle);
-    final start = _normalizeAngle(1.1 * math.pi);
-    final end = start + 1.6 * math.pi;
-    final adjusted = normalized < start ? normalized + 2 * math.pi : normalized;
-    return adjusted >= start && adjusted <= end;
-  }
-
-  double _distanceToQuadratic(
-    Offset point,
-    Offset start,
-    Offset control,
-    Offset end,
-  ) {
-    double minDistance = double.infinity;
-    const segments = 24;
-    for (var i = 0; i <= segments; i++) {
-      final t = i / segments;
-      final sample = TransitionCurve.pointAt(start, control, end, t);
-      final distance = (point - sample).distance;
-      if (distance < minDistance) {
-        minDistance = distance;
-      }
-    }
-    return minDistance;
-  }
-
-  double _normalizeAngle(double angle) {
-    var a = angle;
-    while (a < 0) {
-      a += 2 * math.pi;
-    }
-    while (a >= 2 * math.pi) {
-      a -= 2 * math.pi;
-    }
-    return a;
   }
 
   /// Closes context menu
@@ -408,8 +345,11 @@ class _TouchGestureHandlerState<T extends Transition>
           onScaleEnd: _handleScaleEnd,
           child: Transform(
             transform: Matrix4.identity()
-              ..translate(_panOffset.dx, _panOffset.dy)
-              ..scale(_scale),
+              ..translate(
+                _transformController.panOffset.dx,
+                _transformController.panOffset.dy,
+              )
+              ..scale(_transformController.scale),
             child: widget.child,
           ),
         ),
@@ -488,7 +428,8 @@ class _TouchGestureHandlerState<T extends Transition>
                 icon: Icons.add_circle,
                 label: 'Add State',
                 onTap: () {
-                  final canvasPoint = _toCanvasCoordinates(_contextMenuPosition!);
+                  final canvasPoint = _transformController
+                      .toCanvasCoordinates(_contextMenuPosition!);
                   widget.onStateAdded(canvasPoint);
                   _closeContextMenu();
                 },

--- a/test/presentation/widgets/gestures/canvas_transform_controller_test.dart
+++ b/test/presentation/widgets/gestures/canvas_transform_controller_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/presentation/widgets/gestures/canvas_transform_controller.dart';
+
+void main() {
+  group('CanvasTransformController', () {
+    test('converts local coordinates to canvas coordinates with no transform', () {
+      final controller = CanvasTransformController();
+
+      const position = Offset(100, 50);
+      expect(controller.toCanvasCoordinates(position), equals(position));
+    });
+
+    test('applies pan offset when converting coordinates', () {
+      final controller = CanvasTransformController();
+
+      controller.beginPan();
+      controller.updatePan(const Offset(20, -10));
+
+      final canvasPoint = controller.toCanvasCoordinates(const Offset(30, 10));
+      expect(canvasPoint, const Offset(10, 20));
+    });
+
+    test('applies scaling when converting coordinates', () {
+      final controller = CanvasTransformController();
+
+      controller.beginZoom();
+      controller.updateZoom(2.0, Offset.zero);
+
+      final canvasPoint = controller.toCanvasCoordinates(const Offset(40, 0));
+      expect(canvasPoint, const Offset(20, 0));
+    });
+
+    test('clamps zoom according to limits', () {
+      final controller = CanvasTransformController(minScale: 0.5, maxScale: 2.0);
+
+      controller.beginZoom();
+      controller.updateZoom(10.0, Offset.zero);
+      expect(controller.scale, equals(2.0));
+
+      controller.beginZoom();
+      controller.updateZoom(0.01, Offset.zero);
+      expect(controller.scale, equals(0.5));
+    });
+  });
+}

--- a/test/presentation/widgets/gestures/transition_hit_tester_test.dart
+++ b/test/presentation/widgets/gestures/transition_hit_tester_test.dart
@@ -1,0 +1,105 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/presentation/widgets/gestures/transition_hit_tester.dart';
+import 'package:jflutter/presentation/widgets/transition_geometry.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  group('TransitionHitTester', () {
+    late automaton_state.State q0;
+    late automaton_state.State q1;
+    late List<FSATransition> transitions;
+
+    setUp(() {
+      q0 = automaton_state.State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2(100, 100),
+        isInitial: true,
+        isAccepting: false,
+      );
+      q1 = automaton_state.State(
+        id: 'q1',
+        label: 'q1',
+        position: Vector2(200, 100),
+        isInitial: false,
+        isAccepting: false,
+      );
+      transitions = [
+        FSATransition(
+          id: 't0',
+          fromState: q0,
+          toState: q1,
+          label: 'a',
+          inputSymbols: {'a'},
+        ),
+        FSATransition(
+          id: 'self',
+          fromState: q0,
+          toState: q0,
+          label: 'b',
+          inputSymbols: {'b'},
+        ),
+      ];
+    });
+
+    test('detects hits on linear transitions', () {
+      final tester = TransitionHitTester<FSATransition>(
+        stateRadius: 30,
+        selfLoopBaseRadius: 40,
+        selfLoopSpacing: 12,
+      );
+
+      final curve = TransitionCurve.compute(
+        transitions,
+        transitions.first,
+        stateRadius: 30,
+        curvatureStrength: 45,
+        labelOffset: 16,
+      );
+      final midpoint = TransitionCurve.pointAt(
+        curve.start,
+        curve.control,
+        curve.end,
+        0.5,
+      );
+
+      final hit = tester.findTransitionAt(midpoint, transitions);
+      expect(hit, equals(transitions.first));
+    });
+
+    test('detects hits on self loops', () {
+      final tester = TransitionHitTester<FSATransition>(
+        stateRadius: 30,
+        selfLoopBaseRadius: 40,
+        selfLoopSpacing: 12,
+      );
+
+      final radius = 40.0;
+      final loopCenter = Offset(q0.position.x, q0.position.y - radius);
+      final angle = 1.5 * math.pi;
+      final pointOnLoop = Offset(
+        loopCenter.dx + radius * math.cos(angle),
+        loopCenter.dy + radius * math.sin(angle),
+      );
+
+      final hit = tester.findTransitionAt(pointOnLoop, transitions);
+      expect(hit?.id, equals('self'));
+    });
+
+    test('returns null when no transition is hit', () {
+      final tester = TransitionHitTester<FSATransition>(
+        stateRadius: 30,
+        selfLoopBaseRadius: 40,
+        selfLoopSpacing: 12,
+      );
+
+      final hit = tester.findTransitionAt(const Offset(10, 10), transitions);
+      expect(hit, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extract pan and zoom responsibilities into a reusable `CanvasTransformController`
- move transition and self-loop hit detection into a shared `TransitionHitTester`
- update `TouchGestureHandler` to delegate to the new utilities and add focused unit tests

## Testing
- flutter analyze *(fails: command not found)*
- flutter test test/presentation/widgets/gestures/canvas_transform_controller_test.dart test/presentation/widgets/gestures/transition_hit_tester_test.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d16fedad6c832eb8256c37f656611b