### PR TITLE
Use PDA simulator facade aliases in PDA provider

### DIFF
--- a/lib/core/algorithms/pda/pda_simulator_facade.dart
+++ b/lib/core/algorithms/pda/pda_simulator_facade.dart
@@ -6,6 +6,7 @@ import '../pda_simulator.dart' as pda;
 
 /// Acceptance mode for PDA: by final state, empty stack, or both.
 typedef PDAAcceptanceMode = pda.PDAAcceptanceMode;
+typedef PDASimulationResult = pda.PDASimulationResult;
 
 /// High-level PDA simulator facade supporting different acceptance modes.
 class PDASimulatorFacade {

--- a/lib/presentation/providers/pda_simulation_provider.dart
+++ b/lib/presentation/providers/pda_simulation_provider.dart
@@ -1,7 +1,9 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
-import '../../core/algorithms/pda/pda_simulator_facade.dart';
-import '../../core/algorithms/pda_simulator.dart';
+import '../../core/algorithms/pda/pda_simulator_facade.dart' as pda;
+
+typedef PDASimulationResult = pda.PDASimulationResult;
+typedef PDAAcceptanceMode = pda.PDAAcceptanceMode;
 
 class PDASimulationState {
   final PDA? pda;
@@ -58,7 +60,7 @@ class PDASimulationNotifier extends StateNotifier<PDASimulationState> {
     if (state.pda == null) return;
     state = state.copyWith(isRunning: true, lastInput: input);
 
-    final result = PDASimulatorFacade.run(
+    final result = pda.PDASimulatorFacade.run(
       state.pda!,
       input,
       mode: state.mode,


### PR DESCRIPTION
## Summary
- re-export the PDA simulation result type from the facade for UI consumers
- update the PDA simulation provider to rely solely on the facade import with local aliases

## Testing
- flutter analyze lib/presentation/providers/pda_simulation_provider.dart *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13b15dc8832eaf9191dfe7e9e7ec