### PR TITLE
Add documentation to StateEditDialog

### DIFF
--- a/lib/presentation/widgets/automaton_canvas/state_edit_dialog.dart
+++ b/lib/presentation/widgets/automaton_canvas/state_edit_dialog.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 
 import '../../../core/models/state.dart' as automaton_state;
 
+/// Dialog used to edit a state's label and flags, falling back to the
+/// identifier when the name field is left empty before saving.
 class StateEditDialog extends StatefulWidget {
   final automaton_state.State state;
   final ValueChanged<automaton_state.State> onStateUpdated;
@@ -24,6 +26,8 @@ class _StateEditDialogState extends State<StateEditDialog> {
   @override
   void initState() {
     super.initState();
+    // Seed the form fields with the current state data so later updates
+    // propagate the latest values to the onStateUpdated callback.
     _nameController = TextEditingController(text: widget.state.label);
     _isInitial = widget.state.isInitial;
     _isAccepting = widget.state.isAccepting;
@@ -51,6 +55,8 @@ class _StateEditDialogState extends State<StateEditDialog> {
               ),
             ),
             const SizedBox(height: 16),
+            // Update the "initial" flag that will be forwarded when the
+            // callback receives the updated state.
             CheckboxListTile(
               contentPadding: EdgeInsets.zero,
               title: const Text('Initial state'),
@@ -58,6 +64,8 @@ class _StateEditDialogState extends State<StateEditDialog> {
               onChanged: (value) =>
                   setState(() => _isInitial = value ?? false),
             ),
+            // Update the "accepting" flag so onStateUpdated receives the
+            // latest selection when the dialog is saved.
             CheckboxListTile(
               contentPadding: EdgeInsets.zero,
               title: const Text('Accepting state'),
@@ -82,6 +90,8 @@ class _StateEditDialogState extends State<StateEditDialog> {
   }
 
   void _saveState() {
+    // Build a new state, using the ID as a fallback label, and forward it to
+    // onStateUpdated so the parent widget receives the form values.
     final updated = widget.state.copyWith(
       label: _nameController.text.trim().isEmpty
           ? widget.state.id


### PR DESCRIPTION
## Summary
- document the purpose of `StateEditDialog`, including the label fallback behavior
- add inline comments describing how state updates flow through the dialog

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2225e5e64832eb8b2f07d6561dd2a