### PR TITLE
Add PDA simulation panel widget tests

### DIFF
--- a/lib/presentation/widgets/pda_simulation_panel.dart
+++ b/lib/presentation/widgets/pda_simulation_panel.dart
@@ -2,9 +2,33 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/algorithms/pda_simulator.dart';
+import '../../core/models/pda.dart';
 import '../../core/models/simulation_step.dart';
 import '../../core/result.dart';
 import '../providers/pda_editor_provider.dart';
+
+typedef PDASimulatorRunner = Result<PDASimulationResult> Function(
+  PDA,
+  String, {
+  bool stepByStep,
+  Duration timeout,
+});
+
+final pdaSimulatorRunnerProvider = Provider<PDASimulatorRunner>(
+  (ref) => (
+    pda,
+    inputString, {
+    bool stepByStep = false,
+    Duration timeout = const Duration(seconds: 5),
+  }) {
+    return PDASimulator.simulate(
+      pda,
+      inputString,
+      stepByStep: stepByStep,
+      timeout: timeout,
+    );
+  },
+);
 
 /// Encapsulates the PDA input controls, execution trigger, and results view
 /// so the widget can manage the full life cycle of a simulation from the same
@@ -366,7 +390,8 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
       initialStackSymbol: initialStack,
     );
 
-    final Result<PDASimulationResult> result = PDASimulator.simulate(
+    final simulator = ref.read(pdaSimulatorRunnerProvider);
+    final Result<PDASimulationResult> result = simulator(
       simulationPda,
       inputString,
       stepByStep: _stepByStep,

--- a/test/presentation/widgets/pda_simulation_panel_test.dart
+++ b/test/presentation/widgets/pda_simulation_panel_test.dart
@@ -5,23 +5,31 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
 
-import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
-import 'package:jflutter/presentation/widgets/pda_simulation_panel.dart';
 import 'package:jflutter/core/models/pda.dart';
 import 'package:jflutter/core/models/pda_transition.dart';
+import 'package:jflutter/core/models/simulation_result.dart';
+import 'package:jflutter/core/models/simulation_step.dart';
 import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+import 'package:jflutter/presentation/widgets/pda_simulation_panel.dart';
 
 class _FakePDAEditorNotifier extends StateNotifier<PDAEditorState> {
-  _FakePDAEditorNotifier({PDA? pda})
-      : super(PDAEditorState(pda: pda));
+  _FakePDAEditorNotifier({PDA? pda}) : super(PDAEditorState(pda: pda));
 }
 
-ProviderScope _buildPanelWithFakeEditor({PDA? pda}) {
+ProviderScope _buildPanelWithFakeEditor({
+  PDA? pda,
+  PDASimulatorRunner? overrideSimulator,
+}) {
   return ProviderScope(
     overrides: [
       pdaEditorProvider.overrideWith(
         (ref) => _FakePDAEditorNotifier(pda: pda),
       ),
+      if (overrideSimulator != null)
+        pdaSimulatorRunnerProvider.overrideWithValue(overrideSimulator),
     ],
     child: const MaterialApp(
       home: Scaffold(
@@ -31,10 +39,48 @@ ProviderScope _buildPanelWithFakeEditor({PDA? pda}) {
   );
 }
 
+class _StubSimulator {
+  Result<PDASimulationResult> call(
+    PDA pda,
+    String input, {
+    bool stepByStep = false,
+    Duration timeout = const Duration(seconds: 5),
+  }) {
+    final steps = <SimulationStep>[
+      SimulationStep.initial(
+        initialState: pda.initialState!.id,
+        inputString: input,
+        initialStackSymbol: pda.initialStackSymbol,
+      ),
+      SimulationStep(
+        currentState: pda.acceptingStates.first.id,
+        remainingInput: '',
+        stackContents: pda.initialStackSymbol,
+        stepNumber: 1,
+      ),
+    ];
+
+    return Success(
+      PDASimulationResult.success(
+        inputString: input,
+        steps: steps,
+        executionTime: const Duration(milliseconds: 3),
+      ),
+    );
+  }
+}
+
 Future<void> _fillInputField(WidgetTester tester, String value) async {
   final inputField = find.widgetWithText(TextField, 'Input String');
   expect(inputField, findsOneWidget);
   await tester.enterText(inputField, value);
+  await tester.pumpAndSettle();
+}
+
+Future<void> _tapSimulateButton(WidgetTester tester) async {
+  final button = find.widgetWithText(ElevatedButton, 'Simulate PDA');
+  expect(button, findsOneWidget);
+  await tester.tap(button);
 }
 
 PDA _createAcceptingPda() {
@@ -66,7 +112,7 @@ PDA _createAcceptingPda() {
     id: 'pda',
     name: 'Test PDA',
     states: {initialState, acceptingState},
-    transitions: {transition},
+    transitions: Set<Transition>.from({transition}),
     alphabet: {'a'},
     initialState: initialState,
     acceptingStates: {acceptingState},
@@ -79,15 +125,25 @@ PDA _createAcceptingPda() {
 }
 
 void main() {
-  testWidgets('shows error when input is empty and surfaces failure layout', (tester) async {
-    await tester.pumpWidget(_buildPanelWithFakeEditor(pda: _createAcceptingPda()));
+  testWidgets('shows error when input is empty and surfaces failure layout',
+      (tester) async {
+    final stub = _StubSimulator();
+    await tester.pumpWidget(
+      _buildPanelWithFakeEditor(
+        pda: _createAcceptingPda(),
+        overrideSimulator: stub.call,
+      ),
+    );
     await tester.pumpAndSettle();
 
-    await tester.tap(find.text('Simulate PDA'));
-    await tester.pumpAndSettle();
+    await _tapSimulateButton(tester);
+    await tester.pump();
 
     expect(find.byType(SnackBar), findsOneWidget);
     expect(find.text('Please enter an input string'), findsWidgets);
+
+    await tester.pumpAndSettle();
+
     expect(find.text('Simulation failed'), findsOneWidget);
   });
 
@@ -96,27 +152,34 @@ void main() {
     await tester.pumpAndSettle();
 
     await _fillInputField(tester, 'a');
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text('Simulate PDA'));
-    await tester.pumpAndSettle();
+    await _tapSimulateButton(tester);
+    await tester.pump();
 
     expect(find.byType(SnackBar), findsOneWidget);
     expect(
       find.text('Create a PDA on the canvas before simulating.'),
       findsWidgets,
     );
+
+    await tester.pumpAndSettle();
+
     expect(find.text('Simulation failed'), findsOneWidget);
   });
 
-  testWidgets('displays successful simulation summary and steps', (tester) async {
-    await tester.pumpWidget(_buildPanelWithFakeEditor(pda: _createAcceptingPda()));
+  testWidgets('renders acceptance summary and step trace on success',
+      (tester) async {
+    final stub = _StubSimulator();
+    await tester.pumpWidget(
+      _buildPanelWithFakeEditor(
+        pda: _createAcceptingPda(),
+        overrideSimulator: stub.call,
+      ),
+    );
     await tester.pumpAndSettle();
 
     await _fillInputField(tester, 'a');
-    await tester.pumpAndSettle();
-
-    await tester.tap(find.text('Simulate PDA'));
+    await _tapSimulateButton(tester);
+    await tester.pump();
     await tester.pumpAndSettle();
 
     expect(find.text('Accepted'), findsOneWidget);


### PR DESCRIPTION
## Summary
- expose the PDA simulator through a provider in `PDASimulationPanel` so it can be overridden in tests
- add widget tests for the PDA simulation panel covering validation errors and a successful simulation trace

## Testing
- `flutter test test/presentation/widgets/pda_simulation_panel_test.dart` *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d27cc212a4832e911157b2e888e145