### PR TITLE
docs: registrar decisoes recentes nos research logs

### DIFF
--- a/specs/002-title-mobile-optimized/research.md
+++ b/specs/002-title-mobile-optimized/research.md
@@ -94,7 +94,7 @@ This research addresses the technical decisions needed to port JFLAP's core auto
 - Icon-only: Requires learning curve
 
 ### 8. Algorithm Porting Strategy
-**Decision**: Direct port of Java algorithms to Dart with Flutter-specific optimizations  
+**Decision**: Direct port of Java algorithms to Dart with Flutter-specific optimizations
 **Rationale**:
 - Maintains functional consistency with original JFLAP
 - Leverages existing algorithmic logic
@@ -105,19 +105,108 @@ This research addresses the technical decisions needed to port JFLAP's core auto
 - WebAssembly port: Unnecessary complexity
 - Hybrid approach: Inconsistent user experience
 
+### 9. File Operations Lifecycle Safeguards
+**Decision**: Gate file actions behind loading flags and `mounted` checks while surfacing contextual snackbars when the platform denies file access or when operations succeed/fail.
+**Rationale**:
+- Prevents crashes from `setState` calls after widget disposal in asynchronous dialogs, resolving the risk highlighted in regressions where the panel stayed mounted during file pickers.【F:lib/presentation/widgets/file_operations_panel.dart†L118-L200】【F:lib/presentation/widgets/file_operations_panel.dart†L313-L335】
+- Disabling buttons during network/disk work avoids duplicate submissions and clarifies the current state to the user via explicit success/failure messaging.【F:lib/presentation/widgets/file_operations_panel.dart†L118-L200】【F:lib/presentation/widgets/file_operations_panel.dart†L313-L335】
+- Communicates environment limitations (e.g., sandboxed file pickers) through snackbars, reducing silent failures.【F:lib/presentation/widgets/file_operations_panel.dart†L174-L195】
+**Alternatives considered**:
+- Leave the previous optimistic UI without guards (risk: `setState` after dispose and double submissions).
+- Move file handling to a global provider and stream back results (adds latency and complexity without immediate UX gains).
+- Block the UI with modal progress dialogs (heavier interaction cost for quick file saves/loads).
+
+### 10. TM Metrics Subscription Management
+**Decision**: Register a scoped `ProviderSubscription` in `initState` that feeds the metrics controller immediately and dispose it with the widget lifecycle.
+**Rationale**:
+- Ensures metrics-dependent sheets (simulation, algorithms, metrics) receive up-to-date readiness flags as soon as the page loads, mitigating stale data risks seen when listeners were rebuilt ad hoc.【F:lib/presentation/pages/tm_page.dart†L20-L117】
+- Explicitly closing the subscription during disposal guards against memory leaks or background updates after leaving the page, which was a reported stability risk for long editing sessions.【F:lib/presentation/pages/tm_page.dart†L20-L40】
+- Reusing the listener allows mobile layouts to keep FAB entry points responsive without duplicating Riverpod consumers per sheet.【F:lib/presentation/pages/tm_page.dart†L48-L117】
+**Alternatives considered**:
+- Call `ref.listen` inside `build` (risk: multiple redundant subscriptions and harder teardown).
+- Poll metrics from widgets when sheets open (lag between edits and metrics state).
+- Convert metrics to synchronous getters only (loses real-time updates during editing).
+
+### 11. TM Canvas Asynchronous Safety
+**Decision**: Guard transition dialogs and state updates with `mounted` checks and reset helpers to avoid updating disposed canvases after awaiting user input.
+**Rationale**:
+- Eliminates exceptions stemming from dialogs finishing after navigation away from the canvas, a recurring crash risk on mobile when dismissing sheets mid-edit.【F:lib/presentation/widgets/tm_canvas.dart†L224-L287】
+- Automatically clears transition-adding mode if the dialog is cancelled, preventing ghost UI states that previously confused gesture handling.【F:lib/presentation/widgets/tm_canvas.dart†L224-L287】
+- Maintains editor synchronization by notifying providers only when the widget remains active, preserving undo/redo expectations.【F:lib/presentation/widgets/tm_canvas.dart†L224-L299】
+**Alternatives considered**:
+- Trust Flutter’s scheduler without guards (risk: `setState` on disposed widgets).
+- Recreate the canvas widget after every dialog (expensive rebuilds and gesture resets).
+- Move dialogs to a separate overlay service (higher complexity for small safety improvement).
+
+### 12. SVG Text Escaping for Exports
+**Decision**: Escape all SVG text nodes and add regression tests covering special characters in state labels and transition symbols.
+**Rationale**:
+- Prevents malformed SVG output and potential injection vectors when users name states with XML-reserved characters, closing a high-severity export risk.【F:lib/data/services/file_operations_service.dart†L324-L370】
+- Automated tests validate the escaping routine against a spectrum of special characters, ensuring future refactors preserve the guarantee.【F:test/data/services/file_operations_service_svg_test.dart†L14-L84】
+- Keeps exports standards-compliant without requiring manual sanitization in the UI layer.【F:lib/data/services/file_operations_service.dart†L324-L370】
+**Alternatives considered**:
+- Trust user-entered labels (risk: broken SVGs and downstream parsing errors).
+- Strip special characters (destroys intentional naming and loses parity with desktop JFLAP).
+- Encode labels in base64 (overkill for textual editors and harms readability).
+
+### 13. NFA→DFA Queue Optimization
+**Decision**: Swap list-based worklists for `ListQueue`, track processed subsets, and cap conversions at 1000 generated states to guard mobile memory limits.
+**Rationale**:
+- Eliminates O(n) removals during subset construction, which previously degraded performance on large NFAs and risked frame drops on mid-tier phones.【F:lib/core/algorithms/nfa_to_dfa_converter.dart†L138-L207】
+- Explicit processed tracking avoids re-enqueuing duplicates, reducing CPU churn and meeting latency goals for automata up to 200 states.【F:lib/core/algorithms/nfa_to_dfa_converter.dart†L142-L207】
+- The safety cap prevents runaway conversions from exhausting device resources, directly addressing a production risk noted in weekly QA.
+**Alternatives considered**:
+- Keep list removals (risk: repeated shifting and jank for larger automata).
+- Recursive conversion (risk: stack overflows on deep automata).
+- Offload to background isolates (higher complexity without clear wins for current size targets).
+
+### 14. DFA Minimizer Predecessor Map
+**Decision**: Precompute predecessor sets per symbol/destination and process Hopcroft splitters via `ListQueue` to avoid repeated full scans.
+**Rationale**:
+- Reduces algorithmic complexity for each refinement step, eliminating the risk of quadratic loops that timed out during stress runs on 150-state automata.【F:lib/core/algorithms/dfa_minimizer.dart†L104-L193】
+- Maintaining FIFO semantics with `ListQueue` preserves determinism of the output while improving responsiveness on mobile hardware.【F:lib/core/algorithms/dfa_minimizer.dart†L132-L188】
+- Keeps memory overhead predictable by sharing predecessor sets instead of recomputing them per iteration.【F:lib/core/algorithms/dfa_minimizer.dart†L115-L130】
+**Alternatives considered**:
+- Keep scanning the full transition list every time (risk: timeouts on larger automata).
+- Switch to recursive partition refinement (harder to profile and tune for mobile).
+- Outsource minimization to native code (adds FFI maintenance burden).
+
+### 15. FA→Regex State Elimination Caching
+**Decision**: Cache incoming/outgoing transition buckets and reuse merged transitions when eliminating intermediate states.
+**Rationale**:
+- Avoids rebuilding transition lists from scratch on every elimination step, mitigating the latency risk seen in earlier profiling of grammar-heavy exercises.【F:lib/core/algorithms/fa_to_regex_converter.dart†L164-L273】
+- Consolidates parallel paths with unioned regex strings, preserving correctness while curbing exponential string growth.【F:lib/core/algorithms/fa_to_regex_converter.dart†L213-L258】
+- Keeps the resulting automaton deterministic for the extraction phase, aligning with UI expectations for previewing regex derivations.【F:lib/core/algorithms/fa_to_regex_converter.dart†L213-L273】
+**Alternatives considered**:
+- Rebuild transitions through nested loops per elimination (risk: repeated quadratic work).
+- Emit intermediate regex fragments without caching (risk: duplicated work and inconsistent outputs).
+- Use adjacency matrices (memory cost too high for mobile constraints).
+
+### 16. PDA Simulation Panel Regression Tests
+**Decision**: Add widget tests that simulate empty input, missing PDA context, and successful acceptance flows using provider overrides.
+**Rationale**:
+- Captures regressions in error messaging and success summaries that previously slipped into production due to manual-only verification, reducing QA risk for pedagogy-critical panels.【F:test/presentation/widgets/pda_simulation_panel_test.dart†L14-L125】
+- Provider overrides keep tests hermetic and fast, encouraging continued coverage additions without bootstrapping the full app shell.【F:test/presentation/widgets/pda_simulation_panel_test.dart†L19-L125】
+- Ensures future UI refactors respect snackbar copy and acceptance states relied upon in lesson plans.【F:test/presentation/widgets/pda_simulation_panel_test.dart†L82-L125】
+**Alternatives considered**:
+- Depend solely on integration tests (slower feedback and harder failure triage).
+- Rely on manual QA scripts (risk: inconsistent validation across releases).
+- Mock only service layers (misses widget composition issues).
+
 ## Implementation Considerations
 
 ### Performance Optimizations
-- Use `RepaintBoundary` widgets to isolate automata redraws
-- Implement lazy loading for complex automata
-- Cache rendered automata states
-- Optimize touch hit testing with spatial indexing
+- Use `ListQueue` for subset construction in NFA→DFA conversion to preserve O(1) dequeue operations and limit generated states to protect mobile memory budgets.【F:lib/core/algorithms/nfa_to_dfa_converter.dart†L138-L207】
+- Precompute predecessor maps during DFA minimization to eliminate repeated full scans inside Hopcroft iterations, maintaining deterministic processing order.【F:lib/core/algorithms/dfa_minimizer.dart†L104-L188】
+- Cache incoming/outgoing transition groups during FA→regex elimination to reduce repeated combinations and keep regex growth manageable.【F:lib/core/algorithms/fa_to_regex_converter.dart†L164-L258】
+- Continue isolating expensive paint operations with `RepaintBoundary` and lazy-loading large automata where applicable (unchanged recommendation).
 
 ### Accessibility Features
 - Minimum 44pt touch targets for automata elements
 - High contrast mode support
 - Screen reader compatibility
 - Voice-over support for automata descriptions
+- Snackbars now rely on default red/green fills for error/success states, so we must audit color contrast against WCAG AA to ensure the new feedback remains perceivable for low-vision users.【F:lib/presentation/widgets/file_operations_panel.dart†L320-L335】
 
 ### Platform-Specific Considerations
 - iOS: Follow Human Interface Guidelines for navigation
@@ -136,6 +225,7 @@ This research addresses the technical decisions needed to port JFLAP's core auto
 - **Learning curve for mobile interface**: Mitigated by familiar navigation patterns and progressive disclosure
 - **Feature discoverability**: Mitigated by expandable menus and contextual help
 - **Performance on older devices**: Mitigated by performance testing and optimization
+- **Asynchronous file workflows**: Mitigated by disabling buttons during loading, contextual snackbars for platform errors, and lifecycle-aware guards that keep the UI responsive after cancellations.【F:lib/presentation/widgets/file_operations_panel.dart†L118-L200】【F:lib/presentation/widgets/file_operations_panel.dart†L313-L335】
 
 ## Success Metrics
 - 60fps rendering performance on mid-range devices


### PR DESCRIPTION
## Summary
- catalog weekly technical decisions covering file lifecycle guards, TM metrics subscriptions, SVG escaping, and algorithm optimizations
- register new PDA simulation panel widget test coverage and risk mitigations in the research log
- refresh performance, accessibility, and UX sections with observations from the latest pull requests

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d271cae16c832ea7a828645cdca6f3