### PR TITLE
Refactor file listing to async iteration

### DIFF
--- a/lib/data/services/file_operations_service.dart
+++ b/lib/data/services/file_operations_service.dart
@@ -146,12 +146,13 @@ class FileOperationsService {
       if (!dirResult.isSuccess) return Failure(dirResult.error!);
       
       final directory = Directory(dirResult.data!);
-      final files = directory
-          .listSync()
-          .where((file) => file.path.endsWith('.$extension'))
-          .map((file) => file.path)
-          .toList();
-      
+      final files = <String>[];
+      await for (final entity in directory.list()) {
+        if (entity is File && entity.path.endsWith('.$extension')) {
+          files.add(entity.path);
+        }
+      }
+
       return Success(files);
     } catch (e) {
       return Failure('Failed to list files: $e');


### PR DESCRIPTION
## Summary
- update `FileOperationsService.listFiles` to iterate with `await for` on `Directory.list()` and build a list of matching paths asynchronously
- create a test double for the documents directory in integration tests and expand the file listing test to cover large asynchronous collections
- clean up integration tests to operate within isolated temporary directories for predictable results

## Testing
- `flutter test test/integration/test_file_operations.dart` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d17a9567bc832e82cd3f3cb7dcd920