### PR TITLE
Remove unused imports from algorithm provider

### DIFF
--- a/lib/presentation/providers/algorithm_provider.dart
+++ b/lib/presentation/providers/algorithm_provider.dart
@@ -1,9 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/use_cases/algorithm_use_cases.dart';
 import '../../core/entities/automaton_entity.dart';
-import '../../core/entities/grammar_entity.dart';
-import '../../core/models/grammar.dart';
-import '../../core/result.dart';
 
 /// Provider for algorithm operations
 class AlgorithmProvider extends StateNotifier<AlgorithmState> {


### PR DESCRIPTION
## Summary
- remove unused grammar-related imports from algorithm provider to eliminate analyzer warnings

## Testing
- `flutter analyze lib/presentation/providers/algorithm_provider.dart` *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db13adf1dc832eacccab0db4d3b209