### PR TITLE
Ensure TM canvas transition updates check mounted state

### DIFF
--- a/lib/presentation/widgets/tm_canvas.dart
+++ b/lib/presentation/widgets/tm_canvas.dart
@@ -237,10 +237,9 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
     );
 
     final result = await _showTransitionDialog(initialTransition);
+    if (!mounted) return;
     if (result == null) {
-      setState(() {
-        _isAddingTransition = false;
-      });
+      _clearAddingTransitionFlag();
       return;
     }
 
@@ -254,8 +253,8 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
           label: label,
         ),
       );
-      _isAddingTransition = false;
     });
+    _clearAddingTransitionFlag();
     _notifyEditor();
   }
 
@@ -267,6 +266,7 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
     if (transition is! TMTransition) return;
 
     final result = await _showTransitionDialog(transition);
+    if (!mounted) return;
     if (result == null) return;
 
     setState(() {
@@ -276,6 +276,14 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
       }
     });
     _notifyEditor();
+  }
+
+  void _clearAddingTransitionFlag() {
+    if (!mounted) return;
+    if (!_isAddingTransition) return;
+    setState(() {
+      _isAddingTransition = false;
+    });
   }
 
   void _deleteState(automaton_state.State state) {


### PR DESCRIPTION
## Summary
- guard TM transition addition against setState after the widget is unmounted
- add a helper to safely clear the add-transition flag without calling setState when unmounted
- apply the same mounted check to transition edits before mutating state

## Testing
- `flutter analyze` *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d26e5654d4832eb0e0dc1565e3ee65