### PR TITLE
docs: detail automaton painter math comments

### DIFF
--- a/lib/presentation/widgets/automaton_canvas/automaton_painter.dart
+++ b/lib/presentation/widgets/automaton_canvas/automaton_painter.dart
@@ -7,8 +7,10 @@ import '../../../core/models/fsa_transition.dart';
 import '../../../core/models/state.dart' as automaton_state;
 import '../transition_geometry.dart';
 
-/// Painter responsável por renderizar estados e transições do autômato,
-/// incluindo pré-visualizações, setas iniciais e rótulos.
+/// [CustomPainter] encarregado de desenhar toda a representação visual do
+/// autômato: aplica estilos, sombras e destaques aos estados, além de traçar
+/// curvas, laços e setas que descrevem as transições com seus respectivos
+/// rótulos e pré-visualizações.
 class AutomatonPainter extends CustomPainter {
   final List<automaton_state.State> states;
   final List<FSATransition> transitions;
@@ -48,8 +50,9 @@ class AutomatonPainter extends CustomPainter {
   }
 
   // Desenha transições direcionadas utilizando uma curva quadrática de Bézier,
-  // onde o ponto de controle é calculado pela `TransitionCurve` para manter o
-  // afastamento visual entre múltiplas arestas entre os mesmos estados.
+  // em que o ponto de controle fornecido por `TransitionCurve` desloca o arco
+  // perpendicularmente ao segmento base para separar graficamente transições
+  // paralelas entre o mesmo par de estados.
   void _drawDirectedTransition(Canvas canvas, FSATransition transition) {
     final geometry = TransitionCurve.compute(
       transitions,
@@ -77,10 +80,10 @@ class AutomatonPainter extends CustomPainter {
     _drawTransitionLabel(canvas, transition, geometry.labelPosition);
   }
 
-  // Constrói laços próprios posicionando um arco acima do estado; o raio base
-  // (_selfLoopBaseRadius) e o espaçamento incremental (_selfLoopSpacing)
-  // garantem que múltiplos loops sejam deslocados radialmente para evitar
-  // sobreposição.
+  // Constrói laços próprios projetando um arco circular acima do estado; o
+  // raio base (_selfLoopBaseRadius) e o espaçamento incremental
+  // (_selfLoopSpacing) garantem deslocamento radial entre múltiplos loops e os
+  // ângulos fixos definem a porção da circunferência usada para a curva.
   void _drawSelfLoop(Canvas canvas, FSATransition transition) {
     final center = Offset(
       transition.fromState.position.x,
@@ -132,9 +135,9 @@ class AutomatonPainter extends CustomPainter {
     _drawTransitionLabel(canvas, transition, labelPosition);
   }
 
-  // Posiciona o rótulo da transição no ponto médio da curva, deslocando o
-  // texto na direção do vetor tangente para manter legibilidade em curvas
-  // inclinadas e loops.
+  // Posiciona o rótulo da transição próximo ao ponto médio da curva e o
+  // desloca conforme o vetor tangente para compensar a curvatura, preservando a
+  // legibilidade tanto em curvas quadráticas quanto em laços.
   void _drawTransitionLabel(
     Canvas canvas,
     FSATransition transition,
@@ -179,8 +182,9 @@ class AutomatonPainter extends CustomPainter {
     return '';
   }
 
-  // Calcula o triângulo da seta deslocando-se a partir do ponto final na
-  // direção da tangente e aplicando rotação simétrica pelo ângulo da seta.
+  // Calcula o triângulo da seta a partir do ponto final da curva, retrocedendo
+  // ao longo do vetor tangente e rotacionando segmentos simétricos em torno do
+  // ângulo da seta para obter as duas abas do bico.
   void _drawArrowhead(
     Canvas canvas,
     Offset tip,


### PR DESCRIPTION
## Summary
- document AutomatonPainter responsibilities across states, transitions and previews
- clarify the quadratic and circular geometry used for transitions and self-loops, noting base radius and spacing constants
- explain tangent-based offsets for labels and arrowheads to highlight underlying math

## Testing
- no automated tests were run (not required for documentation-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d27f3d44b0832ea508f71bc0c858e8