### PR TITLE
Refactor settings switches into reusable tile

### DIFF
--- a/lib/presentation/widgets/settings/settings_canvas_card.dart
+++ b/lib/presentation/widgets/settings/settings_canvas_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'settings_toggle_tile.dart';
+
 class SettingsCanvasCard extends StatelessWidget {
   const SettingsCanvasCard({
     super.key,
@@ -34,7 +36,7 @@ class SettingsCanvasCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _SwitchSetting(
+            SettingsToggleTile(
               title: 'Show Grid',
               subtitle: 'Display grid lines on canvas',
               value: showGrid,
@@ -42,7 +44,7 @@ class SettingsCanvasCard extends StatelessWidget {
               switchKey: const ValueKey('settings_show_grid_switch'),
             ),
             const SizedBox(height: 16),
-            _SwitchSetting(
+            SettingsToggleTile(
               title: 'Show Coordinates',
               subtitle: 'Display coordinate information',
               value: showCoordinates,
@@ -82,51 +84,6 @@ class SettingsCanvasCard extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class _SwitchSetting extends StatelessWidget {
-  const _SwitchSetting({
-    required this.title,
-    required this.subtitle,
-    required this.value,
-    required this.onChanged,
-    this.switchKey,
-  });
-
-  final String title;
-  final String subtitle;
-  final bool value;
-  final ValueChanged<bool> onChanged;
-  final Key? switchKey;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                subtitle,
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ],
-          ),
-        ),
-        Switch(
-          key: switchKey,
-          value: value,
-          onChanged: onChanged,
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/widgets/settings/settings_general_card.dart
+++ b/lib/presentation/widgets/settings/settings_general_card.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import 'settings_toggle_tile.dart';
+
 class SettingsGeneralCard extends StatelessWidget {
   const SettingsGeneralCard({
     super.key,
@@ -22,7 +24,7 @@ class SettingsGeneralCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            _SwitchSetting(
+            SettingsToggleTile(
               title: 'Auto Save',
               subtitle: 'Automatically save changes',
               value: autoSave,
@@ -30,7 +32,7 @@ class SettingsGeneralCard extends StatelessWidget {
               switchKey: const ValueKey('settings_auto_save_switch'),
             ),
             const SizedBox(height: 16),
-            _SwitchSetting(
+            SettingsToggleTile(
               title: 'Show Tooltips',
               subtitle: 'Display helpful tooltips',
               value: showTooltips,
@@ -40,51 +42,6 @@ class SettingsGeneralCard extends StatelessWidget {
           ],
         ),
       ),
-    );
-  }
-}
-
-class _SwitchSetting extends StatelessWidget {
-  const _SwitchSetting({
-    required this.title,
-    required this.subtitle,
-    required this.value,
-    required this.onChanged,
-    this.switchKey,
-  });
-
-  final String title;
-  final String subtitle;
-  final bool value;
-  final ValueChanged<bool> onChanged;
-  final Key? switchKey;
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      children: [
-        Expanded(
-          child: Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Text(
-                title,
-                style: const TextStyle(fontWeight: FontWeight.bold),
-              ),
-              const SizedBox(height: 4),
-              Text(
-                subtitle,
-                style: Theme.of(context).textTheme.bodySmall,
-              ),
-            ],
-          ),
-        ),
-        Switch(
-          key: switchKey,
-          value: value,
-          onChanged: onChanged,
-        ),
-      ],
     );
   }
 }

--- a/lib/presentation/widgets/settings/settings_toggle_tile.dart
+++ b/lib/presentation/widgets/settings/settings_toggle_tile.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+
+class SettingsToggleTile extends StatelessWidget {
+  const SettingsToggleTile({
+    super.key,
+    required this.title,
+    required this.subtitle,
+    required this.value,
+    required this.onChanged,
+    this.switchKey,
+  });
+
+  final String title;
+  final String subtitle;
+  final bool value;
+  final ValueChanged<bool> onChanged;
+  final Key? switchKey;
+
+  @override
+  Widget build(BuildContext context) {
+    return Row(
+      children: [
+        Expanded(
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                title,
+                style: const TextStyle(fontWeight: FontWeight.bold),
+              ),
+              const SizedBox(height: 4),
+              Text(
+                subtitle,
+                style: Theme.of(context).textTheme.bodySmall,
+              ),
+            ],
+          ),
+        ),
+        Switch(
+          key: switchKey,
+          value: value,
+          onChanged: onChanged,
+        ),
+      ],
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add SettingsToggleTile widget encapsulating switch title/subtitle layout
- reuse the new widget in canvas and general settings cards, removing duplicate _SwitchSetting classes

## Testing
- dart format lib/presentation/widgets/settings/settings_toggle_tile.dart lib/presentation/widgets/settings/settings_canvas_card.dart lib/presentation/widgets/settings/settings_general_card.dart *(fails: command not found: dart)*
- flutter analyze *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e2051d64832e8abefafa5f9fe327