### PR TITLE
Refactor algorithm panel widgets

### DIFF
--- a/lib/presentation/widgets/algorithm_panel/algorithm_action_button.dart
+++ b/lib/presentation/widgets/algorithm_panel/algorithm_action_button.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/material.dart';
+
+class AlgorithmActionButton extends StatelessWidget {
+  final String title;
+  final String description;
+  final IconData icon;
+  final VoidCallback? onPressed;
+  final bool isDestructive;
+  final bool isExecuting;
+  final bool isCurrentAlgorithm;
+  final double executionProgress;
+  final String? executionStatus;
+
+  const AlgorithmActionButton({
+    super.key,
+    required this.title,
+    required this.description,
+    required this.icon,
+    this.onPressed,
+    this.isDestructive = false,
+    this.isExecuting = false,
+    this.isCurrentAlgorithm = false,
+    this.executionProgress = 0.0,
+    this.executionStatus,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final color = isDestructive ? colorScheme.error : colorScheme.primary;
+    final isDisabled = (isExecuting && !isCurrentAlgorithm) || onPressed == null;
+
+    return InkWell(
+      onTap: isDisabled ? null : onPressed,
+      borderRadius: BorderRadius.circular(8),
+      child: Container(
+        padding: const EdgeInsets.all(12),
+        decoration: BoxDecoration(
+          border: Border.all(
+            color: isCurrentAlgorithm ? color : color.withOpacity(0.3),
+            width: isCurrentAlgorithm ? 2 : 1,
+          ),
+          borderRadius: BorderRadius.circular(8),
+          color: isCurrentAlgorithm
+              ? color.withOpacity(0.1)
+              : isDisabled
+                  ? colorScheme.surfaceVariant.withOpacity(0.5)
+                  : null,
+        ),
+        child: Row(
+          children: [
+            if (isCurrentAlgorithm && isExecuting)
+              SizedBox(
+                width: 24,
+                height: 24,
+                child: CircularProgressIndicator(
+                  strokeWidth: 2,
+                  valueColor: AlwaysStoppedAnimation<Color>(color),
+                ),
+              )
+            else
+              Icon(
+                icon,
+                color: isDisabled
+                    ? colorScheme.outline.withOpacity(0.5)
+                    : color,
+                size: 24,
+              ),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                    title,
+                    style: Theme.of(context).textTheme.titleMedium?.copyWith(
+                          color: isDisabled
+                              ? colorScheme.outline.withOpacity(0.5)
+                              : color,
+                          fontWeight: FontWeight.w600,
+                        ),
+                  ),
+                  const SizedBox(height: 4),
+                  Text(
+                    isCurrentAlgorithm && executionStatus != null
+                        ? executionStatus!
+                        : description,
+                    style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                          color: isDisabled
+                              ? colorScheme.outline.withOpacity(0.5)
+                              : colorScheme.onSurface.withOpacity(0.7),
+                        ),
+                  ),
+                ],
+              ),
+            ),
+            if (isCurrentAlgorithm && isExecuting)
+              Text(
+                '${(executionProgress * 100).toInt()}%',
+                style: Theme.of(context).textTheme.bodySmall?.copyWith(
+                      color: color,
+                      fontWeight: FontWeight.bold,
+                    ),
+              )
+            else
+              Icon(
+                Icons.arrow_forward_ios,
+                color: isDisabled
+                    ? colorScheme.outline.withOpacity(0.5)
+                    : color.withOpacity(0.5),
+                size: 16,
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/algorithm_panel/algorithm_progress_indicator.dart
+++ b/lib/presentation/widgets/algorithm_panel/algorithm_progress_indicator.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class AlgorithmProgressIndicator extends StatelessWidget {
+  final String? algorithmName;
+  final double progress;
+  final String? status;
+
+  const AlgorithmProgressIndicator({
+    super.key,
+    required this.algorithmName,
+    required this.progress,
+    required this.status,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(
+                Icons.auto_awesome,
+                color: theme.colorScheme.primary,
+                size: 20,
+              ),
+              const SizedBox(width: 8),
+              Text(
+                'Executing ${algorithmName ?? 'algorithm'}',
+                style: theme.textTheme.titleSmall?.copyWith(
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: 12),
+          LinearProgressIndicator(
+            value: progress,
+            backgroundColor: theme.colorScheme.outline.withOpacity(0.2),
+            valueColor: AlwaysStoppedAnimation<Color>(
+              theme.colorScheme.primary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            status ?? 'Processing...',
+            style: theme.textTheme.bodySmall,
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/algorithm_panel/algorithm_step.dart
+++ b/lib/presentation/widgets/algorithm_panel/algorithm_step.dart
@@ -1,0 +1,11 @@
+class AlgorithmStep {
+  final String title;
+  final String description;
+  final Map<String, dynamic>? data;
+
+  const AlgorithmStep({
+    required this.title,
+    required this.description,
+    this.data,
+  });
+}

--- a/lib/presentation/widgets/algorithm_panel/algorithm_steps_list.dart
+++ b/lib/presentation/widgets/algorithm_panel/algorithm_steps_list.dart
@@ -1,0 +1,122 @@
+import 'package:flutter/material.dart';
+
+import 'algorithm_step.dart';
+
+class AlgorithmStepsList extends StatelessWidget {
+  final List<AlgorithmStep> steps;
+  final int currentStepIndex;
+
+  const AlgorithmStepsList({
+    super.key,
+    required this.steps,
+    required this.currentStepIndex,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: theme.colorScheme.surfaceVariant,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Algorithm Steps',
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ),
+          ),
+          const SizedBox(height: 12),
+          SizedBox(
+            height: 200,
+            child: ListView.builder(
+              itemCount: steps.length,
+              itemBuilder: (context, index) {
+                final step = steps[index];
+                final isCurrentStep = index == currentStepIndex;
+                final isCompleted = index < currentStepIndex;
+
+                return Container(
+                  margin: const EdgeInsets.only(bottom: 8),
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: isCurrentStep
+                        ? theme.colorScheme.primaryContainer.withOpacity(0.3)
+                        : isCompleted
+                            ? theme.colorScheme.surface
+                            : null,
+                    border: Border.all(
+                      color: isCurrentStep
+                          ? theme.colorScheme.primary
+                          : theme.colorScheme.outline.withOpacity(0.2),
+                    ),
+                    borderRadius: BorderRadius.circular(8),
+                  ),
+                  child: Row(
+                    children: [
+                      CircleAvatar(
+                        radius: 12,
+                        backgroundColor: isCompleted
+                            ? Colors.green
+                            : isCurrentStep
+                                ? theme.colorScheme.primary
+                                : theme.colorScheme.outline.withOpacity(0.3),
+                        child: isCompleted
+                            ? const Icon(Icons.check, size: 16, color: Colors.white)
+                            : Text(
+                                '${index + 1}',
+                                style: TextStyle(
+                                  color: isCurrentStep
+                                      ? theme.colorScheme.onPrimary
+                                      : theme.colorScheme.onSurface,
+                                  fontSize: 10,
+                                  fontWeight: FontWeight.bold,
+                                ),
+                              ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              step.title,
+                              style: theme.textTheme.titleSmall?.copyWith(
+                                fontWeight: FontWeight.w600,
+                              ),
+                            ),
+                            const SizedBox(height: 4),
+                            Text(
+                              step.description,
+                              style: theme.textTheme.bodySmall,
+                            ),
+                          ],
+                        ),
+                      ),
+                      if (isCurrentStep)
+                        SizedBox(
+                          width: 16,
+                          height: 16,
+                          child: CircularProgressIndicator(
+                            strokeWidth: 2,
+                            valueColor: AlwaysStoppedAnimation<Color>(
+                              theme.colorScheme.primary,
+                            ),
+                          ),
+                        ),
+                    ],
+                  ),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/algorithm_panel/equivalence_result_card.dart
+++ b/lib/presentation/widgets/algorithm_panel/equivalence_result_card.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+
+class EquivalenceResultCard extends StatelessWidget {
+  final bool? result;
+  final String? details;
+
+  const EquivalenceResultCard({
+    super.key,
+    required this.result,
+    required this.details,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final message = details ?? '';
+    final Color accent;
+    IconData icon;
+
+    if (result == null) {
+      accent = theme.colorScheme.secondary;
+      icon = Icons.info_outline;
+    } else if (result!) {
+      accent = Colors.green;
+      icon = Icons.check_circle;
+    } else {
+      accent = Colors.red;
+      icon = Icons.cancel;
+    }
+
+    return Container(
+      width: double.infinity,
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: accent.withOpacity(0.12),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: accent.withOpacity(0.4)),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            children: [
+              Icon(icon, color: accent),
+              const SizedBox(width: 8),
+              Text(
+                result == null
+                    ? 'Equivalence comparison'
+                    : result!
+                        ? 'Automata are equivalent'
+                        : 'Automata are not equivalent',
+                style: theme.textTheme.titleMedium?.copyWith(
+                  color: accent,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ],
+          ),
+          if (message.isNotEmpty) ...[
+            const SizedBox(height: 8),
+            Text(message, style: theme.textTheme.bodyMedium),
+          ],
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract the algorithm action button, progress indicator, steps list, and equivalence result into dedicated widgets under `lib/presentation/widgets/algorithm_panel`
- update `AlgorithmPanel` to consume the new widgets and share the `AlgorithmStep` model for cleaner structure

## Testing
- not run (Flutter SDK is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68d4e1fd5bc8832ea42208a23bfea007