### PR TITLE
Return success from stub layout repository methods

### DIFF
--- a/test/unit/presentation/automaton_provider_large_conversion_test.dart
+++ b/test/unit/presentation/automaton_provider_large_conversion_test.dart
@@ -27,28 +27,28 @@ class _StubLayoutRepository implements LayoutRepository {
   }
 
   @override
-  Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) {
-    throw UnimplementedError();
+  Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) async {
+    return Success(_entityToReturn);
   }
 
   @override
-  Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) {
-    throw UnimplementedError();
+  Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) async {
+    return Success(_entityToReturn);
   }
 
   @override
-  Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) {
-    throw UnimplementedError();
+  Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) async {
+    return Success(_entityToReturn);
   }
 
   @override
-  Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) {
-    throw UnimplementedError();
+  Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) async {
+    return Success(_entityToReturn);
   }
 
   @override
-  Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) {
-    throw UnimplementedError();
+  Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) async {
+    return Success(_entityToReturn);
   }
 }
 


### PR DESCRIPTION
## Summary
- update the stub layout repository in the large conversion test to return Success for every layout operation, keeping the prepared entity consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d22275cf88832ebbd899e6df70361b