### PR TITLE
Add TM metrics controller and refactor TM page layout

### DIFF
--- a/lib/presentation/providers/tm_metrics_controller.dart
+++ b/lib/presentation/providers/tm_metrics_controller.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../../core/models/tm.dart';
+import 'tm_editor_provider.dart';
+
+/// Holds computed metrics about the current TM being edited.
+class TmMetricsState {
+  /// Latest TM produced by the editor.
+  final TM? tm;
+
+  /// Total number of states present in the TM.
+  final int stateCount;
+
+  /// Total number of transitions present in the TM.
+  final int transitionCount;
+
+  /// Unique tape symbols discovered across transitions.
+  final Set<String> tapeSymbols;
+
+  /// Move directions used in transitions.
+  final Set<String> moveDirections;
+
+  /// Identifiers of transitions that are part of nondeterministic choices.
+  final Set<String> nondeterministicTransitionIds;
+
+  /// Whether the TM declares an initial state.
+  final bool hasInitialState;
+
+  /// Whether the TM has at least one accepting state.
+  final bool hasAcceptingState;
+
+  TmMetricsState({
+    this.tm,
+    this.stateCount = 0,
+    this.transitionCount = 0,
+    Set<String> tapeSymbols = const <String>{},
+    Set<String> moveDirections = const <String>{},
+    Set<String> nondeterministicTransitionIds = const <String>{},
+    this.hasInitialState = false,
+    this.hasAcceptingState = false,
+  })  : tapeSymbols = Set.unmodifiable(tapeSymbols),
+        moveDirections = Set.unmodifiable(moveDirections),
+        nondeterministicTransitionIds =
+            Set.unmodifiable(nondeterministicTransitionIds);
+
+  /// Whether there is any TM currently available.
+  bool get hasMachine => tm != null && stateCount > 0;
+
+  /// Whether the TM is ready to be simulated.
+  bool get isMachineReady => hasMachine && hasInitialState && hasAcceptingState;
+}
+
+/// Manages the TM metrics derived from the editor provider.
+class TmMetricsController extends StateNotifier<TmMetricsState> {
+  TmMetricsController() : super(TmMetricsState());
+
+  /// Updates the metrics based on the latest editor state.
+  void updateFromEditor(TMEditorState editorState) {
+    final tm = editorState.tm;
+    if (tm == null) {
+      state = TmMetricsState();
+      return;
+    }
+
+    final transitions = tm.tmTransitions;
+    final moveDirections = editorState.moveDirections
+        .map((direction) => direction.toUpperCase())
+        .toSet();
+
+    state = TmMetricsState(
+      tm: tm,
+      stateCount: tm.states.length,
+      transitionCount: transitions.length,
+      tapeSymbols: editorState.tapeSymbols,
+      moveDirections: moveDirections,
+      nondeterministicTransitionIds: editorState.nondeterministicTransitionIds,
+      hasInitialState: tm.initialState != null,
+      hasAcceptingState: tm.acceptingStates.isNotEmpty,
+    );
+  }
+}
+
+/// Provider exposing the TM metrics controller synchronized with the editor.
+final tmMetricsControllerProvider =
+    StateNotifierProvider<TmMetricsController, TmMetricsState>((ref) {
+  final controller = TmMetricsController();
+  ref.listen<TMEditorState>(
+    tmEditorProvider,
+    (_, next) => controller.updateFromEditor(next),
+    fireImmediately: true,
+  );
+  return controller;
+});

--- a/lib/presentation/widgets/tm/tm_action_bar.dart
+++ b/lib/presentation/widgets/tm/tm_action_bar.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+
+/// Action bar used in the TM mobile layout to expose bottom sheet shortcuts.
+class TMActionBar extends StatelessWidget {
+  final VoidCallback onOpenSimulation;
+  final VoidCallback onOpenAlgorithms;
+  final VoidCallback onOpenMetrics;
+  final bool isMachineReady;
+  final bool hasMachine;
+
+  const TMActionBar({
+    super.key,
+    required this.onOpenSimulation,
+    required this.onOpenAlgorithms,
+    required this.onOpenMetrics,
+    required this.isMachineReady,
+    required this.hasMachine,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      child: Row(
+        children: [
+          Expanded(
+            child: _buildActionButton(
+              icon: Icons.play_arrow,
+              label: 'Simulate',
+              isEnabled: isMachineReady,
+              onPressed: onOpenSimulation,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _buildActionButton(
+              icon: Icons.auto_awesome,
+              label: 'Algorithms',
+              isEnabled: hasMachine,
+              onPressed: onOpenAlgorithms,
+            ),
+          ),
+          const SizedBox(width: 8),
+          Expanded(
+            child: _buildActionButton(
+              icon: Icons.bar_chart,
+              label: 'Metrics',
+              onPressed: onOpenMetrics,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildActionButton({
+    required IconData icon,
+    required String label,
+    required VoidCallback onPressed,
+    bool isEnabled = true,
+  }) {
+    return ElevatedButton.icon(
+      onPressed: isEnabled ? onPressed : null,
+      icon: Icon(icon, size: 16),
+      label: Text(label, style: const TextStyle(fontSize: 11)),
+      style: ElevatedButton.styleFrom(
+        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 8),
+        minimumSize: Size.zero,
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/tm/tm_desktop_layout.dart
+++ b/lib/presentation/widgets/tm/tm_desktop_layout.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+import '../../providers/tm_metrics_controller.dart';
+import '../../widgets/tm_algorithm_panel.dart';
+import '../../widgets/tm_canvas.dart';
+import '../../widgets/tm_simulation_panel.dart';
+import 'tm_metrics_panel.dart';
+
+/// Layout arrangement for TM editing on wide screens.
+class TMDesktopLayout extends StatelessWidget {
+  final GlobalKey canvasKey;
+  final TmMetricsState metrics;
+
+  const TMDesktopLayout({
+    super.key,
+    required this.canvasKey,
+    required this.metrics,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          flex: 2,
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            child: TMCanvas(
+              canvasKey: canvasKey,
+            ),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          flex: 1,
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            child: const TMSimulationPanel(),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Expanded(
+          flex: 1,
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            child: const TMAlgorithmPanel(),
+          ),
+        ),
+        const SizedBox(width: 16),
+        Flexible(
+          child: Container(
+            margin: const EdgeInsets.all(8),
+            child: TMMetricsPanel(metrics: metrics),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/tm/tm_metrics_panel.dart
+++ b/lib/presentation/widgets/tm/tm_metrics_panel.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../providers/tm_metrics_controller.dart';
+
+/// Panel displaying aggregated information about the current TM.
+class TMMetricsPanel extends StatelessWidget {
+  final TmMetricsState metrics;
+
+  const TMMetricsPanel({
+    super.key,
+    required this.metrics,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Turing Machine Overview',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Monitor the structure of your machine and resolve issues before running simulations or algorithms.',
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          _buildInfoRow('States', '${metrics.stateCount}', theme),
+          _buildInfoRow('Transitions', '${metrics.transitionCount}', theme),
+          _buildInfoRow('Tape Symbols', _formatSet(metrics.tapeSymbols), theme),
+          _buildInfoRow('Move Directions', _formatSet(metrics.moveDirections), theme),
+          _buildInfoRow(
+            'Initial State',
+            metrics.hasInitialState ? 'Yes' : 'No',
+            theme,
+          ),
+          _buildInfoRow(
+            'Accepting State',
+            metrics.hasAcceptingState ? 'Yes' : 'No',
+            theme,
+          ),
+          _buildInfoRow(
+            'Simulation Ready',
+            metrics.isMachineReady ? 'Yes' : 'No',
+            theme,
+          ),
+          _buildInfoRow(
+            'Nondeterministic Transitions',
+            metrics.nondeterministicTransitionIds.isEmpty
+                ? '0'
+                : '${metrics.nondeterministicTransitionIds.length}',
+            theme,
+          ),
+          if (metrics.nondeterministicTransitionIds.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(
+              'Resolve nondeterminism before running deterministic algorithms.',
+              style: theme.textTheme.bodySmall?.copyWith(
+                color: theme.colorScheme.error,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildInfoRow(String label, String value, ThemeData theme) {
+    final textStyle = theme.textTheme.bodyMedium;
+    final emphasizedStyle = textStyle?.copyWith(fontWeight: FontWeight.w600);
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Text(
+        '$label: $value',
+        style: emphasizedStyle,
+      ),
+    );
+  }
+
+  String _formatSet(Set<String> values) {
+    if (values.isEmpty) {
+      return '-';
+    }
+    final sorted = values.toList()..sort();
+    return sorted.join(', ');
+  }
+}

--- a/lib/presentation/widgets/tm/tm_mobile_layout.dart
+++ b/lib/presentation/widgets/tm/tm_mobile_layout.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../../widgets/tm_canvas.dart';
+import 'tm_action_bar.dart';
+
+/// Layout used for TM editing on small screens.
+class TMMobileLayout extends StatelessWidget {
+  final GlobalKey canvasKey;
+  final VoidCallback onOpenSimulation;
+  final VoidCallback onOpenAlgorithms;
+  final VoidCallback onOpenMetrics;
+  final bool isMachineReady;
+  final bool hasMachine;
+
+  const TMMobileLayout({
+    super.key,
+    required this.canvasKey,
+    required this.onOpenSimulation,
+    required this.onOpenAlgorithms,
+    required this.onOpenMetrics,
+    required this.isMachineReady,
+    required this.hasMachine,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return SafeArea(
+      child: Column(
+        children: [
+          TMActionBar(
+            onOpenSimulation: onOpenSimulation,
+            onOpenAlgorithms: onOpenAlgorithms,
+            onOpenMetrics: onOpenMetrics,
+            isMachineReady: isMachineReady,
+            hasMachine: hasMachine,
+          ),
+          Expanded(
+            child: Padding(
+              padding: const EdgeInsets.all(8),
+              child: TMCanvas(
+                canvasKey: canvasKey,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/tm_canvas.dart
+++ b/lib/presentation/widgets/tm_canvas.dart
@@ -16,12 +16,12 @@ import 'touch_gesture_handler.dart';
 /// Interactive canvas for drawing and editing Turing Machines
 class TMCanvas extends ConsumerStatefulWidget {
   final GlobalKey canvasKey;
-  final ValueChanged<TM> onTMModified;
+  final ValueChanged<TM>? onTMModified;
 
   const TMCanvas({
     super.key,
     required this.canvasKey,
-    required this.onTMModified,
+    this.onTMModified,
   });
 
   @override
@@ -315,8 +315,9 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
       transitions: List<TMTransition>.unmodifiable(_transitions),
     );
 
-    if (tm != null) {
-      widget.onTMModified(tm);
+    final callback = widget.onTMModified;
+    if (tm != null && callback != null) {
+      callback(tm);
     }
   }
 

--- a/test/unit/presentation/providers/tm_metrics_controller_test.dart
+++ b/test/unit/presentation/providers/tm_metrics_controller_test.dart
@@ -1,0 +1,105 @@
+import 'dart:math' as math;
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+import 'package:jflutter/presentation/providers/tm_metrics_controller.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  group('TmMetricsController', () {
+    test('exposes empty metrics when editor has no TM', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final metrics = container.read(tmMetricsControllerProvider);
+
+      expect(metrics.hasMachine, isFalse);
+      expect(metrics.isMachineReady, isFalse);
+      expect(metrics.stateCount, 0);
+      expect(metrics.transitionCount, 0);
+      expect(metrics.tapeSymbols, isEmpty);
+    });
+
+    test('updates metrics when editor state changes', () {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final tm = _buildSampleTM();
+      final notifier = container.read(tmEditorProvider.notifier);
+
+      notifier.state = TMEditorState(
+        tm: tm,
+        tapeSymbols: {'B', 'a'},
+        moveDirections: {'right'},
+        nondeterministicTransitionIds: {'t0'},
+      );
+
+      final metrics = container.read(tmMetricsControllerProvider);
+
+      expect(metrics.tm, same(tm));
+      expect(metrics.stateCount, 2);
+      expect(metrics.transitionCount, 1);
+      expect(metrics.tapeSymbols, unorderedEquals(['B', 'a']));
+      expect(metrics.moveDirections, contains('RIGHT'));
+      expect(metrics.hasMachine, isTrue);
+      expect(metrics.isMachineReady, isTrue);
+      expect(metrics.nondeterministicTransitionIds, contains('t0'));
+
+      notifier.state = const TMEditorState();
+      final cleared = container.read(tmMetricsControllerProvider);
+      expect(cleared.hasMachine, isFalse);
+      expect(cleared.stateCount, 0);
+    });
+  });
+}
+
+TM _buildSampleTM() {
+  final initialState = automaton_state.State(
+    id: 'q0',
+    label: 'q0',
+    position: Vector2.zero(),
+    isInitial: true,
+  );
+
+  final acceptingState = automaton_state.State(
+    id: 'q1',
+    label: 'q1',
+    position: Vector2(150, 0),
+    isAccepting: true,
+  );
+
+  final transition = TMTransition(
+    id: 't0',
+    fromState: initialState,
+    toState: acceptingState,
+    label: 'a',
+    readSymbol: 'a',
+    writeSymbol: 'a',
+    direction: TapeDirection.right,
+  );
+
+  const bounds = math.Rectangle<double>(0, 0, 400, 400);
+  final now = DateTime(2024, 1, 1);
+
+  return TM(
+    id: 'test',
+    name: 'Test TM',
+    states: {initialState, acceptingState},
+    transitions: {transition},
+    alphabet: {'a'},
+    initialState: initialState,
+    acceptingStates: {acceptingState},
+    created: now,
+    modified: now,
+    bounds: bounds,
+    tapeAlphabet: {'B', 'a'},
+    blankSymbol: 'B',
+    tapeCount: 1,
+    zoomLevel: 1,
+    panOffset: Vector2.zero(),
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated TM metrics controller that listens to the editor provider and exposes derived readiness data
- refactor TMPage into modular layouts/widgets powered by the metrics provider
- add unit and widget coverage for the new controller-driven workflow

## Testing
- Attempted to run `flutter test` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d2224a344c832eb773a2af7c96fe44