### PR TITLE
Add const to Pumping Lemma progress provider collections

### DIFF
--- a/lib/presentation/providers/pumping_lemma_progress_provider.dart
+++ b/lib/presentation/providers/pumping_lemma_progress_provider.dart
@@ -126,10 +126,10 @@ class PumpingLemmaProgressNotifier
   void startNewGame({required int totalChallenges}) {
     state = PumpingLemmaProgressState(
       totalChallenges: totalChallenges,
-      completedChallengeIds: <int>{},
+      completedChallengeIds: const <int>{},
       score: 0,
       attempts: 0,
-      history: <PumpingLemmaHistoryEntry>[],
+      history: const <PumpingLemmaHistoryEntry>[],
     );
   }
 
@@ -190,10 +190,10 @@ class PumpingLemmaProgressNotifier
     final totalChallenges = state.totalChallenges;
     state = PumpingLemmaProgressState(
       totalChallenges: totalChallenges,
-      completedChallengeIds: <int>{},
+      completedChallengeIds: const <int>{},
       score: 0,
       attempts: 0,
-      history: <PumpingLemmaHistoryEntry>[],
+      history: const <PumpingLemmaHistoryEntry>[],
     );
   }
 }


### PR DESCRIPTION
## Summary
- mark the Pumping Lemma progress resets with const empty set and list literals to avoid unnecessary allocations

## Testing
- flutter analyze lib/presentation/providers/pumping_lemma_progress_provider.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13b2ae94832e80dd9ecbd0e0272a