### PR TITLE
Enable home page swiping

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -77,6 +77,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 
   void _onPageChanged(int index) {
+    _lastNavigationIndex = index;
     ref.read(homeNavigationProvider.notifier).setIndex(index);
   }
 
@@ -145,7 +146,7 @@ class _HomePageState extends ConsumerState<HomePage> {
       body: PageView(
         controller: _pageController,
         onPageChanged: _onPageChanged,
-        physics: const NeverScrollableScrollPhysics(), // Disable swipe gestures
+        physics: const PageScrollPhysics(),
         children: const [
           FSAPage(),
           GrammarPage(),

--- a/test/integration/test_mobile_ui.dart
+++ b/test/integration/test_mobile_ui.dart
@@ -177,6 +177,26 @@ void main() {
       expect(canvas, findsOneWidget);
     });
     
+    testWidgets('should allow swipe gestures between tabs', (WidgetTester tester) async {
+      // Arrange
+      await tester.pumpWidget(const JFlutterApp());
+      await tester.pumpAndSettle();
+
+      // Assert initial page description is shown
+      expect(find.text('Finite State Automata'), findsOneWidget);
+
+      // Verify that the PageView uses scrollable physics
+      final pageView = tester.widget<PageView>(find.byType(PageView));
+      expect(pageView.physics, isA<PageScrollPhysics>());
+
+      // Act - Swipe to next tab
+      await tester.drag(find.byType(PageView), const Offset(-400, 0));
+      await tester.pumpAndSettle();
+
+      // Assert - The next page is visible and description updated
+      expect(find.text('Context-Free Grammars'), findsOneWidget);
+    });
+
     testWidgets('should maintain touch target size of at least 44dp', (WidgetTester tester) async {
       // Arrange
       await tester.pumpWidget(const JFlutterApp());


### PR DESCRIPTION
## Summary
- allow the home page PageView to use PageScrollPhysics so swipe gestures work on mobile
- keep the navigation provider in sync when the page changes due to gestures
- cover the swipe behaviour with an integration test that verifies the new physics and navigation update

## Testing
- flutter test *(fails: flutter command is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d27c99a708832eb8aa1eba3e24d139