### PR TITLE
Refactor automaton provider into modular controllers

### DIFF
--- a/lib/presentation/providers/automaton/automaton_conversion_controller.dart
+++ b/lib/presentation/providers/automaton/automaton_conversion_controller.dart
@@ -1,0 +1,220 @@
+import '../../../core/models/fsa.dart';
+import '../../../core/use_cases/algorithm_use_cases.dart';
+import '../../../core/utils/automaton_entity_mapper.dart';
+
+import 'automaton_state.dart';
+
+class AutomatonConversionController {
+  final NfaToDfaUseCase _nfaToDfaUseCase;
+  final MinimizeDfaUseCase _minimizeDfaUseCase;
+  final CompleteDfaUseCase _completeDfaUseCase;
+  final RegexToNfaUseCase _regexToNfaUseCase;
+  final DfaToRegexUseCase _dfaToRegexUseCase;
+  final FsaToGrammarUseCase _fsaToGrammarUseCase;
+  final CheckEquivalenceUseCase _checkEquivalenceUseCase;
+
+  AutomatonConversionController({
+    required NfaToDfaUseCase nfaToDfaUseCase,
+    required MinimizeDfaUseCase minimizeDfaUseCase,
+    required CompleteDfaUseCase completeDfaUseCase,
+    required RegexToNfaUseCase regexToNfaUseCase,
+    required DfaToRegexUseCase dfaToRegexUseCase,
+    required FsaToGrammarUseCase fsaToGrammarUseCase,
+    required CheckEquivalenceUseCase checkEquivalenceUseCase,
+  })  : _nfaToDfaUseCase = nfaToDfaUseCase,
+        _minimizeDfaUseCase = minimizeDfaUseCase,
+        _completeDfaUseCase = completeDfaUseCase,
+        _regexToNfaUseCase = regexToNfaUseCase,
+        _dfaToRegexUseCase = dfaToRegexUseCase,
+        _fsaToGrammarUseCase = fsaToGrammarUseCase,
+        _checkEquivalenceUseCase = checkEquivalenceUseCase;
+
+  Future<AutomatonState> convertNfaToDfa(AutomatonState state) async {
+    try {
+      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final result = await _nfaToDfaUseCase.execute(automatonEntity);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          currentAutomaton: automatonEntityToFsa(result.data!),
+          simulationResult: null,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error converting NFA to DFA: $e',
+      );
+    }
+  }
+
+  Future<AutomatonState> minimizeDfa(AutomatonState state) async {
+    try {
+      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final result = await _minimizeDfaUseCase.execute(automatonEntity);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          currentAutomaton: automatonEntityToFsa(result.data!),
+          simulationResult: null,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error minimizing DFA: $e',
+      );
+    }
+  }
+
+  Future<AutomatonState> completeDfa(AutomatonState state) async {
+    try {
+      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final result = await _completeDfaUseCase.execute(automatonEntity);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          currentAutomaton: automatonEntityToFsa(result.data!),
+          simulationResult: null,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error completing DFA: $e',
+      );
+    }
+  }
+
+  Future<AutomatonState> convertRegexToNfa(
+    AutomatonState state,
+    String regex,
+  ) async {
+    try {
+      final result = await _regexToNfaUseCase.execute(regex);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          currentAutomaton: automatonEntityToFsa(result.data!),
+          simulationResult: null,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error converting regex to NFA: $e',
+      );
+    }
+  }
+
+  Future<AutomatonState> convertFsaToGrammar(AutomatonState state) async {
+    try {
+      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final result = await _fsaToGrammarUseCase.execute(automatonEntity);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          grammarResult: result.data,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error converting FSA to Grammar: $e',
+      );
+    }
+  }
+
+  Future<AutomatonState> convertFaToRegex(AutomatonState state) async {
+    try {
+      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final result = await _dfaToRegexUseCase.execute(automatonEntity);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          regexResult: result.data,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error converting FA to regex: $e',
+      );
+    }
+  }
+
+  Future<AutomatonState> compareEquivalence(
+    AutomatonState state,
+    FSA other,
+  ) async {
+    try {
+      final currentEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final otherEntity = fsaToAutomatonEntity(other);
+      final result = await _checkEquivalenceUseCase.execute(
+        currentEntity,
+        otherEntity,
+      );
+
+      if (result.isSuccess) {
+        final areEquivalent = result.data!;
+        return state.copyWith(
+          isLoading: false,
+          equivalenceResult: areEquivalent,
+          equivalenceDetails: areEquivalent
+              ? 'The automata accept the same language.'
+              : 'A distinguishing string was found between the automata.',
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          equivalenceResult: null,
+          equivalenceDetails: result.error,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        equivalenceResult: null,
+        equivalenceDetails: 'Error comparing automata: $e',
+        error: 'Error comparing automata: $e',
+      );
+    }
+  }
+}

--- a/lib/presentation/providers/automaton/automaton_creation_controller.dart
+++ b/lib/presentation/providers/automaton/automaton_creation_controller.dart
@@ -1,0 +1,96 @@
+import '../../../core/entities/automaton_entity.dart';
+import '../../../core/models/fsa.dart';
+import '../../../core/use_cases/automaton_use_cases.dart';
+import '../../../core/utils/automaton_entity_mapper.dart';
+
+import 'automaton_state.dart';
+
+class AutomatonCreationController {
+  final CreateAutomatonUseCase _createAutomatonUseCase;
+  final AddStateUseCase _addStateUseCase;
+
+  AutomatonCreationController({
+    required CreateAutomatonUseCase createAutomatonUseCase,
+    required AddStateUseCase addStateUseCase,
+  })  : _createAutomatonUseCase = createAutomatonUseCase,
+        _addStateUseCase = addStateUseCase;
+
+  Future<AutomatonState> createAutomaton(
+    AutomatonState state, {
+    required String name,
+    required List<String> alphabet,
+  }) async {
+    try {
+      final createResult = await _createAutomatonUseCase.execute(
+        name: name,
+        type: AutomatonType.dfa,
+        alphabet: alphabet.toSet(),
+      );
+
+      if (createResult.isFailure) {
+        return state.copyWith(
+          isLoading: false,
+          error: createResult.error,
+        );
+      }
+
+      var automatonEntity = createResult.data!;
+      final addInitialStateResult = await _addStateUseCase.execute(
+        automaton: automatonEntity,
+        name: 'q0',
+        x: 100,
+        y: 100,
+        isInitial: true,
+        isFinal: false,
+      );
+
+      if (addInitialStateResult.isFailure) {
+        return state.copyWith(
+          isLoading: false,
+          error: addInitialStateResult.error,
+        );
+      }
+
+      automatonEntity = addInitialStateResult.data!;
+
+      return state.copyWith(
+        currentAutomaton: automatonEntityToFsa(automatonEntity),
+        simulationResult: null,
+        regexResult: null,
+        grammarResult: null,
+        equivalenceResult: null,
+        equivalenceDetails: null,
+        isLoading: false,
+      );
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error creating automaton: $e',
+      );
+    }
+  }
+
+  AutomatonState updateAutomaton(AutomatonState state, FSA automaton) {
+    return state.copyWith(
+      currentAutomaton: automaton,
+      equivalenceResult: null,
+      equivalenceDetails: null,
+    );
+  }
+
+  AutomatonState clearAutomaton(AutomatonState state) {
+    return state.copyWith(
+      currentAutomaton: null,
+      simulationResult: null,
+      regexResult: null,
+      grammarResult: null,
+      equivalenceResult: null,
+      equivalenceDetails: null,
+      error: null,
+    );
+  }
+
+  AutomatonState clearError(AutomatonState state) {
+    return state.copyWith(error: null);
+  }
+}

--- a/lib/presentation/providers/automaton/automaton_layout_controller.dart
+++ b/lib/presentation/providers/automaton/automaton_layout_controller.dart
@@ -1,0 +1,37 @@
+import '../../../core/use_cases/algorithm_use_cases.dart';
+import '../../../core/utils/automaton_entity_mapper.dart';
+
+import 'automaton_state.dart';
+
+class AutomatonLayoutController {
+  final ApplyAutoLayoutUseCase _applyAutoLayoutUseCase;
+
+  AutomatonLayoutController({
+    required ApplyAutoLayoutUseCase applyAutoLayoutUseCase,
+  }) : _applyAutoLayoutUseCase = applyAutoLayoutUseCase;
+
+  Future<AutomatonState> applyAutoLayout(AutomatonState state) async {
+    try {
+      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
+      final result = await _applyAutoLayoutUseCase.execute(automatonEntity);
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          currentAutomaton: automatonEntityToFsa(result.data!),
+          simulationResult: null,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error applying auto layout: $e',
+      );
+    }
+  }
+}

--- a/lib/presentation/providers/automaton/automaton_simulation_controller.dart
+++ b/lib/presentation/providers/automaton/automaton_simulation_controller.dart
@@ -1,0 +1,43 @@
+import '../../../core/use_cases/algorithm_use_cases.dart';
+import '../../../core/utils/automaton_entity_mapper.dart';
+
+import 'automaton_state.dart';
+
+class AutomatonSimulationController {
+  final SimulateWordUseCase _simulateWordUseCase;
+
+  AutomatonSimulationController({
+    required SimulateWordUseCase simulateWordUseCase,
+  }) : _simulateWordUseCase = simulateWordUseCase;
+
+  Future<AutomatonState> simulate(
+    AutomatonState state,
+    String inputString,
+  ) async {
+    try {
+      final automatonEntity =
+          fsaToAutomatonEntity(state.currentAutomaton!); // assumes non-null
+      final result = await _simulateWordUseCase.execute(
+        automatonEntity,
+        inputString,
+      );
+
+      if (result.isSuccess) {
+        return state.copyWith(
+          simulationResult: result.data,
+          isLoading: false,
+        );
+      } else {
+        return state.copyWith(
+          isLoading: false,
+          error: result.error,
+        );
+      }
+    } catch (e) {
+      return state.copyWith(
+        isLoading: false,
+        error: 'Error simulating automaton: $e',
+      );
+    }
+  }
+}

--- a/lib/presentation/providers/automaton/automaton_state.dart
+++ b/lib/presentation/providers/automaton/automaton_state.dart
@@ -1,0 +1,60 @@
+import '../../core/models/fsa.dart';
+import '../../core/models/grammar.dart';
+import '../../core/models/simulation_result.dart' as sim_result;
+
+class AutomatonState {
+  final FSA? currentAutomaton;
+  final sim_result.SimulationResult? simulationResult;
+  final String? regexResult;
+  final Grammar? grammarResult;
+  final bool? equivalenceResult;
+  final String? equivalenceDetails;
+  final bool isLoading;
+  final String? error;
+
+  const AutomatonState({
+    this.currentAutomaton,
+    this.simulationResult,
+    this.regexResult,
+    this.grammarResult,
+    this.equivalenceResult,
+    this.equivalenceDetails,
+    this.isLoading = false,
+    this.error,
+  });
+
+  static const _unset = Object();
+
+  AutomatonState copyWith({
+    Object? currentAutomaton = _unset,
+    Object? simulationResult = _unset,
+    Object? regexResult = _unset,
+    Object? grammarResult = _unset,
+    Object? equivalenceResult = _unset,
+    Object? equivalenceDetails = _unset,
+    bool? isLoading,
+    Object? error = _unset,
+  }) {
+    return AutomatonState(
+      currentAutomaton: currentAutomaton == _unset
+          ? this.currentAutomaton
+          : currentAutomaton as FSA?,
+      simulationResult: simulationResult == _unset
+          ? this.simulationResult
+          : simulationResult as sim_result.SimulationResult?,
+      regexResult:
+          regexResult == _unset ? this.regexResult : regexResult as String?,
+      grammarResult: grammarResult == _unset
+          ? this.grammarResult
+          : grammarResult as Grammar?,
+      equivalenceResult: equivalenceResult == _unset
+          ? this.equivalenceResult
+          : equivalenceResult as bool?,
+      equivalenceDetails: equivalenceDetails == _unset
+          ? this.equivalenceDetails
+          : equivalenceDetails as String?,
+      isLoading: isLoading ?? this.isLoading,
+      error: error == _unset ? this.error : error as String?,
+    );
+  }
+}

--- a/lib/presentation/providers/automaton_provider.dart
+++ b/lib/presentation/providers/automaton_provider.dart
@@ -1,121 +1,58 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../../core/entities/automaton_entity.dart';
 import '../../core/models/fsa.dart';
 import '../../core/models/grammar.dart';
-import '../../core/models/simulation_result.dart' as sim_result;
-import '../../core/result.dart';
 import '../../core/use_cases/algorithm_use_cases.dart';
 import '../../core/use_cases/automaton_use_cases.dart';
-import '../../core/utils/automaton_entity_mapper.dart';
 import '../../data/repositories/algorithm_repository_impl.dart';
 import '../../data/repositories/automaton_repository_impl.dart';
 import '../../data/services/automaton_service.dart';
 import '../../features/layout/layout_repository_impl.dart';
+import 'automaton/automaton_conversion_controller.dart';
+import 'automaton/automaton_creation_controller.dart';
+import 'automaton/automaton_layout_controller.dart';
+import 'automaton/automaton_simulation_controller.dart';
+import 'automaton/automaton_state.dart';
 
-/// Provider for automaton state management
 class AutomatonProvider extends StateNotifier<AutomatonState> {
-  final CreateAutomatonUseCase _createAutomatonUseCase;
-  final AddStateUseCase _addStateUseCase;
-  final NfaToDfaUseCase _nfaToDfaUseCase;
-  final MinimizeDfaUseCase _minimizeDfaUseCase;
-  final CompleteDfaUseCase _completeDfaUseCase;
-  final RegexToNfaUseCase _regexToNfaUseCase;
-  final DfaToRegexUseCase _dfaToRegexUseCase;
-  final FsaToGrammarUseCase _fsaToGrammarUseCase;
-  final CheckEquivalenceUseCase _checkEquivalenceUseCase;
-  final SimulateWordUseCase _simulateWordUseCase;
-  final ApplyAutoLayoutUseCase _applyAutoLayoutUseCase;
+  final AutomatonCreationController _creationController;
+  final AutomatonSimulationController _simulationController;
+  final AutomatonConversionController _conversionController;
+  final AutomatonLayoutController _layoutController;
 
   AutomatonProvider({
-    required CreateAutomatonUseCase createAutomatonUseCase,
-    required AddStateUseCase addStateUseCase,
-    required NfaToDfaUseCase nfaToDfaUseCase,
-    required MinimizeDfaUseCase minimizeDfaUseCase,
-    required CompleteDfaUseCase completeDfaUseCase,
-    required RegexToNfaUseCase regexToNfaUseCase,
-    required DfaToRegexUseCase dfaToRegexUseCase,
-    required FsaToGrammarUseCase fsaToGrammarUseCase,
-    required CheckEquivalenceUseCase checkEquivalenceUseCase,
-    required SimulateWordUseCase simulateWordUseCase,
-    required ApplyAutoLayoutUseCase applyAutoLayoutUseCase,
-  })  : _createAutomatonUseCase = createAutomatonUseCase,
-        _addStateUseCase = addStateUseCase,
-        _nfaToDfaUseCase = nfaToDfaUseCase,
-        _minimizeDfaUseCase = minimizeDfaUseCase,
-        _completeDfaUseCase = completeDfaUseCase,
-        _regexToNfaUseCase = regexToNfaUseCase,
-        _dfaToRegexUseCase = dfaToRegexUseCase,
-        _fsaToGrammarUseCase = fsaToGrammarUseCase,
-        _checkEquivalenceUseCase = checkEquivalenceUseCase,
-        _simulateWordUseCase = simulateWordUseCase,
-        _applyAutoLayoutUseCase = applyAutoLayoutUseCase,
+    required AutomatonCreationController creationController,
+    required AutomatonSimulationController simulationController,
+    required AutomatonConversionController conversionController,
+    required AutomatonLayoutController layoutController,
+  })  : _creationController = creationController,
+        _simulationController = simulationController,
+        _conversionController = conversionController,
+        _layoutController = layoutController,
         super(const AutomatonState());
 
-  /// Creates a new automaton
   Future<void> createAutomaton({
     required String name,
     required List<String> alphabet,
   }) async {
-    state = state.copyWith(isLoading: true, error: null);
-
-    try {
-      final createResult = await _createAutomatonUseCase.execute(
-        name: name,
-        type: AutomatonType.dfa,
-        alphabet: alphabet.toSet(),
-      );
-
-      if (createResult.isFailure) {
-        state = state.copyWith(
-          isLoading: false,
-          error: createResult.error,
-        );
-        return;
-      }
-
-      var automatonEntity = createResult.data!;
-      final addInitialStateResult = await _addStateUseCase.execute(
-        automaton: automatonEntity,
-        name: 'q0',
-        x: 100,
-        y: 100,
-        isInitial: true,
-        isFinal: false,
-      );
-
-      if (addInitialStateResult.isFailure) {
-        state = state.copyWith(
-          isLoading: false,
-          error: addInitialStateResult.error,
-        );
-        return;
-      }
-
-      automatonEntity = addInitialStateResult.data!;
-
-      state = state.copyWith(
-        currentAutomaton: automatonEntityToFsa(automatonEntity),
-        isLoading: false,
-      );
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error creating automaton: $e',
-      );
-    }
-  }
-
-  /// Updates the current automaton
-  void updateAutomaton(FSA automaton) {
     state = state.copyWith(
-      currentAutomaton: automaton,
+      isLoading: true,
+      error: null,
       equivalenceResult: null,
       equivalenceDetails: null,
     );
+
+    state = await _creationController.createAutomaton(
+      state,
+      name: name,
+      alphabet: alphabet,
+    );
   }
 
-  /// Simulates the current automaton with input string
+  void updateAutomaton(FSA automaton) {
+    state = _creationController.updateAutomaton(state, automaton);
+  }
+
   Future<void> simulateAutomaton(String inputString) async {
     if (state.currentAutomaton == null) return;
 
@@ -126,33 +63,9 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _simulateWordUseCase.execute(
-        automatonEntity,
-        inputString,
-      );
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          simulationResult: result.data,
-          isLoading: false,
-        );
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error simulating automaton: $e',
-      );
-    }
+    state = await _simulationController.simulate(state, inputString);
   }
 
-  /// Converts NFA to DFA
   Future<void> convertNfaToDfa() async {
     if (state.currentAutomaton == null) return;
 
@@ -163,31 +76,9 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _nfaToDfaUseCase.execute(automatonEntity);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          currentAutomaton: automatonEntityToFsa(result.data!),
-          isLoading: false,
-          simulationResult: null,
-        );
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error converting NFA to DFA: $e',
-      );
-    }
+    state = await _conversionController.convertNfaToDfa(state);
   }
 
-  /// Minimizes DFA
   Future<void> minimizeDfa() async {
     if (state.currentAutomaton == null) return;
 
@@ -198,31 +89,9 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _minimizeDfaUseCase.execute(automatonEntity);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          currentAutomaton: automatonEntityToFsa(result.data!),
-          isLoading: false,
-          simulationResult: null,
-        );
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error minimizing DFA: $e',
-      );
-    }
+    state = await _conversionController.minimizeDfa(state);
   }
 
-  /// Completes DFA
   Future<void> completeDfa() async {
     if (state.currentAutomaton == null) return;
 
@@ -233,63 +102,17 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _completeDfaUseCase.execute(automatonEntity);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          currentAutomaton: automatonEntityToFsa(result.data!),
-          isLoading: false,
-          simulationResult: null,
-        );
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error completing DFA: $e',
-      );
-    }
+    state = await _conversionController.completeDfa(state);
   }
 
-  /// Converts FSA to Grammar
   Future<Grammar?> convertFsaToGrammar() async {
     if (state.currentAutomaton == null) return null;
 
     state = state.copyWith(isLoading: true, error: null);
-
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _fsaToGrammarUseCase.execute(automatonEntity);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          isLoading: false,
-          grammarResult: result.data,
-        );
-        return result.data;
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-        return null;
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error converting FSA to Grammar: $e',
-      );
-      return null;
-    }
+    state = await _conversionController.convertFsaToGrammar(state);
+    return state.grammarResult;
   }
 
-  /// Applies auto layout
   Future<void> applyAutoLayout() async {
     if (state.currentAutomaton == null) return;
 
@@ -300,31 +123,9 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _applyAutoLayoutUseCase.execute(automatonEntity);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          currentAutomaton: automatonEntityToFsa(result.data!),
-          isLoading: false,
-          simulationResult: null,
-        );
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error applying auto layout: $e',
-      );
-    }
+    state = await _layoutController.applyAutoLayout(state);
   }
 
-  /// Converts regex to NFA
   Future<void> convertRegexToNfa(String regex) async {
     state = state.copyWith(
       isLoading: true,
@@ -333,62 +134,17 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final result = await _regexToNfaUseCase.execute(regex);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          currentAutomaton: automatonEntityToFsa(result.data!),
-          isLoading: false,
-          simulationResult: null,
-        );
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error converting regex to NFA: $e',
-      );
-    }
+    state = await _conversionController.convertRegexToNfa(state, regex);
   }
 
-  /// Converts FA to regex
   Future<String?> convertFaToRegex() async {
     if (state.currentAutomaton == null) return null;
 
     state = state.copyWith(isLoading: true, error: null);
-
-    try {
-      final automatonEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final result = await _dfaToRegexUseCase.execute(automatonEntity);
-
-      if (result.isSuccess) {
-        state = state.copyWith(
-          regexResult: result.data,
-          isLoading: false,
-        );
-        return result.data;
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          error: result.error,
-        );
-        return null;
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        error: 'Error converting FA to regex: $e',
-      );
-      return null;
-    }
+    state = await _conversionController.convertFaToRegex(state);
+    return state.regexResult;
   }
 
-  /// Compares the current automaton with another automaton for equivalence
   Future<bool?> compareEquivalence(FSA other) async {
     if (state.currentAutomaton == null) return null;
 
@@ -399,133 +155,44 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
       equivalenceDetails: null,
     );
 
-    try {
-      final currentEntity = fsaToAutomatonEntity(state.currentAutomaton!);
-      final otherEntity = fsaToAutomatonEntity(other);
-      final result = await _checkEquivalenceUseCase.execute(
-        currentEntity,
-        otherEntity,
-      );
-
-      if (result.isSuccess) {
-        final areEquivalent = result.data!;
-        state = state.copyWith(
-          isLoading: false,
-          equivalenceResult: areEquivalent,
-          equivalenceDetails: areEquivalent
-              ? 'The automata accept the same language.'
-              : 'A distinguishing string was found between the automata.',
-        );
-        return areEquivalent;
-      } else {
-        state = state.copyWith(
-          isLoading: false,
-          equivalenceResult: null,
-          equivalenceDetails: result.error,
-          error: result.error,
-        );
-        return null;
-      }
-    } catch (e) {
-      state = state.copyWith(
-        isLoading: false,
-        equivalenceResult: null,
-        equivalenceDetails: 'Error comparing automata: $e',
-        error: 'Error comparing automata: $e',
-      );
-      return null;
-    }
+    state = await _conversionController.compareEquivalence(state, other);
+    return state.equivalenceResult;
   }
 
-  /// Clears the current automaton
   void clearAutomaton() {
-    state = state.copyWith(
-      currentAutomaton: null,
-      simulationResult: null,
-      regexResult: null,
-      grammarResult: null,
-      equivalenceResult: null,
-      equivalenceDetails: null,
-      error: null,
-    );
+    state = _creationController.clearAutomaton(state);
   }
 
-  /// Clears any error messages
   void clearError() {
-    state = state.copyWith(error: null);
-  }
-
-}
-
-/// State class for automaton provider
-class AutomatonState {
-  final FSA? currentAutomaton;
-  final sim_result.SimulationResult? simulationResult;
-  final String? regexResult;
-  final Grammar? grammarResult;
-  final bool? equivalenceResult;
-  final String? equivalenceDetails;
-  final bool isLoading;
-  final String? error;
-
-  const AutomatonState({
-    this.currentAutomaton,
-    this.simulationResult,
-    this.regexResult,
-    this.grammarResult,
-    this.equivalenceResult,
-    this.equivalenceDetails,
-    this.isLoading = false,
-    this.error,
-  });
-
-  static const _unset = Object();
-
-  AutomatonState copyWith({
-    Object? currentAutomaton = _unset,
-    Object? simulationResult = _unset,
-    Object? regexResult = _unset,
-    Object? grammarResult = _unset,
-    Object? equivalenceResult = _unset,
-    Object? equivalenceDetails = _unset,
-    bool? isLoading,
-    Object? error = _unset,
-  }) {
-    return AutomatonState(
-      currentAutomaton: currentAutomaton == _unset
-          ? this.currentAutomaton
-          : currentAutomaton as FSA?,
-      simulationResult: simulationResult == _unset
-          ? this.simulationResult
-          : simulationResult as sim_result.SimulationResult?,
-      regexResult:
-          regexResult == _unset ? this.regexResult : regexResult as String?,
-      grammarResult: grammarResult == _unset
-          ? this.grammarResult
-          : grammarResult as Grammar?,
-      equivalenceResult: equivalenceResult == _unset
-          ? this.equivalenceResult
-          : equivalenceResult as bool?,
-      equivalenceDetails: equivalenceDetails == _unset
-          ? this.equivalenceDetails
-          : equivalenceDetails as String?,
-      isLoading: isLoading ?? this.isLoading,
-      error: error == _unset ? this.error : error as String?,
-    );
+    state = _creationController.clearError(state);
   }
 }
 
-/// Provider instances
-final automatonProvider =
-    StateNotifierProvider<AutomatonProvider, AutomatonState>((ref) {
-  final automatonService = AutomatonService();
-  final automatonRepository = AutomatonRepositoryImpl(automatonService);
-  final algorithmRepository = AlgorithmRepositoryImpl();
-  final layoutRepository = LayoutRepositoryImpl();
+final _automatonServiceProvider = Provider((ref) => AutomatonService());
+final _automatonRepositoryProvider = Provider(
+  (ref) => AutomatonRepositoryImpl(ref.read(_automatonServiceProvider)),
+);
+final _algorithmRepositoryProvider = Provider((ref) => AlgorithmRepositoryImpl());
+final _layoutRepositoryProvider = Provider((ref) => LayoutRepositoryImpl());
 
-  return AutomatonProvider(
-    createAutomatonUseCase: CreateAutomatonUseCase(automatonRepository),
-    addStateUseCase: AddStateUseCase(automatonRepository),
+final automatonCreationControllerProvider = Provider((ref) {
+  final repository = ref.read(_automatonRepositoryProvider);
+  return AutomatonCreationController(
+    createAutomatonUseCase: CreateAutomatonUseCase(repository),
+    addStateUseCase: AddStateUseCase(repository),
+  );
+});
+
+final automatonSimulationControllerProvider = Provider((ref) {
+  final algorithmRepository = ref.read(_algorithmRepositoryProvider);
+  return AutomatonSimulationController(
+    simulateWordUseCase: SimulateWordUseCase(algorithmRepository),
+  );
+});
+
+final automatonConversionControllerProvider = Provider((ref) {
+  final algorithmRepository = ref.read(_algorithmRepositoryProvider);
+  return AutomatonConversionController(
     nfaToDfaUseCase: NfaToDfaUseCase(algorithmRepository),
     minimizeDfaUseCase: MinimizeDfaUseCase(algorithmRepository),
     completeDfaUseCase: CompleteDfaUseCase(algorithmRepository),
@@ -533,7 +200,27 @@ final automatonProvider =
     dfaToRegexUseCase: DfaToRegexUseCase(algorithmRepository),
     fsaToGrammarUseCase: FsaToGrammarUseCase(algorithmRepository),
     checkEquivalenceUseCase: CheckEquivalenceUseCase(algorithmRepository),
-    simulateWordUseCase: SimulateWordUseCase(algorithmRepository),
+  );
+});
+
+final automatonLayoutControllerProvider = Provider((ref) {
+  final layoutRepository = ref.read(_layoutRepositoryProvider);
+  return AutomatonLayoutController(
     applyAutoLayoutUseCase: ApplyAutoLayoutUseCase(layoutRepository),
+  );
+});
+
+final automatonProvider =
+    StateNotifierProvider<AutomatonProvider, AutomatonState>((ref) {
+  final creationController = ref.watch(automatonCreationControllerProvider);
+  final simulationController = ref.watch(automatonSimulationControllerProvider);
+  final conversionController = ref.watch(automatonConversionControllerProvider);
+  final layoutController = ref.watch(automatonLayoutControllerProvider);
+
+  return AutomatonProvider(
+    creationController: creationController,
+    simulationController: simulationController,
+    conversionController: conversionController,
+    layoutController: layoutController,
   );
 });

--- a/test/presentation/providers/automaton/automaton_conversion_controller_test.dart
+++ b/test/presentation/providers/automaton/automaton_conversion_controller_test.dart
@@ -1,0 +1,207 @@
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/entities/grammar_entity.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/core/use_cases/algorithm_use_cases.dart';
+import 'package:jflutter/core/utils/automaton_entity_mapper.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_conversion_controller.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_state.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+class _StubAlgorithmRepository extends FakeAlgorithmRepository {
+  _StubAlgorithmRepository({
+    this.nfaToDfaResult,
+    this.minimizeDfaResult,
+    this.completeDfaResult,
+    this.regexToNfaResult,
+    this.dfaToRegexResult,
+    this.fsaToGrammarResult,
+    this.equivalenceResult,
+  });
+
+  final AutomatonResult? nfaToDfaResult;
+  final AutomatonResult? minimizeDfaResult;
+  final AutomatonResult? completeDfaResult;
+  final AutomatonResult? regexToNfaResult;
+  final StringResult? dfaToRegexResult;
+  final GrammarResult? fsaToGrammarResult;
+  final BoolResult? equivalenceResult;
+
+  @override
+  Future<AutomatonResult> nfaToDfa(AutomatonEntity nfa) async {
+    if (nfaToDfaResult != null) return nfaToDfaResult!;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> minimizeDfa(AutomatonEntity dfa) async {
+    if (minimizeDfaResult != null) return minimizeDfaResult!;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> completeDfa(AutomatonEntity dfa) async {
+    if (completeDfaResult != null) return completeDfaResult!;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> regexToNfa(String regex) async {
+    if (regexToNfaResult != null) return regexToNfaResult!;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StringResult> dfaToRegex(AutomatonEntity dfa, {bool allowLambda = false}) async {
+    if (dfaToRegexResult != null) return dfaToRegexResult!;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<GrammarResult> fsaToGrammar(AutomatonEntity fsa) async {
+    if (fsaToGrammarResult != null) return fsaToGrammarResult!;
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BoolResult> areEquivalent(AutomatonEntity a, AutomatonEntity b) async {
+    if (equivalenceResult != null) return equivalenceResult!;
+    throw UnimplementedError();
+  }
+}
+
+AutomatonConversionController _buildController(_StubAlgorithmRepository repository) {
+  return AutomatonConversionController(
+    nfaToDfaUseCase: NfaToDfaUseCase(repository),
+    minimizeDfaUseCase: MinimizeDfaUseCase(repository),
+    completeDfaUseCase: CompleteDfaUseCase(repository),
+    regexToNfaUseCase: RegexToNfaUseCase(repository),
+    dfaToRegexUseCase: DfaToRegexUseCase(repository),
+    fsaToGrammarUseCase: FsaToGrammarUseCase(repository),
+    checkEquivalenceUseCase: CheckEquivalenceUseCase(repository),
+  );
+}
+
+void main() {
+  group('AutomatonConversionController', () {
+    test('convertNfaToDfa updates automaton on success', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final repository = _StubAlgorithmRepository(
+        nfaToDfaResult: Success(buildAutomatonEntity(id: 'converted')),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.convertNfaToDfa(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.error, isNull);
+      expect(updated.currentAutomaton, isNotNull);
+      expect(updated.currentAutomaton!.id, equals('converted'));
+    });
+
+    test('convertNfaToDfa stores error on failure', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final repository = _StubAlgorithmRepository(
+        nfaToDfaResult: Failure('conversion failed'),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.convertNfaToDfa(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.currentAutomaton?.id, equals(baseAutomaton.id));
+      expect(updated.error, 'conversion failed');
+    });
+
+    test('convertRegexToNfa sets current automaton', () async {
+      final repository = _StubAlgorithmRepository(
+        regexToNfaResult: Success(buildAutomatonEntity(id: 'regex')),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.convertRegexToNfa(
+        const AutomatonState(isLoading: true),
+        'a*',
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.currentAutomaton, isNotNull);
+      expect(updated.currentAutomaton!.id, equals('regex'));
+    });
+
+    test('convertFsaToGrammar stores grammar result', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final grammar = buildGrammarEntity();
+      final repository = _StubAlgorithmRepository(
+        fsaToGrammarResult: Success(grammar),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.convertFsaToGrammar(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.error, isNull);
+      expect(updated.grammarResult, equals(grammar));
+    });
+
+    test('convertFaToRegex stores regex string', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final repository = _StubAlgorithmRepository(
+        dfaToRegexResult: Success('a*'),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.convertFaToRegex(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.regexResult, 'a*');
+    });
+
+    test('compareEquivalence stores success result', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final otherAutomaton = automatonEntityToFsa(buildAutomatonEntity(id: 'other'));
+      final repository = _StubAlgorithmRepository(
+        equivalenceResult: Success(true),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.compareEquivalence(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+        otherAutomaton,
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.equivalenceResult, isTrue);
+      expect(updated.equivalenceDetails,
+          'The automata accept the same language.');
+    });
+
+    test('compareEquivalence stores failure result', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final otherAutomaton = automatonEntityToFsa(buildAutomatonEntity(id: 'other'));
+      final repository = _StubAlgorithmRepository(
+        equivalenceResult: Failure('not equivalent'),
+      );
+      final controller = _buildController(repository);
+
+      final updated = await controller.compareEquivalence(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+        otherAutomaton,
+      );
+
+      expect(updated.isLoading, isFalse);
+      expect(updated.equivalenceResult, isNull);
+      expect(updated.equivalenceDetails, 'not equivalent');
+      expect(updated.error, 'not equivalent');
+    });
+  });
+}

--- a/test/presentation/providers/automaton/automaton_creation_controller_test.dart
+++ b/test/presentation/providers/automaton/automaton_creation_controller_test.dart
@@ -1,0 +1,210 @@
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/core/use_cases/automaton_use_cases.dart';
+import 'package:jflutter/core/utils/automaton_entity_mapper.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_creation_controller.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_state.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+class _StubCreateAutomatonUseCase extends CreateAutomatonUseCase {
+  _StubCreateAutomatonUseCase(this._result)
+      : super(FakeAutomatonRepository());
+
+  final AutomatonResult Function({
+    required String name,
+    required AutomatonType type,
+    Set<String> alphabet,
+  }) _result;
+
+  @override
+  Future<AutomatonResult> execute({
+    required String name,
+    required AutomatonType type,
+    Set<String> alphabet = const {},
+  }) async {
+    return _result(name: name, type: type, alphabet: alphabet);
+  }
+}
+
+class _StubAddStateUseCase extends AddStateUseCase {
+  _StubAddStateUseCase(this._result) : super(FakeAutomatonRepository());
+
+  factory _StubAddStateUseCase.unused() {
+    return _StubAddStateUseCase(({
+      required automaton,
+      required String name,
+      required double x,
+      required double y,
+      bool isInitial = false,
+      bool isFinal = false,
+    }) {
+      throw UnimplementedError();
+    });
+  }
+
+  final AutomatonResult Function({
+    required AutomatonEntity automaton,
+    required String name,
+    required double x,
+    required double y,
+    bool isInitial,
+    bool isFinal,
+  }) _result;
+
+  @override
+  Future<AutomatonResult> execute({
+    required AutomatonEntity automaton,
+    required String name,
+    required double x,
+    required double y,
+    bool isInitial = false,
+    bool isFinal = false,
+  }) async {
+    return _result(
+      automaton: automaton,
+      name: name,
+      x: x,
+      y: y,
+      isInitial: isInitial,
+      isFinal: isFinal,
+    );
+  }
+}
+
+void main() {
+  group('AutomatonCreationController', () {
+    test('createAutomaton builds initial automaton on success', () async {
+      final createdEntity = buildAutomatonEntity();
+      final withInitialState = buildAutomatonEntity(id: 'withState');
+
+      final controller = AutomatonCreationController(
+        createAutomatonUseCase: _StubCreateAutomatonUseCase(
+          ({required name, required type, Set<String> alphabet = const {}}) =>
+              Success(createdEntity),
+        ),
+        addStateUseCase: _StubAddStateUseCase(
+          ({
+            required automaton,
+            required name,
+            required double x,
+            required double y,
+            bool isInitial = false,
+            bool isFinal = false,
+          }) =>
+              Success(withInitialState),
+        ),
+      );
+
+      final result = await controller.createAutomaton(
+        const AutomatonState(isLoading: true),
+        name: 'Test',
+        alphabet: const ['0', '1'],
+      );
+
+      expect(result.isLoading, isFalse);
+      expect(result.error, isNull);
+      expect(result.currentAutomaton, isNotNull);
+      expect(result.currentAutomaton!.states.length, equals(2));
+      expect(result.simulationResult, isNull);
+      expect(result.equivalenceResult, isNull);
+    });
+
+    test('createAutomaton propagates creation failure', () async {
+      final controller = AutomatonCreationController(
+        createAutomatonUseCase: _StubCreateAutomatonUseCase(
+          ({required name, required type, Set<String> alphabet = const {}}) =>
+              Failure('unable to create'),
+        ),
+        addStateUseCase: _StubAddStateUseCase.unused(),
+      );
+
+      final result = await controller.createAutomaton(
+        const AutomatonState(isLoading: true),
+        name: 'Test',
+        alphabet: const ['0'],
+      );
+
+      expect(result.isLoading, isFalse);
+      expect(result.error, 'unable to create');
+      expect(result.currentAutomaton, isNull);
+    });
+
+    test('createAutomaton propagates add state failure', () async {
+      final controller = AutomatonCreationController(
+        createAutomatonUseCase: _StubCreateAutomatonUseCase(
+          ({required name, required type, Set<String> alphabet = const {}}) =>
+              Success(buildAutomatonEntity()),
+        ),
+        addStateUseCase: _StubAddStateUseCase(({
+          required automaton,
+          required String name,
+          required double x,
+          required double y,
+          bool isInitial = false,
+          bool isFinal = false,
+        }) =>
+            Failure('add state failed')),
+      );
+
+      final result = await controller.createAutomaton(
+        const AutomatonState(isLoading: true),
+        name: 'Test',
+        alphabet: const [],
+      );
+
+      expect(result.isLoading, isFalse);
+      expect(result.error, 'add state failed');
+      expect(result.currentAutomaton, isNull);
+    });
+
+    test('updateAutomaton replaces automaton and clears equivalence', () {
+      final controller = AutomatonCreationController(
+        createAutomatonUseCase: _StubCreateAutomatonUseCase(({}) =>
+            throw UnimplementedError()),
+        addStateUseCase: _StubAddStateUseCase.unused(),
+      );
+
+      final automaton = controller.updateAutomaton(
+        const AutomatonState(),
+        automatonEntityToFsa(buildAutomatonEntity()),
+      );
+
+      expect(automaton.currentAutomaton, isNotNull);
+      expect(automaton.equivalenceDetails, isNull);
+      expect(automaton.equivalenceResult, isNull);
+    });
+
+    test('clear helpers reset fields', () {
+      final controller = AutomatonCreationController(
+        createAutomatonUseCase: _StubCreateAutomatonUseCase(({}) =>
+            throw UnimplementedError()),
+        addStateUseCase: _StubAddStateUseCase.unused(),
+      );
+
+      final cleared = controller.clearAutomaton(
+        const AutomatonState(
+          currentAutomaton: null,
+          simulationResult: null,
+          regexResult: 'regex',
+          grammarResult: null,
+          equivalenceResult: true,
+          equivalenceDetails: 'details',
+          error: 'err',
+        ),
+      );
+
+      expect(cleared.currentAutomaton, isNull);
+      expect(cleared.regexResult, isNull);
+      expect(cleared.equivalenceResult, isNull);
+      expect(cleared.error, isNull);
+
+      final errorCleared = controller.clearError(
+        const AutomatonState(error: 'err'),
+      );
+
+      expect(errorCleared.error, isNull);
+    });
+  });
+}

--- a/test/presentation/providers/automaton/automaton_layout_controller_test.dart
+++ b/test/presentation/providers/automaton/automaton_layout_controller_test.dart
@@ -1,0 +1,60 @@
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/core/use_cases/algorithm_use_cases.dart';
+import 'package:jflutter/core/utils/automaton_entity_mapper.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_layout_controller.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_state.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+class _StubApplyAutoLayoutUseCase extends ApplyAutoLayoutUseCase {
+  _StubApplyAutoLayoutUseCase(this._result)
+      : super(FakeLayoutRepository());
+
+  final AutomatonResult Function(AutomatonEntity automaton) _result;
+
+  @override
+  Future<AutomatonResult> execute(AutomatonEntity automaton) async {
+    return _result(automaton);
+  }
+}
+
+void main() {
+  group('AutomatonLayoutController', () {
+    test('applyAutoLayout updates automaton on success', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final updatedEntity = buildAutomatonEntity(id: 'layout');
+      final controller = AutomatonLayoutController(
+        applyAutoLayoutUseCase: _StubApplyAutoLayoutUseCase(
+          (automaton) => Success(updatedEntity),
+        ),
+      );
+
+      final updatedState = await controller.applyAutoLayout(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+      );
+
+      expect(updatedState.isLoading, isFalse);
+      expect(updatedState.error, isNull);
+      expect(updatedState.currentAutomaton?.id, 'layout');
+    });
+
+    test('applyAutoLayout stores error on failure', () async {
+      final baseAutomaton = automatonEntityToFsa(buildAutomatonEntity());
+      final controller = AutomatonLayoutController(
+        applyAutoLayoutUseCase: _StubApplyAutoLayoutUseCase(
+          (automaton) => Failure('layout error'),
+        ),
+      );
+
+      final updatedState = await controller.applyAutoLayout(
+        AutomatonState(currentAutomaton: baseAutomaton, isLoading: true),
+      );
+
+      expect(updatedState.isLoading, isFalse);
+      expect(updatedState.error, 'layout error');
+      expect(updatedState.currentAutomaton?.id, baseAutomaton.id);
+    });
+  });
+}

--- a/test/presentation/providers/automaton/automaton_simulation_controller_test.dart
+++ b/test/presentation/providers/automaton/automaton_simulation_controller_test.dart
@@ -1,0 +1,75 @@
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/models/simulation_result.dart';
+import 'package:jflutter/core/models/simulation_step.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/core/use_cases/algorithm_use_cases.dart';
+import 'package:jflutter/core/utils/automaton_entity_mapper.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_simulation_controller.dart';
+import 'package:jflutter/presentation/providers/automaton/automaton_state.dart';
+import 'package:test/test.dart';
+
+import 'test_helpers.dart';
+
+class _StubSimulateWordUseCase extends SimulateWordUseCase {
+  _StubSimulateWordUseCase(this._result)
+      : super(FakeAlgorithmRepository());
+
+  final Result<SimulationResult> Function(
+    AutomatonEntity automaton,
+    String word,
+  ) _result;
+
+  @override
+  Future<Result<SimulationResult>> execute(
+    AutomatonEntity automaton,
+    String word,
+  ) async {
+    return _result(automaton, word);
+  }
+}
+
+void main() {
+  group('AutomatonSimulationController', () {
+    test('simulate stores simulation result on success', () async {
+      final automaton = automatonEntityToFsa(buildAutomatonEntity());
+      final result = SimulationResult.success(
+        inputString: '01',
+        steps: const [SimulationStep(currentState: 'q0', remainingInput: '', stepNumber: 0)],
+        executionTime: const Duration(milliseconds: 5),
+      );
+
+      final controller = AutomatonSimulationController(
+        simulateWordUseCase: _StubSimulateWordUseCase(
+          (automaton, word) => Success(result),
+        ),
+      );
+
+      final updatedState = await controller.simulate(
+        AutomatonState(currentAutomaton: automaton, isLoading: true),
+        '01',
+      );
+
+      expect(updatedState.isLoading, isFalse);
+      expect(updatedState.simulationResult, equals(result));
+      expect(updatedState.error, isNull);
+    });
+
+    test('simulate stores error on failure', () async {
+      final automaton = automatonEntityToFsa(buildAutomatonEntity());
+      final controller = AutomatonSimulationController(
+        simulateWordUseCase: _StubSimulateWordUseCase(
+          (automaton, word) => Failure('simulation failed'),
+        ),
+      );
+
+      final updatedState = await controller.simulate(
+        AutomatonState(currentAutomaton: automaton, isLoading: true),
+        '01',
+      );
+
+      expect(updatedState.isLoading, isFalse);
+      expect(updatedState.simulationResult, isNull);
+      expect(updatedState.error, 'simulation failed');
+    });
+  });
+}

--- a/test/presentation/providers/automaton/test_helpers.dart
+++ b/test/presentation/providers/automaton/test_helpers.dart
@@ -1,0 +1,213 @@
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/entities/grammar_entity.dart';
+import 'package:jflutter/core/models/production.dart';
+import 'package:jflutter/core/models/simulation_result.dart';
+import 'package:jflutter/core/models/simulation_step.dart';
+import 'package:jflutter/core/repositories/automaton_repository.dart';
+import 'package:jflutter/core/result.dart';
+
+class FakeAutomatonRepository implements AutomatonRepository {
+  @override
+  Future<AutomatonResult> saveAutomaton(AutomatonEntity automaton) async {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> loadAutomaton(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<ListResult<AutomatonEntity>> loadAllAutomatons() {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BoolResult> deleteAutomaton(String id) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StringResult> exportAutomaton(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> importAutomaton(String jsonString) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BoolResult> validateAutomaton(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+}
+
+class FakeAlgorithmRepository implements AlgorithmRepository {
+  @override
+  Future<AutomatonResult> nfaToDfa(AutomatonEntity nfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> removeLambdaTransitions(AutomatonEntity nfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> minimizeDfa(AutomatonEntity dfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> completeDfa(AutomatonEntity dfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> complementDfa(AutomatonEntity dfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> unionDfa(AutomatonEntity a, AutomatonEntity b) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> intersectionDfa(AutomatonEntity a, AutomatonEntity b) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> differenceDfa(AutomatonEntity a, AutomatonEntity b) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> prefixClosureDfa(AutomatonEntity dfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> suffixClosureDfa(AutomatonEntity dfa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> regexToNfa(String regex) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<StringResult> dfaToRegex(AutomatonEntity dfa, {bool allowLambda = false}) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<GrammarResult> fsaToGrammar(AutomatonEntity fsa) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<BoolResult> areEquivalent(AutomatonEntity a, AutomatonEntity b) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Result<SimulationResult>> simulateWord(AutomatonEntity automaton, String word) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<Result<List<SimulationStep>>> createStepByStepSimulation(
+    AutomatonEntity automaton,
+    String word,
+  ) {
+    throw UnimplementedError();
+  }
+}
+
+class FakeLayoutRepository implements LayoutRepository {
+  @override
+  Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> applyAutoLayout(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+
+  @override
+  Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) {
+    throw UnimplementedError();
+  }
+}
+
+AutomatonEntity buildAutomatonEntity({String id = '1'}) {
+  return AutomatonEntity(
+    id: id,
+    name: 'Automaton$id',
+    alphabet: {'0', '1'},
+    states: const [
+      StateEntity(
+        id: 'q0',
+        name: 'q0',
+        x: 0,
+        y: 0,
+        isInitial: true,
+        isFinal: false,
+      ),
+      StateEntity(
+        id: 'q1',
+        name: 'q1',
+        x: 100,
+        y: 0,
+        isInitial: false,
+        isFinal: true,
+      ),
+    ],
+    transitions: const {
+      'q0|0': ['q1'],
+      'q1|1': ['q1'],
+    },
+    initialId: 'q0',
+    nextId: 2,
+    type: AutomatonType.dfa,
+  );
+}
+
+GrammarEntity buildGrammarEntity({String id = 'g1'}) {
+  return GrammarEntity(
+    id: id,
+    name: 'Grammar$id',
+    terminals: const ['a'],
+    nonTerminals: const ['S'],
+    productions: const [
+      Production(
+        id: 'p1',
+        leftSide: ['S'],
+        rightSide: ['a'],
+      ),
+    ],
+    startSymbol: 'S',
+    type: GrammarType.regular,
+  );
+}


### PR DESCRIPTION
## Summary
- split automaton management into dedicated creation, conversion, simulation, and layout controllers with shared AutomatonState
- refactor the automaton provider to orchestrate new controllers and expose Riverpod providers for each module
- add focused unit tests for each controller covering success and failure flows with helper stubs

## Testing
- `flutter test` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d1866c1b24832ea80b7ef4619e7b52