### PR TITLE
Ensure automaton state identifiers remain unique

### DIFF
--- a/lib/presentation/providers/automaton_canvas_controller.dart
+++ b/lib/presentation/providers/automaton_canvas_controller.dart
@@ -22,6 +22,7 @@ class AutomatonCanvasController extends ChangeNotifier {
 
   final List<automaton_state.State> _states = [];
   final List<FSATransition> _transitions = [];
+  int _nextStateIndex = 0;
 
   automaton_state.State? _selectedState;
   bool _isAddingState = false;
@@ -70,6 +71,15 @@ class AutomatonCanvasController extends ChangeNotifier {
       ..addAll(
         automaton?.transitions.cast<FSATransition>() ?? const <FSATransition>{},
       );
+    _nextStateIndex = _states.fold<int>(0, (maxIndex, state) {
+      final match = RegExp(r'\d+$').firstMatch(state.id);
+      if (match == null) {
+        return maxIndex;
+      }
+
+      final value = int.tryParse(match.group(0)!) ?? 0;
+      return math.max(maxIndex, value + 1);
+    });
     _selectedState = null;
     _isAddingState = false;
     _isAddingTransition = false;
@@ -108,14 +118,15 @@ class AutomatonCanvasController extends ChangeNotifier {
   /// Adds a new state at the provided canvas position.
   void addState(Offset position) {
     final newState = automaton_state.State(
-      id: 'q${_states.length}',
-      label: 'q${_states.length}',
+      id: 'q$_nextStateIndex',
+      label: 'q$_nextStateIndex',
       position: Vector2(position.dx, position.dy),
       isInitial: _states.isEmpty,
       isAccepting: false,
     );
 
     _states.add(newState);
+    _nextStateIndex++;
     _isAddingState = false;
     notifyListeners();
     _emitAutomatonChanged();

--- a/test/presentation/providers/automaton_canvas_controller_test.dart
+++ b/test/presentation/providers/automaton_canvas_controller_test.dart
@@ -1,0 +1,72 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/presentation/providers/automaton_canvas_controller.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('AutomatonCanvasController state IDs', () {
+    test('increments IDs when adding new states', () {
+      final controller = AutomatonCanvasController();
+
+      controller.addState(Offset.zero);
+      controller.addState(const Offset(100, 0));
+
+      final ids = controller.states.map((state) => state.id).toList();
+      final labels = controller.states.map((state) => state.label).toList();
+
+      expect(ids, equals(['q0', 'q1']));
+      expect(ids.toSet().length, ids.length);
+      expect(labels.toSet().length, labels.length);
+    });
+
+    test('respects loaded automaton when generating next IDs', () {
+      final existingStates = <automaton_state.State>{
+        automaton_state.State(
+          id: 'q0',
+          label: 'q0',
+          position: Vector2.zero(),
+          isInitial: true,
+        ),
+        automaton_state.State(
+          id: 'q10',
+          label: 'q10',
+          position: Vector2(50, 0),
+          isAccepting: true,
+        ),
+      };
+
+      final automaton = FSA(
+        id: 'test',
+        name: 'Test Automaton',
+        states: existingStates,
+        transitions: <Transition>{},
+        alphabet: <String>{},
+        initialState: existingStates.first,
+        acceptingStates: existingStates.where((state) => state.isAccepting).toSet(),
+        created: DateTime.now(),
+        modified: DateTime.now(),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+
+      final controller = AutomatonCanvasController(automaton: automaton);
+
+      controller.addState(const Offset(200, 0));
+
+      expect(controller.states.last.id, 'q11');
+      expect(controller.states.last.label, 'q11');
+      expect(controller.states.map((s) => s.id).toSet().length,
+          controller.states.length);
+      expect(controller.states.map((s) => s.label).toSet().length,
+          controller.states.length);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a private counter in the canvas controller to generate unique state IDs
- initialize the counter when loading existing automatons and use it when creating new states
- cover the new behavior with unit tests for clean ID and label generation

## Testing
- `flutter test test/presentation/providers/automaton_canvas_controller_test.dart` *(fails: `flutter` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d1804e0c34832e94c09f2021ca9f43