### PR TITLE
Escape SVG text values

### DIFF
--- a/lib/data/services/file_operations_service.dart
+++ b/lib/data/services/file_operations_service.dart
@@ -340,7 +340,7 @@ class FileOperationsService {
       final midX = (from.dx + to.dx) / 2;
       final midY = (from.dy + to.dy) / 2;
       buffer.writeln(
-        '  <text x="$midX" y="$midY" text-anchor="middle" font-family="Arial" font-size="12" fill="${_colorToHex(_kTextColor)}">${transition.label}</text>',
+        '  <text x="$midX" y="$midY" text-anchor="middle" font-family="Arial" font-size="12" fill="${_colorToHex(_kTextColor)}">${_escapeXml(transition.label)}</text>',
       );
     }
 
@@ -352,12 +352,21 @@ class FileOperationsService {
         '  <circle cx="$x" cy="$y" r="$_kStateRadius" fill="${_colorToHex(state.fillColor)}" stroke="${_colorToHex(state.strokeColor)}" stroke-width="${state.strokeWidth}"/>',
       );
       buffer.writeln(
-        '  <text x="$x" y="${y + 5}" text-anchor="middle" font-family="Arial" font-size="14" fill="${_colorToHex(_kTextColor)}">${state.label}</text>',
+        '  <text x="$x" y="${y + 5}" text-anchor="middle" font-family="Arial" font-size="14" fill="${_colorToHex(_kTextColor)}">${_escapeXml(state.label)}</text>',
       );
     }
 
     buffer.writeln('</svg>');
     return buffer.toString();
+  }
+
+  String _escapeXml(String value) {
+    return value
+        .replaceAll('&', '&amp;')
+        .replaceAll('<', '&lt;')
+        .replaceAll('>', '&gt;')
+        .replaceAll('"', '&quot;')
+        .replaceAll("'", '&apos;');
   }
 
   _AutomatonDrawingData _prepareDrawingData(FSA automaton) {

--- a/test/data/services/file_operations_service_svg_test.dart
+++ b/test/data/services/file_operations_service_svg_test.dart
@@ -1,0 +1,86 @@
+import 'dart:io';
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/data/services/file_operations_service.dart';
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FileOperationsService SVG export', () {
+    late Directory tempDir;
+    late FileOperationsService service;
+    late FSA automatonWithSpecialChars;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('svg_escape_test');
+      service = FileOperationsService();
+
+      const stateLabel = "S &<>\"'";
+      const transitionSymbol = "a&<>\"'";
+
+      final initialState = automaton_state.State(
+        id: 's0',
+        label: stateLabel,
+        position: Vector2(100, 100),
+        isInitial: true,
+      );
+
+      final acceptingState = automaton_state.State(
+        id: 's1',
+        label: 'accept',
+        position: Vector2(200, 100),
+        isAccepting: true,
+      );
+
+      final transition = FSATransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        label: transitionSymbol,
+        inputSymbols: {transitionSymbol},
+      );
+
+      automatonWithSpecialChars = FSA(
+        id: 'special_chars_automaton',
+        name: 'SpecialChars',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {transitionSymbol},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        bounds: const math.Rectangle(0, 0, 400, 300),
+        created: DateTime.now(),
+        modified: DateTime.now(),
+      );
+    });
+
+    tearDown(() async {
+      if (await tempDir.exists()) {
+        await tempDir.delete(recursive: true);
+      }
+    });
+
+    test('escapes special characters in SVG text nodes', () async {
+      final filePath = '${tempDir.path}/special_chars.svg';
+      final result = await service.exportAutomatonToSVG(
+        automatonWithSpecialChars,
+        filePath,
+      );
+
+      expect(result.isSuccess, isTrue, reason: result.error);
+
+      final svgContent = await File(filePath).readAsString();
+
+      expect(svgContent, contains('S &amp;&lt;&gt;&quot;&apos;'));
+      expect(svgContent, contains('a&amp;&lt;&gt;&quot;&apos;'));
+      expect(svgContent, contains('&apos;'));
+      expect(svgContent, isNot(contains('S &<')));
+      expect(svgContent, isNot(contains('a&<')));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- escape user-provided SVG text content using a dedicated XML escaping helper
- cover special-character labels with a new SVG export unit test

## Testing
- flutter test test/data/services/file_operations_service_svg_test.dart *(fails: `flutter` command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d26e5c56e4832eb0d488b2a2218867