### PR TITLE
Update grammar to PDA conversion return types

### DIFF
--- a/lib/data/services/conversion_service.dart
+++ b/lib/data/services/conversion_service.dart
@@ -1,5 +1,6 @@
 import '../../core/models/fsa.dart';
 import '../../core/models/grammar.dart';
+import '../../core/models/pda.dart';
 import '../../core/result.dart';
 import '../../core/algorithms/nfa_to_dfa_converter.dart';
 import '../../core/algorithms/dfa_minimizer.dart';
@@ -91,7 +92,7 @@ class ConversionService {
   }
 
   /// Converts a grammar to a PDA
-  Result<dynamic> convertGrammarToPda(ConversionRequest request) {
+  Result<PDA> convertGrammarToPda(ConversionRequest request) {
     try {
       // Validate request
       if (request.grammar == null) {
@@ -111,7 +112,7 @@ class ConversionService {
   }
 
   /// Converts a grammar to a PDA using standard construction
-  Result<dynamic> convertGrammarToPdaStandard(ConversionRequest request) {
+  Result<PDA> convertGrammarToPdaStandard(ConversionRequest request) {
     try {
       // Validate request
       if (request.grammar == null) {
@@ -131,7 +132,7 @@ class ConversionService {
   }
 
   /// Converts a grammar to a PDA using Greibach normal form
-  Result<dynamic> convertGrammarToPdaGreibach(ConversionRequest request) {
+  Result<PDA> convertGrammarToPdaGreibach(ConversionRequest request) {
     try {
       // Validate request
       if (request.grammar == null) {


### PR DESCRIPTION
## Summary
- import the PDA model into the conversion service
- update grammar-to-PDA conversion methods to return `Result<PDA>` for stricter typing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4e2003a50832ebfe62712ccafb14b