### PR TITLE
Fix pumping lemma page imports and color usage

### DIFF
--- a/lib/presentation/pages/pumping_lemma_page.dart
+++ b/lib/presentation/pages/pumping_lemma_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/pumping_lemma_game/pumping_lemma_game.dart';
-import '../widgets/pumping_lemma_game/pumping_lemma_help.dart';
-import '../widgets/pumping_lemma_game/pumping_lemma_progress.dart';
+import '../widgets/pumping_lemma_help.dart';
+import '../widgets/pumping_lemma_progress.dart';
 
 /// Page for the Pumping Lemma Game
 class PumpingLemmaPage extends ConsumerStatefulWidget {
@@ -108,7 +108,7 @@ class _PumpingLemmaPageState extends ConsumerState<PumpingLemmaPage> {
             margin: const EdgeInsets.all(8),
             padding: const EdgeInsets.all(16),
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surfaceVariant,
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
               borderRadius: BorderRadius.circular(8),
             ),
             child: Column(


### PR DESCRIPTION
## Summary
- point the pumping lemma help and progress imports to their widget directories
- update the info panel background to use `surfaceContainerHighest`

## Testing
- `flutter analyze lib/presentation/pages/pumping_lemma_page.dart` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db13ad2384832eb432ab7befd8ccde