### PR TITLE
Fix AddStateUseCase initial state handling

### DIFF
--- a/lib/core/use_cases/automaton_use_cases.dart
+++ b/lib/core/use_cases/automaton_use_cases.dart
@@ -121,18 +121,18 @@ class AddStateUseCase {
         isFinal: isFinal,
       );
 
-      final updatedStates = [...automaton.states, newState];
-      
+      final updatedStates = isInitial
+          ? [
+              ...automaton.states
+                  .map((state) => state.copyWith(isInitial: false)),
+              newState,
+            ]
+          : [...automaton.states, newState];
+
       // If this is the initial state, update initialId
       String? newInitialId = automaton.initialId;
       if (isInitial) {
         newInitialId = newState.id;
-        // Remove initial flag from other states
-        updatedStates.forEach((state) {
-          if (state.id != newState.id && state.isInitial) {
-            state = state.copyWith(isInitial: false);
-          }
-        });
       }
 
       final updatedAutomaton = automaton.copyWith(

--- a/test/unit/core/use_cases/add_state_use_case_test.dart
+++ b/test/unit/core/use_cases/add_state_use_case_test.dart
@@ -1,0 +1,103 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/lib/core/entities/automaton_entity.dart';
+import 'package:jflutter/lib/core/repositories/automaton_repository.dart';
+import 'package:jflutter/lib/core/result.dart';
+import 'package:jflutter/lib/core/use_cases/automaton_use_cases.dart';
+
+class _RecordingAutomatonRepository implements AutomatonRepository {
+  AutomatonEntity? lastSaved;
+
+  @override
+  Future<AutomatonResult> saveAutomaton(AutomatonEntity automaton) async {
+    lastSaved = automaton;
+    return Success(automaton);
+  }
+
+  @override
+  Future<BoolResult> deleteAutomaton(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StringResult> exportAutomaton(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> importAutomaton(String jsonString) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ListResult<AutomatonEntity>> loadAllAutomatons() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> loadAutomaton(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BoolResult> validateAutomaton(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+}
+
+void main() {
+  group('AddStateUseCase', () {
+    test('updates previous states to non-initial when new initial state is added', () async {
+      final repository = _RecordingAutomatonRepository();
+      final useCase = AddStateUseCase(repository);
+      final automaton = AutomatonEntity(
+        id: 'auto-1',
+        name: 'Test',
+        alphabet: const {},
+        states: const [
+          StateEntity(
+            id: 'q0',
+            name: 'q0',
+            x: 0,
+            y: 0,
+            isInitial: true,
+            isFinal: false,
+          ),
+          StateEntity(
+            id: 'q1',
+            name: 'q1',
+            x: 100,
+            y: 0,
+            isInitial: false,
+            isFinal: true,
+          ),
+        ],
+        transitions: const {},
+        initialId: 'q0',
+        nextId: 2,
+        type: AutomatonType.dfa,
+      );
+
+      final result = await useCase.execute(
+        automaton: automaton,
+        name: 'q2',
+        x: 200,
+        y: 0,
+        isInitial: true,
+        isFinal: false,
+      );
+
+      expect(result, isA<Success<AutomatonEntity>>());
+      final savedAutomaton = repository.lastSaved;
+      expect(savedAutomaton, isNotNull);
+      expect(savedAutomaton!.initialId, equals('q2'));
+
+      final initialStates = savedAutomaton.states.where((state) => state.isInitial).toList();
+      expect(initialStates.length, 1);
+      expect(initialStates.single.id, equals('q2'));
+
+      final previousInitial =
+          savedAutomaton.states.firstWhere((state) => state.id == 'q0');
+      expect(previousInitial.isInitial, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- rebuild the state list when adding a new initial state so all previous states lose the initial flag
- keep the new initial state's flag and update the automaton's initial id when saving
- add a unit test for AddStateUseCase to ensure only the new state remains initial

## Testing
- flutter test test/unit/core/use_cases/add_state_use_case_test.dart *(fails: flutter command not available in container)*
- dart test test/unit/core/use_cases/add_state_use_case_test.dart *(fails: dart command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1866de758832eba31aba7324fcc24