### PR TITLE
Simplify TMPage metrics consumption

### DIFF
--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../providers/tm_editor_provider.dart';
 import '../providers/tm_metrics_controller.dart';
 import '../widgets/tm/tm_desktop_layout.dart';
 import '../widgets/tm/tm_metrics_panel.dart';
@@ -19,25 +18,6 @@ class TMPage extends ConsumerStatefulWidget {
 
 class _TMPageState extends ConsumerState<TMPage> {
   final GlobalKey _canvasKey = GlobalKey();
-  ProviderSubscription<TMEditorState>? _subscription;
-
-  @override
-  void initState() {
-    super.initState();
-    _subscription?.close();
-    _subscription = ref.listen<TMEditorState>(
-      tmEditorProvider,
-      (_, next) =>
-          ref.read(tmMetricsControllerProvider.notifier).updateFromEditor(next),
-      fireImmediately: true,
-    );
-  }
-
-  @override
-  void dispose() {
-    _subscription?.close();
-    super.dispose();
-  }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Summary
- rely on `tmMetricsControllerProvider` inside `TMPage` instead of maintaining a manual editor subscription
- keep the existing layout and bottom sheet callbacks while feeding them metrics from the provider

## Testing
- flutter test *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d27c94b8b4832e9cf831c0826a29a4