### PR TITLE
Improve provider logging and error handling

### DIFF
--- a/lib/core/repositories/base_repository.dart
+++ b/lib/core/repositories/base_repository.dart
@@ -1,6 +1,7 @@
 // Base repository class to consolidate common patterns
 // Reduces duplication across repository implementations
 
+import 'package:jflutter/core/error_handler.dart';
 import 'package:jflutter/core/result.dart';
 
 /// Base repository class with common error handling and caching patterns
@@ -92,22 +93,28 @@ abstract class BaseRepository {
 
   /// Log operation start
   void logOperationStart(String operationName, [Map<String, dynamic>? parameters]) {
-    // TODO: Implement proper logging
-    print('Starting operation: $operationName');
-    if (parameters != null) {
-      print('Parameters: $parameters');
+    final buffer = StringBuffer('Starting operation: $operationName');
+    if (parameters != null && parameters.isNotEmpty) {
+      final formattedParameters = parameters.entries
+          .map((entry) => '${entry.key}=${entry.value}')
+          .join(', ');
+      buffer.write(' (parameters: $formattedParameters)');
     }
+
+    ErrorHandler.logInfo(buffer.toString());
   }
 
   /// Log operation completion
   void logOperationComplete(String operationName, Duration duration) {
-    // TODO: Implement proper logging
-    print('Completed operation: $operationName in ${duration.inMilliseconds}ms');
+    final durationMs = duration.inMilliseconds;
+    final durationSeconds = (durationMs / 1000).toStringAsFixed(2);
+    ErrorHandler.logInfo(
+      'Completed operation: $operationName in ${durationMs}ms (~${durationSeconds}s)',
+    );
   }
 
   /// Log operation error
   void logOperationError(String operationName, dynamic error) {
-    // TODO: Implement proper logging
-    print('Error in operation: $operationName - $error');
+    ErrorHandler.logError('Error in operation: $operationName', error);
   }
 }

--- a/test/unit/core/providers/provider_utils_test.dart
+++ b/test/unit/core/providers/provider_utils_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/providers/base_provider.dart';
+
+void main() {
+  group('ProviderUtils', () {
+    test('createWithErrorHandling wraps synchronous errors', () {
+      final provider = ProviderUtils.createWithErrorHandling<int>(
+        () => throw StateError('sync failure'),
+        name: 'sync',
+      );
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        () => container.read(provider),
+        throwsA(
+          isA<ProviderCreationException>()
+              .having((exception) => exception.message, 'message', contains('provider sync'))
+              .having((exception) => exception.cause, 'cause', isA<StateError>()),
+        ),
+      );
+    });
+
+    test('createAsyncWithErrorHandling wraps asynchronous errors', () async {
+      final provider = ProviderUtils.createAsyncWithErrorHandling<int>(
+        () async => throw StateError('async failure'),
+        name: 'async',
+      );
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      await expectLater(
+        container.read(provider.future),
+        throwsA(
+          isA<ProviderCreationException>()
+              .having((exception) => exception.message, 'message', contains('async provider async'))
+              .having((exception) => exception.cause, 'cause', isA<StateError>()),
+        ),
+      );
+    });
+
+    test('createStateNotifierWithErrorHandling wraps initialization errors', () {
+      final provider = ProviderUtils.createStateNotifierWithErrorHandling<_FailingNotifier, int>(
+        () => throw StateError('notifier failure'),
+        name: 'notifier',
+      );
+
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      expect(
+        () => container.read(provider.notifier),
+        throwsA(
+          isA<ProviderCreationException>()
+              .having((exception) => exception.message, 'message', contains('state notifier provider notifier'))
+              .having((exception) => exception.cause, 'cause', isA<StateError>()),
+        ),
+      );
+    });
+  });
+}
+
+class _FailingNotifier extends StateNotifier<AsyncValue<int>> {
+  _FailingNotifier() : super(const AsyncValue.data(0));
+}


### PR DESCRIPTION
## Summary
- replace print-based repository logging with centralized ErrorHandler integration
- add ProviderCreationException and ensure provider factory helpers log and wrap creation failures
- cover the new provider utilities behaviour with targeted unit tests

## Testing
- make test *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4dedce57c832e97b93e4a441ab4da