### PR TITLE
Escape SVG labels and add regression test

### DIFF
--- a/lib/data/services/file_operations_service.dart
+++ b/lib/data/services/file_operations_service.dart
@@ -339,8 +339,9 @@ class FileOperationsService {
       // Draw transition label
       final midX = (from.dx + to.dx) / 2;
       final midY = (from.dy + to.dy) / 2;
+      final escapedLabel = _escapeXml(transition.label);
       buffer.writeln(
-        '  <text x="$midX" y="$midY" text-anchor="middle" font-family="Arial" font-size="12" fill="${_colorToHex(_kTextColor)}">${_escapeXml(transition.label)}</text>',
+        '  <text x="$midX" y="$midY" text-anchor="middle" font-family="Arial" font-size="12" fill="${_colorToHex(_kTextColor)}">$escapedLabel</text>',
       );
     }
 
@@ -348,25 +349,17 @@ class FileOperationsService {
     for (final state in drawingData.states) {
       final x = state.center.dx;
       final y = state.center.dy;
+      final escapedLabel = _escapeXml(state.label);
       buffer.writeln(
         '  <circle cx="$x" cy="$y" r="$_kStateRadius" fill="${_colorToHex(state.fillColor)}" stroke="${_colorToHex(state.strokeColor)}" stroke-width="${state.strokeWidth}"/>',
       );
       buffer.writeln(
-        '  <text x="$x" y="${y + 5}" text-anchor="middle" font-family="Arial" font-size="14" fill="${_colorToHex(_kTextColor)}">${_escapeXml(state.label)}</text>',
+        '  <text x="$x" y="${y + 5}" text-anchor="middle" font-family="Arial" font-size="14" fill="${_colorToHex(_kTextColor)}">$escapedLabel</text>',
       );
     }
 
     buffer.writeln('</svg>');
     return buffer.toString();
-  }
-
-  String _escapeXml(String value) {
-    return value
-        .replaceAll('&', '&amp;')
-        .replaceAll('<', '&lt;')
-        .replaceAll('>', '&gt;')
-        .replaceAll('"', '&quot;')
-        .replaceAll("'", '&apos;');
   }
 
   _AutomatonDrawingData _prepareDrawingData(FSA automaton) {
@@ -430,6 +423,15 @@ class _AutomatonDrawingData {
 
   final List<_DrawableState> states;
   final List<_DrawableTransition> transitions;
+}
+
+String _escapeXml(String value) {
+  return value
+      .replaceAll('&', '&amp;')
+      .replaceAll('<', '&lt;')
+      .replaceAll('>', '&gt;')
+      .replaceAll('"', '&quot;')
+      .replaceAll("'", '&apos;');
 }
 
 class _DrawableState {

--- a/test/data/services/file_operations_service_svg_test.dart
+++ b/test/data/services/file_operations_service_svg_test.dart
@@ -76,8 +76,14 @@ void main() {
 
       final svgContent = await File(filePath).readAsString();
 
-      expect(svgContent, contains('S &amp;&lt;&gt;&quot;&apos;'));
-      expect(svgContent, contains('a&amp;&lt;&gt;&quot;&apos;'));
+      expect(
+        svgContent,
+        contains('<text x="100.0" y="105.0" text-anchor="middle" font-family="Arial" font-size="14" fill="#000000">S &amp;&lt;&gt;&quot;&apos;</text>'),
+      );
+      expect(
+        svgContent,
+        contains('<text x="150.0" y="100.0" text-anchor="middle" font-family="Arial" font-size="12" fill="#000000">a&amp;&lt;&gt;&quot;&apos;</text>'),
+      );
       expect(svgContent, contains('&apos;'));
       expect(svgContent, isNot(contains('S &<')));
       expect(svgContent, isNot(contains('a&<')));


### PR DESCRIPTION
## Summary
- reuse a private XML escaping helper when serializing SVG text nodes
- move the escaping helper to file scope for reuse across builders
- add a regression test ensuring SVG export encodes special characters in state and transition labels

## Testing
- flutter test test/data/services/file_operations_service_svg_test.dart *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d27cbd258c832eaca2551908b58610