### PR TITLE
Add platform-aware configuration to dependency injection

### DIFF
--- a/lib/data/repositories/automaton_repository_impl.dart
+++ b/lib/data/repositories/automaton_repository_impl.dart
@@ -11,10 +11,14 @@ class AutomatonRepositoryImpl {
   final AutomatonService _service;
   final AutomatonStorage _storage;
 
-  AutomatonRepositoryImpl({
-    required AutomatonService service,
-    required AutomatonStorage storage,
-  }) : _service = service, _storage = storage;
+  /// Creates an [AutomatonRepositoryImpl] using the provided [service]. When no
+  /// storage implementation is supplied, an in-memory cache is used so legacy
+  /// call sites keep working without having to wire the storage explicitly.
+  AutomatonRepositoryImpl(
+    AutomatonService service, {
+    AutomatonStorage? storage,
+  })  : _service = service,
+        _storage = storage ?? AutomatonStorageFactory.createInMemory();
 
   /// Get all automata
   Future<List<FiniteAutomaton>> getAllAutomata() async {

--- a/lib/data/services/automaton_service.dart
+++ b/lib/data/services/automaton_service.dart
@@ -9,13 +9,19 @@ import 'package:serializers/serializers.dart';
 
 /// Service for automaton API operations
 class AutomatonService {
+  /// Default API endpoint used when a caller does not provide an explicit
+  /// backend URL. This keeps legacy tests working while allowing the value to
+  /// be overridden through dependency injection.
+  static const String _defaultBaseUrl = 'https://api.jflutter.dev';
+
   final String baseUrl;
   final http.Client _client;
 
   AutomatonService({
-    required this.baseUrl,
+    String? baseUrl,
     http.Client? client,
-  }) : _client = client ?? http.Client();
+  })  : baseUrl = baseUrl ?? _defaultBaseUrl,
+        _client = client ?? http.Client();
 
   /// Get all automata
   Future<List<FiniteAutomaton>> getAllAutomata() async {

--- a/lib/injection/app_configuration.dart
+++ b/lib/injection/app_configuration.dart
@@ -1,0 +1,8 @@
+import 'app_configuration_model.dart';
+import 'platform/app_configuration_stub.dart'
+    if (dart.library.io) 'platform/app_configuration_io.dart'
+    if (dart.library.html) 'platform/app_configuration_web.dart';
+
+/// Resolves the platform specific configuration by delegating to the
+/// appropriate implementation based on the active runtime (web, mobile, etc).
+AppConfiguration resolveAppConfiguration() => buildAppConfiguration();

--- a/lib/injection/app_configuration_model.dart
+++ b/lib/injection/app_configuration_model.dart
@@ -1,0 +1,16 @@
+/// Platform-aware application configuration surface used during dependency
+/// injection. Centralizes values that vary per target, such as backend API
+/// endpoints, allowing services to resolve their runtime configuration without
+/// scattering platform checks across the codebase.
+class AppConfiguration {
+  const AppConfiguration({
+    required this.apiBaseUrl,
+    required this.platformLabel,
+  });
+
+  /// Base URL used by HTTP services to reach the backend.
+  final String apiBaseUrl;
+
+  /// Human readable platform tag (web, mobile, desktop, etc).
+  final String platformLabel;
+}

--- a/lib/injection/dependency_injection.dart
+++ b/lib/injection/dependency_injection.dart
@@ -18,12 +18,17 @@ import '../presentation/providers/automaton/automaton_creation_controller.dart';
 import '../presentation/providers/automaton/automaton_simulation_controller.dart';
 import '../presentation/providers/automaton/automaton_conversion_controller.dart';
 import '../presentation/providers/automaton/automaton_layout_controller.dart';
+import 'app_configuration.dart';
+import 'app_configuration_model.dart';
 
 /// Global service locator instance
 final GetIt getIt = GetIt.instance;
 
 /// Sets up dependency injection for the application
 Future<void> setupDependencyInjection() async {
+  final appConfiguration = resolveAppConfiguration();
+  getIt.registerSingleton<AppConfiguration>(appConfiguration);
+
   // Data Sources
   getIt.registerLazySingleton<LocalStorageDataSource>(
     () => LocalStorageDataSource(),
@@ -35,7 +40,9 @@ Future<void> setupDependencyInjection() async {
 
   // Services
   getIt.registerLazySingleton<AutomatonService>(
-    () => AutomatonService(),
+    () => AutomatonService(
+      baseUrl: getIt<AppConfiguration>().apiBaseUrl,
+    ),
   );
   
   getIt.registerLazySingleton<SimulationService>(

--- a/lib/injection/platform/app_configuration_io.dart
+++ b/lib/injection/platform/app_configuration_io.dart
@@ -1,0 +1,25 @@
+import 'dart:io';
+
+import '../app_configuration_model.dart';
+
+/// Builds configuration for mobile and desktop platforms using dart:io.
+AppConfiguration buildAppConfiguration() {
+  if (Platform.isAndroid || Platform.isIOS) {
+    return const AppConfiguration(
+      apiBaseUrl: 'https://api.jflutter.dev',
+      platformLabel: 'mobile',
+    );
+  }
+
+  if (Platform.isMacOS || Platform.isWindows || Platform.isLinux) {
+    return const AppConfiguration(
+      apiBaseUrl: 'http://localhost:8080/api',
+      platformLabel: 'desktop',
+    );
+  }
+
+  return const AppConfiguration(
+    apiBaseUrl: 'https://api.jflutter.dev',
+    platformLabel: 'io',
+  );
+}

--- a/lib/injection/platform/app_configuration_stub.dart
+++ b/lib/injection/platform/app_configuration_stub.dart
@@ -1,0 +1,8 @@
+import '../app_configuration_model.dart';
+
+/// Fallback configuration used when neither the IO nor web libraries are
+/// available (e.g. during analysis). Defaults to the production API endpoint.
+AppConfiguration buildAppConfiguration() => const AppConfiguration(
+      apiBaseUrl: 'https://api.jflutter.dev',
+      platformLabel: 'unknown',
+    );

--- a/lib/injection/platform/app_configuration_web.dart
+++ b/lib/injection/platform/app_configuration_web.dart
@@ -1,0 +1,8 @@
+import '../app_configuration_model.dart';
+
+/// Configuration for the web build. Uses a relative path so the web server can
+/// proxy API calls regardless of deployment origin.
+AppConfiguration buildAppConfiguration() => const AppConfiguration(
+      apiBaseUrl: '/api',
+      platformLabel: 'web',
+    );


### PR DESCRIPTION
## Summary
- add a platform-aware AppConfiguration surface and resolve it during dependency setup
- default AutomatonService to a configurable base URL and expose storage defaults on the repository
- update dependency_injection to register the resolved configuration and feed it to service wiring

## Testing
- Not run (Flutter SDK is unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68d4dede0bb0832e9c075f63d933c2e1