### PR TITLE
Use collection-if for PDA accepting states fallback

### DIFF
--- a/lib/presentation/providers/pda_editor_provider.dart
+++ b/lib/presentation/providers/pda_editor_provider.dart
@@ -96,8 +96,9 @@ class PDAEditorNotifier extends StateNotifier<PDAEditorState> {
       transitions: transitionSet.map<Transition>((t) => t).toSet(),
       alphabet: alphabet,
       initialState: initialState,
-      acceptingStates:
-          acceptingStates.isEmpty ? {states.last} : acceptingStates,
+      acceptingStates: {
+        if (acceptingStates.isEmpty) states.last else ...acceptingStates,
+      },
       created: now,
       modified: now,
       bounds: const math.Rectangle(0, 0, 800, 600),


### PR DESCRIPTION
## Summary
- replace the conditional operator used to construct the PDA accepting states with a set literal that uses collection-if/else

## Testing
- flutter analyze lib/presentation/providers/pda_editor_provider.dart *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13b03c60832e9f95d9927f5ca70e