### PR TITLE
Ensure stub layout repository returns prepared entity for all layouts

### DIFF
--- a/test/unit/presentation/automaton_provider_large_conversion_test.dart
+++ b/test/unit/presentation/automaton_provider_large_conversion_test.dart
@@ -21,34 +21,38 @@ class _StubLayoutRepository implements LayoutRepository {
 
   final AutomatonEntity _entityToReturn;
 
+  Future<AutomatonResult> _returnPreparedEntity() async {
+    return Success(_entityToReturn);
+  }
+
   @override
   Future<AutomatonResult> applyAutoLayout(AutomatonEntity automaton) async {
-    return Success(_entityToReturn);
+    return _returnPreparedEntity();
   }
 
   @override
   Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) async {
-    return Success(_entityToReturn);
+    return _returnPreparedEntity();
   }
 
   @override
   Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) async {
-    return Success(_entityToReturn);
+    return _returnPreparedEntity();
   }
 
   @override
   Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) async {
-    return Success(_entityToReturn);
+    return _returnPreparedEntity();
   }
 
   @override
   Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) async {
-    return Success(_entityToReturn);
+    return _returnPreparedEntity();
   }
 
   @override
   Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) async {
-    return Success(_entityToReturn);
+    return _returnPreparedEntity();
   }
 }
 


### PR DESCRIPTION
## Summary
- adjust the layout stub used in the large conversion test so every layout method returns the prepared automaton entity via a shared helper

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d27f514d90832e8555200223646b9e