### PR TITLE
Refactor settings page to use Riverpod view model

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,6 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'data/repositories/settings_repository_impl.dart';
+import 'data/storage/settings_storage.dart';
 import 'presentation/pages/home_page.dart';
+import 'presentation/providers/settings_providers.dart';
 import 'presentation/theme/app_theme.dart';
 
 /// Main application widget with clean architecture
@@ -10,6 +13,13 @@ class JFlutterApp extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return ProviderScope(
+      overrides: [
+        settingsRepositoryProvider.overrideWithValue(
+          const SharedPreferencesSettingsRepository(
+            storage: const SharedPreferencesSettingsStorage(),
+          ),
+        ),
+      ],
       child: MaterialApp(
         title: 'JFlutter',
         theme: AppTheme.lightTheme,

--- a/lib/presentation/providers/settings_providers.dart
+++ b/lib/presentation/providers/settings_providers.dart
@@ -1,0 +1,16 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/settings_model.dart';
+import '../../core/repositories/settings_repository.dart';
+import 'settings_view_model.dart';
+
+/// Provider for injecting the [SettingsRepository].
+final settingsRepositoryProvider = Provider<SettingsRepository>((ref) {
+  throw UnimplementedError('settingsRepositoryProvider must be overridden');
+});
+
+/// Provider exposing the [SettingsViewModel].
+final settingsViewModelProvider =
+    StateNotifierProvider<SettingsViewModel, AsyncValue<SettingsModel>>(
+  (ref) => SettingsViewModel(ref.watch(settingsRepositoryProvider)),
+);

--- a/lib/presentation/providers/settings_view_model.dart
+++ b/lib/presentation/providers/settings_view_model.dart
@@ -1,0 +1,143 @@
+import 'dart:async';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/settings_model.dart';
+import '../../core/repositories/settings_repository.dart';
+
+/// State notifier responsible for managing settings persistence and updates.
+class SettingsViewModel extends StateNotifier<AsyncValue<SettingsModel>> {
+  SettingsViewModel(this._repository)
+      : super(const AsyncValue.loading()) {
+    unawaited(load());
+  }
+
+  /// Error message displayed when loading settings fails.
+  static const String loadErrorMessage =
+      'Failed to load settings. Please try again.';
+
+  /// Error message displayed when saving settings fails.
+  static const String saveErrorMessage =
+      'Failed to save settings. Please try again.';
+
+  /// Error message displayed when resetting settings fails.
+  static const String resetErrorMessage =
+      'Failed to reset settings. Please try again.';
+
+  final SettingsRepository _repository;
+
+  /// Loads persisted settings and updates the notifier state.
+  Future<String?> load() async {
+    state = const AsyncValue.loading();
+    try {
+      final settings = await _repository.loadSettings();
+      state = AsyncValue.data(settings);
+      return null;
+    } catch (error, stackTrace) {
+      state = AsyncValue.error(error, stackTrace);
+      return loadErrorMessage;
+    }
+  }
+
+  /// Persists the current settings.
+  Future<String?> save() async {
+    final settings = state.valueOrNull;
+    if (settings == null) {
+      return saveErrorMessage;
+    }
+
+    try {
+      await _repository.saveSettings(settings);
+      return null;
+    } catch (_) {
+      return saveErrorMessage;
+    }
+  }
+
+  /// Restores settings to their default values and persists them.
+  Future<String?> reset() async {
+    const defaults = SettingsModel();
+    final previousState = state.valueOrNull;
+    state = const AsyncValue.data(defaults);
+
+    try {
+      await _repository.saveSettings(defaults);
+      return null;
+    } catch (_) {
+      if (previousState != null) {
+        state = AsyncValue.data(previousState);
+      }
+      return resetErrorMessage;
+    }
+  }
+
+  /// Updates the empty string symbol.
+  void updateEmptyStringSymbol(String value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(emptyStringSymbol: value),
+    );
+  }
+
+  /// Updates the epsilon transition symbol.
+  void updateEpsilonSymbol(String value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(epsilonSymbol: value),
+    );
+  }
+
+  /// Updates the selected theme mode.
+  void updateThemeMode(String value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(themeMode: value),
+    );
+  }
+
+  /// Toggles the grid visibility.
+  void updateShowGrid(bool value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(showGrid: value),
+    );
+  }
+
+  /// Toggles the coordinates visibility.
+  void updateShowCoordinates(bool value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(showCoordinates: value),
+    );
+  }
+
+  /// Updates the grid size.
+  void updateGridSize(double value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(gridSize: value),
+    );
+  }
+
+  /// Updates the node size.
+  void updateNodeSize(double value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(nodeSize: value),
+    );
+  }
+
+  /// Updates the font size.
+  void updateFontSize(double value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(fontSize: value),
+    );
+  }
+
+  /// Toggles autosave behaviour.
+  void updateAutoSave(bool value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(autoSave: value),
+    );
+  }
+
+  /// Toggles tooltip visibility.
+  void updateShowTooltips(bool value) {
+    state = state.whenData(
+      (settings) => settings.copyWith(showTooltips: value),
+    );
+  }
+}

--- a/lib/presentation/widgets/settings/settings_actions_card.dart
+++ b/lib/presentation/widgets/settings/settings_actions_card.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+
+class SettingsActionsCard extends StatelessWidget {
+  const SettingsActionsCard({
+    super.key,
+    required this.onSave,
+    required this.onReset,
+  });
+
+  final VoidCallback onSave;
+  final VoidCallback onReset;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton.icon(
+                onPressed: onSave,
+                icon: const Icon(Icons.save),
+                label: const Text('Save Settings'),
+                key: const ValueKey('settings_save_button'),
+              ),
+            ),
+            const SizedBox(height: 12),
+            SizedBox(
+              width: double.infinity,
+              child: OutlinedButton.icon(
+                onPressed: onReset,
+                icon: const Icon(Icons.restore),
+                label: const Text('Reset to Defaults'),
+                key: const ValueKey('settings_reset_button'),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/settings/settings_canvas_card.dart
+++ b/lib/presentation/widgets/settings/settings_canvas_card.dart
@@ -1,0 +1,193 @@
+import 'package:flutter/material.dart';
+
+class SettingsCanvasCard extends StatelessWidget {
+  const SettingsCanvasCard({
+    super.key,
+    required this.showGrid,
+    required this.showCoordinates,
+    required this.gridSize,
+    required this.nodeSize,
+    required this.fontSize,
+    required this.onShowGridChanged,
+    required this.onShowCoordinatesChanged,
+    required this.onGridSizeChanged,
+    required this.onNodeSizeChanged,
+    required this.onFontSizeChanged,
+  });
+
+  final bool showGrid;
+  final bool showCoordinates;
+  final double gridSize;
+  final double nodeSize;
+  final double fontSize;
+  final ValueChanged<bool> onShowGridChanged;
+  final ValueChanged<bool> onShowCoordinatesChanged;
+  final ValueChanged<double> onGridSizeChanged;
+  final ValueChanged<double> onNodeSizeChanged;
+  final ValueChanged<double> onFontSizeChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _SwitchSetting(
+              title: 'Show Grid',
+              subtitle: 'Display grid lines on canvas',
+              value: showGrid,
+              onChanged: onShowGridChanged,
+              switchKey: const ValueKey('settings_show_grid_switch'),
+            ),
+            const SizedBox(height: 16),
+            _SwitchSetting(
+              title: 'Show Coordinates',
+              subtitle: 'Display coordinate information',
+              value: showCoordinates,
+              onChanged: onShowCoordinatesChanged,
+              switchKey: const ValueKey('settings_show_coordinates_switch'),
+            ),
+            const SizedBox(height: 16),
+            _SliderSetting(
+              title: 'Grid Size',
+              subtitle: 'Size of grid cells',
+              value: gridSize,
+              min: 10.0,
+              max: 50.0,
+              onChanged: onGridSizeChanged,
+              sliderKey: const ValueKey('settings_grid_size_slider'),
+            ),
+            const SizedBox(height: 16),
+            _SliderSetting(
+              title: 'Node Size',
+              subtitle: 'Size of automaton nodes',
+              value: nodeSize,
+              min: 20.0,
+              max: 60.0,
+              onChanged: onNodeSizeChanged,
+              sliderKey: const ValueKey('settings_node_size_slider'),
+            ),
+            const SizedBox(height: 16),
+            _SliderSetting(
+              title: 'Font Size',
+              subtitle: 'Text size in the interface',
+              value: fontSize,
+              min: 12.0,
+              max: 20.0,
+              onChanged: onFontSizeChanged,
+              sliderKey: const ValueKey('settings_font_size_slider'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SwitchSetting extends StatelessWidget {
+  const _SwitchSetting({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+    this.switchKey,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final Key? switchKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                subtitle,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ),
+        Switch(
+          key: switchKey,
+          value: value,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}
+
+class _SliderSetting extends StatelessWidget {
+  const _SliderSetting({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.min,
+    required this.max,
+    required this.onChanged,
+    this.sliderKey,
+  });
+
+  final String title;
+  final String subtitle;
+  final double value;
+  final double min;
+  final double max;
+  final ValueChanged<double> onChanged;
+  final Key? sliderKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final divisions = ((max - min) / 5).round();
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          subtitle,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        Row(
+          children: [
+            Expanded(
+              child: Slider(
+                key: sliderKey,
+                value: value,
+                min: min,
+                max: max,
+                divisions: divisions,
+                label: value.round().toString(),
+                onChanged: onChanged,
+              ),
+            ),
+            const SizedBox(width: 16),
+            Text(
+              value.round().toString(),
+              style: const TextStyle(fontWeight: FontWeight.bold),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/settings/settings_general_card.dart
+++ b/lib/presentation/widgets/settings/settings_general_card.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+
+class SettingsGeneralCard extends StatelessWidget {
+  const SettingsGeneralCard({
+    super.key,
+    required this.autoSave,
+    required this.showTooltips,
+    required this.onAutoSaveChanged,
+    required this.onShowTooltipsChanged,
+  });
+
+  final bool autoSave;
+  final bool showTooltips;
+  final ValueChanged<bool> onAutoSaveChanged;
+  final ValueChanged<bool> onShowTooltipsChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _SwitchSetting(
+              title: 'Auto Save',
+              subtitle: 'Automatically save changes',
+              value: autoSave,
+              onChanged: onAutoSaveChanged,
+              switchKey: const ValueKey('settings_auto_save_switch'),
+            ),
+            const SizedBox(height: 16),
+            _SwitchSetting(
+              title: 'Show Tooltips',
+              subtitle: 'Display helpful tooltips',
+              value: showTooltips,
+              onChanged: onShowTooltipsChanged,
+              switchKey: const ValueKey('settings_show_tooltips_switch'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _SwitchSetting extends StatelessWidget {
+  const _SwitchSetting({
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+    this.switchKey,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final Key? switchKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                subtitle,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ),
+        Switch(
+          key: switchKey,
+          value: value,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/settings/settings_symbols_card.dart
+++ b/lib/presentation/widgets/settings/settings_symbols_card.dart
@@ -1,0 +1,129 @@
+import 'package:flutter/material.dart';
+
+class SettingsSymbolsCard extends StatelessWidget {
+  const SettingsSymbolsCard({
+    super.key,
+    required this.emptyStringSymbol,
+    required this.epsilonSymbol,
+    required this.onEmptyStringSymbolChanged,
+    required this.onEpsilonSymbolChanged,
+  });
+
+  final String emptyStringSymbol;
+  final String epsilonSymbol;
+  final ValueChanged<String> onEmptyStringSymbolChanged;
+  final ValueChanged<String> onEpsilonSymbolChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            _ChoiceGroup(
+              title: 'Empty String Symbol',
+              subtitle: 'Symbol used to represent empty string (λ or ε)',
+              currentValue: emptyStringSymbol,
+              choices: const [
+                _SettingsChoice(
+                  label: 'λ (Lambda)',
+                  value: 'λ',
+                  key: ValueKey('settings_empty_string_lambda'),
+                ),
+                _SettingsChoice(
+                  label: 'ε (Epsilon)',
+                  value: 'ε',
+                  key: ValueKey('settings_empty_string_epsilon'),
+                ),
+              ],
+              onChanged: onEmptyStringSymbolChanged,
+            ),
+            const SizedBox(height: 16),
+            _ChoiceGroup(
+              title: 'Epsilon Symbol',
+              subtitle: 'Symbol used to represent epsilon transitions',
+              currentValue: epsilonSymbol,
+              choices: const [
+                _SettingsChoice(
+                  label: 'ε (Epsilon)',
+                  value: 'ε',
+                  key: ValueKey('settings_epsilon_epsilon'),
+                ),
+                _SettingsChoice(
+                  label: 'λ (Lambda)',
+                  value: 'λ',
+                  key: ValueKey('settings_epsilon_lambda'),
+                ),
+              ],
+              onChanged: onEpsilonSymbolChanged,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ChoiceGroup extends StatelessWidget {
+  const _ChoiceGroup({
+    required this.title,
+    required this.subtitle,
+    required this.currentValue,
+    required this.choices,
+    required this.onChanged,
+  });
+
+  final String title;
+  final String subtitle;
+  final String currentValue;
+  final List<_SettingsChoice> choices;
+  final ValueChanged<String> onChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          title,
+          style: const TextStyle(fontWeight: FontWeight.bold),
+        ),
+        const SizedBox(height: 4),
+        Text(
+          subtitle,
+          style: Theme.of(context).textTheme.bodySmall,
+        ),
+        const SizedBox(height: 8),
+        Wrap(
+          spacing: 8,
+          children: choices.map((choice) {
+            return FilterChip(
+              key: choice.key,
+              label: Text(choice.label),
+              selected: choice.value == currentValue,
+              onSelected: (selected) {
+                if (selected) {
+                  onChanged(choice.value);
+                }
+              },
+            );
+          }).toList(),
+        ),
+      ],
+    );
+  }
+}
+
+class _SettingsChoice {
+  const _SettingsChoice({
+    required this.label,
+    required this.value,
+    this.key,
+  });
+
+  final String label;
+  final String value;
+  final Key? key;
+}

--- a/lib/presentation/widgets/settings/settings_theme_card.dart
+++ b/lib/presentation/widgets/settings/settings_theme_card.dart
@@ -1,0 +1,102 @@
+import 'package:flutter/material.dart';
+
+class SettingsThemeCard extends StatelessWidget {
+  const SettingsThemeCard({
+    super.key,
+    required this.themeMode,
+    required this.onThemeModeChanged,
+  });
+
+  final String themeMode;
+  final ValueChanged<String> onThemeModeChanged;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Theme Mode',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 4),
+            Text(
+              'Choose your preferred theme',
+              style: Theme.of(context).textTheme.bodySmall,
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: const [
+                _ThemeOption(
+                  label: 'System',
+                  value: 'system',
+                  key: ValueKey('settings_theme_system'),
+                ),
+                _ThemeOption(
+                  label: 'Light',
+                  value: 'light',
+                  key: ValueKey('settings_theme_light'),
+                ),
+                _ThemeOption(
+                  label: 'Dark',
+                  value: 'dark',
+                  key: ValueKey('settings_theme_dark'),
+                ),
+              ]
+                  .map(
+                    (option) => _ThemeFilterChip(
+                      option: option,
+                      isSelected: option.value == themeMode,
+                      onSelected: onThemeModeChanged,
+                    ),
+                  )
+                  .toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ThemeOption {
+  const _ThemeOption({
+    required this.label,
+    required this.value,
+    this.key,
+  });
+
+  final String label;
+  final String value;
+  final Key? key;
+}
+
+class _ThemeFilterChip extends StatelessWidget {
+  const _ThemeFilterChip({
+    required this.option,
+    required this.isSelected,
+    required this.onSelected,
+  });
+
+  final _ThemeOption option;
+  final bool isSelected;
+  final ValueChanged<String> onSelected;
+
+  @override
+  Widget build(BuildContext context) {
+    return FilterChip(
+      key: option.key,
+      label: Text(option.label),
+      selected: isSelected,
+      onSelected: (selected) {
+        if (selected) {
+          onSelected(option.value);
+        }
+      },
+    );
+  }
+}

--- a/test/presentation/providers/settings_view_model_test.dart
+++ b/test/presentation/providers/settings_view_model_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/core/models/settings_model.dart';
+import 'package:jflutter/core/repositories/settings_repository.dart';
+import 'package:jflutter/presentation/providers/settings_providers.dart';
+import 'package:jflutter/presentation/providers/settings_view_model.dart';
+
+void main() {
+  late FakeSettingsRepository repository;
+  late ProviderContainer container;
+
+  setUp(() {
+    repository = FakeSettingsRepository();
+    container = ProviderContainer(
+      overrides: [
+        settingsRepositoryProvider.overrideWithValue(repository),
+      ],
+    );
+    addTearDown(container.dispose);
+  });
+
+  test('load populates state with repository values', () async {
+    repository.settingsToLoad = const SettingsModel(themeMode: 'dark');
+
+    await container.read(settingsViewModelProvider.notifier).load();
+    final state = container.read(settingsViewModelProvider);
+
+    expect(state.asData?.value, equals(repository.settingsToLoad));
+  });
+
+  test('save persists current settings', () async {
+    await container.read(settingsViewModelProvider.notifier).load();
+    final viewModel = container.read(settingsViewModelProvider.notifier);
+
+    viewModel.updateThemeMode('dark');
+    final message = await viewModel.save();
+
+    expect(message, isNull);
+    expect(repository.savedSettings?.themeMode, equals('dark'));
+  });
+
+  test('save returns error message when repository throws', () async {
+    await container.read(settingsViewModelProvider.notifier).load();
+    repository.throwOnSave = true;
+
+    final message = await container.read(settingsViewModelProvider.notifier).save();
+
+    expect(message, SettingsViewModel.saveErrorMessage);
+  });
+
+  test('reset restores defaults and persists them', () async {
+    repository.settingsToLoad = const SettingsModel(themeMode: 'light', showGrid: false);
+    await container.read(settingsViewModelProvider.notifier).load();
+    repository.throwOnSave = false;
+
+    final message = await container.read(settingsViewModelProvider.notifier).reset();
+    final state = container.read(settingsViewModelProvider);
+
+    expect(message, isNull);
+    expect(state.asData?.value, const SettingsModel());
+    expect(repository.savedSettings, const SettingsModel());
+  });
+
+  test('reset returns error message and restores previous state when save fails', () async {
+    repository.settingsToLoad = const SettingsModel(themeMode: 'light', showGrid: false);
+    await container.read(settingsViewModelProvider.notifier).load();
+    final viewModel = container.read(settingsViewModelProvider.notifier);
+    viewModel.updateThemeMode('dark');
+    repository.throwOnSave = true;
+
+    final message = await viewModel.reset();
+    final state = container.read(settingsViewModelProvider);
+
+    expect(message, SettingsViewModel.resetErrorMessage);
+    expect(state.asData?.value.themeMode, equals('dark'));
+  });
+
+  test('load returns error message when repository throws', () async {
+    repository.throwOnLoad = true;
+
+    final message = await container.read(settingsViewModelProvider.notifier).load();
+    final state = container.read(settingsViewModelProvider);
+
+    expect(message, SettingsViewModel.loadErrorMessage);
+    expect(state.hasError, isTrue);
+  });
+
+  test('field updates modify the current settings state', () async {
+    await container.read(settingsViewModelProvider.notifier).load();
+    final viewModel = container.read(settingsViewModelProvider.notifier);
+
+    viewModel
+      ..updateEmptyStringSymbol('ε')
+      ..updateEpsilonSymbol('λ')
+      ..updateThemeMode('dark')
+      ..updateShowGrid(false)
+      ..updateShowCoordinates(true)
+      ..updateGridSize(30)
+      ..updateNodeSize(45)
+      ..updateFontSize(18)
+      ..updateAutoSave(false)
+      ..updateShowTooltips(false);
+
+    final settings = container.read(settingsViewModelProvider).asData?.value;
+
+    expect(settings, isNotNull);
+    expect(settings?.emptyStringSymbol, equals('ε'));
+    expect(settings?.epsilonSymbol, equals('λ'));
+    expect(settings?.themeMode, equals('dark'));
+    expect(settings?.showGrid, isFalse);
+    expect(settings?.showCoordinates, isTrue);
+    expect(settings?.gridSize, equals(30));
+    expect(settings?.nodeSize, equals(45));
+    expect(settings?.fontSize, equals(18));
+    expect(settings?.autoSave, isFalse);
+    expect(settings?.showTooltips, isFalse);
+  });
+}
+
+class FakeSettingsRepository implements SettingsRepository {
+  FakeSettingsRepository({SettingsModel? initial})
+      : settingsToLoad = initial ?? const SettingsModel();
+
+  SettingsModel settingsToLoad;
+  SettingsModel? savedSettings;
+  bool throwOnLoad = false;
+  bool throwOnSave = false;
+
+  @override
+  Future<SettingsModel> loadSettings() async {
+    if (throwOnLoad) {
+      throw Exception('Failed to load');
+    }
+    return settingsToLoad;
+  }
+
+  @override
+  Future<void> saveSettings(SettingsModel settings) async {
+    if (throwOnSave) {
+      throw Exception('Failed to save');
+    }
+    savedSettings = settings;
+  }
+}

--- a/test/widget/settings_page_test.dart
+++ b/test/widget/settings_page_test.dart
@@ -1,8 +1,11 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
+import 'package:jflutter/data/repositories/settings_repository_impl.dart';
 import 'package:jflutter/data/storage/settings_storage.dart';
 import 'package:jflutter/presentation/pages/settings_page.dart';
+import 'package:jflutter/presentation/providers/settings_providers.dart';
 
 void main() {
   testWidgets('loads settings from stored preferences', (WidgetTester tester) async {
@@ -19,7 +22,7 @@ void main() {
       'settings_font_size': 16.0,
     });
 
-    await tester.pumpWidget(MaterialApp(home: SettingsPage(storage: storage)));
+    await _pumpSettingsPage(tester, storage);
     await tester.pumpAndSettle();
 
     final emptyStringChip = tester.widget<FilterChip>(
@@ -51,7 +54,7 @@ void main() {
   testWidgets('saves settings and restores them on next load', (WidgetTester tester) async {
     final storage = InMemorySettingsStorage();
 
-    await tester.pumpWidget(MaterialApp(home: SettingsPage(storage: storage)));
+    await _pumpSettingsPage(tester, storage);
     await tester.pumpAndSettle();
 
     await tester.tap(find.byKey(const ValueKey('settings_show_grid_switch')));
@@ -73,7 +76,7 @@ void main() {
     await tester.pumpWidget(const SizedBox.shrink());
     await tester.pump();
 
-    await tester.pumpWidget(MaterialApp(home: SettingsPage(storage: storage)));
+    await _pumpSettingsPage(tester, storage);
     await tester.pumpAndSettle();
 
     final reloadedGridSwitch = tester.widget<Switch>(
@@ -96,4 +99,20 @@ void main() {
     );
     expect(reloadedThemeChip.selected, isTrue);
   });
+}
+
+Future<void> _pumpSettingsPage(
+  WidgetTester tester,
+  SettingsStorage storage,
+) {
+  return tester.pumpWidget(
+    ProviderScope(
+      overrides: [
+        settingsRepositoryProvider.overrideWithValue(
+          SharedPreferencesSettingsRepository(storage: storage),
+        ),
+      ],
+      child: const MaterialApp(home: SettingsPage()),
+    ),
+  );
 }


### PR DESCRIPTION
## Summary
- add a SettingsViewModel state notifier and provider overrides for injecting the settings repository
- refactor the settings page to consume the notifier, extract UI cards, and remove direct SharedPreferences wiring
- cover the new logic with unit tests and update widget tests to use the provider-based setup

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68d2224dca80832e96e82a6b6672b684