### PR TITLE
Add documentation comments to PDA simulation panel

### DIFF
--- a/lib/presentation/widgets/pda_simulation_panel.dart
+++ b/lib/presentation/widgets/pda_simulation_panel.dart
@@ -30,9 +30,9 @@ final pdaSimulatorRunnerProvider = Provider<PDASimulatorRunner>(
   },
 );
 
-/// Encapsulates the PDA input controls, execution trigger, and results view
-/// so the widget can manage the full life cycle of a simulation from the same
-/// panel.
+/// Encapsulates the PDA input controls, execution trigger, and results view so
+/// the widget can manage the full life cycle of a pushdown automaton simulation
+/// from a single panel.
 class PDASimulationPanel extends ConsumerStatefulWidget {
   const PDASimulationPanel({super.key});
 
@@ -95,8 +95,9 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
     );
   }
 
-  // Presents the input fields, including the `_stepByStep` switch that toggles
-  // whether the simulator collects the detailed transition trace.
+  // Presents the input fields and notes, including the `_stepByStep` switch
+  // that toggles whether the simulator collects the detailed transition trace
+  // before `_simulatePDA` runs.
   Widget _buildInputSection(BuildContext context) {
     return Container(
       padding: const EdgeInsets.all(12),
@@ -156,7 +157,7 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
 
   // Provides the execute button, reflecting the loading state while the
   // simulation runs and delegating to `_simulatePDA` with the current
-  // `_stepByStep` selection.
+  // `_stepByStep` selection to decide if transitions should be recorded.
   Widget _buildSimulateButton(BuildContext context) {
     return SizedBox(
       width: double.infinity,
@@ -174,9 +175,9 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
     );
   }
 
-  // Shows the results container, falling back to placeholder or error
-  // messaging when `_simulationResult` is empty due to validation or runtime
-  // failures.
+  // Shows the results container, falling back to placeholder or error messaging
+  // when `_simulationResult` is empty due to validation or runtime failures or
+  // when `_stepByStep` was disabled and no trace data exists.
   Widget _buildResultsSection(BuildContext context) {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
@@ -200,7 +201,8 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
 
   Widget _buildEmptyResults(BuildContext context) {
     // Placeholder shown before any simulation has been run or when errors clear
-    // previous output.
+    // previous output, reminding the user why no trace information is
+    // available.
     return Container(
       width: double.infinity,
       padding: const EdgeInsets.all(24),
@@ -249,9 +251,9 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
         : 'Simulation failed';
     final errorText = _errorMessage ?? result?.errorMessage;
 
-    // Displays either the simulator error (if available) or the last
-    // validation error bubbled up via `_showError` when no results can be
-    // produced.
+    // Displays either the simulator error (if available) or the last validation
+    // error bubbled up via `_showError` when no results can be produced, also
+    // accounting for empty traces when `_stepByStep` is false.
 
     return Container(
       padding: const EdgeInsets.all(16),
@@ -425,7 +427,8 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
       _simulationResult = null;
     });
     // Surface the validation issue in both the snackbar and results section so
-    // the UI clarifies why no simulation output is currently available.
+    // the UI clarifies why no simulation output or trace is currently
+    // available.
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),


### PR DESCRIPTION
## Summary
- document the PDA simulation panel class to clarify its role managing input, execution, and results
- expand method comments to describe UI sections and how the step-by-step option affects simulation traces
- note the messaging shown when no results or traces are available

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d27f3f8b94832e90339e21813d3e27