### PR TITLE
Update regex page border color alpha usage

### DIFF
--- a/lib/presentation/pages/regex_page.dart
+++ b/lib/presentation/pages/regex_page.dart
@@ -560,8 +560,10 @@ class _RegexPageState extends ConsumerState<RegexPage> {
                 color: Theme.of(context).colorScheme.surface,
                 border: Border(
                   right: BorderSide(
-                    color:
-                        Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                    color: Theme.of(context)
+                        .colorScheme
+                        .outline
+                        .withValues(alpha: 0.2),
                   ),
                 ),
               ),


### PR DESCRIPTION
## Summary
- switch the desktop regex page border color adjustment to use `withValues` for alpha control

## Testing
- `flutter analyze lib/presentation/pages/regex_page.dart` *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db13af24a8832e9d950f4df5cd3993