### PR TITLE
Track TM editor listener subscription

### DIFF
--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
+import '../providers/tm_editor_provider.dart';
 import '../providers/tm_metrics_controller.dart';
 import '../widgets/tm/tm_desktop_layout.dart';
 import '../widgets/tm/tm_metrics_panel.dart';
@@ -18,6 +19,25 @@ class TMPage extends ConsumerStatefulWidget {
 
 class _TMPageState extends ConsumerState<TMPage> {
   final GlobalKey _canvasKey = GlobalKey();
+  ProviderSubscription<TMEditorState>? _subscription;
+
+  @override
+  void initState() {
+    super.initState();
+    _subscription?.close();
+    _subscription = ref.listen<TMEditorState>(
+      tmEditorProvider,
+      (_, next) =>
+          ref.read(tmMetricsControllerProvider.notifier).updateFromEditor(next),
+      fireImmediately: true,
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- add a ProviderSubscription field to `_TMPageState` and initialize it from the existing `ref.listen` registration
- close the subscription on dispose to avoid leaks and guard against reassignment by closing any existing listener first

## Testing
- not run (flutter toolchain unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68d26e54657c832e9a9de3dcd7d51383