### PR TITLE
Update PDA algorithm panel color adjustments

### DIFF
--- a/lib/presentation/widgets/pda_algorithm_panel.dart
+++ b/lib/presentation/widgets/pda_algorithm_panel.dart
@@ -126,12 +126,13 @@ class _PDAAlgorithmPanelState extends ConsumerState<PDAAlgorithmPanel> {
         decoration: BoxDecoration(
           border: Border.all(
             color: _isAnalyzing
-                ? colorScheme.outline.withOpacity(0.3)
-                : colorScheme.primary.withOpacity(0.3),
+                ? colorScheme.outline.withValues(alpha: 0.3)
+                : colorScheme.primary.withValues(alpha: 0.3),
           ),
           borderRadius: BorderRadius.circular(8),
-          color:
-              _isAnalyzing ? colorScheme.surfaceVariant.withOpacity(0.5) : null,
+          color: _isAnalyzing
+              ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.5)
+              : null,
         ),
         child: Row(
           children: [
@@ -158,7 +159,7 @@ class _PDAAlgorithmPanelState extends ConsumerState<PDAAlgorithmPanel> {
                   Text(
                     description,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.7),
+                          color: colorScheme.onSurface.withValues(alpha: 0.7),
                         ),
                   ),
                 ],
@@ -173,7 +174,7 @@ class _PDAAlgorithmPanelState extends ConsumerState<PDAAlgorithmPanel> {
             else
               Icon(
                 Icons.arrow_forward_ios,
-                color: colorScheme.primary.withOpacity(0.5),
+                color: colorScheme.primary.withValues(alpha: 0.5),
                 size: 16,
               ),
           ],
@@ -209,10 +210,10 @@ class _PDAAlgorithmPanelState extends ConsumerState<PDAAlgorithmPanel> {
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),
       ),
       child: Column(
@@ -248,9 +249,10 @@ class _PDAAlgorithmPanelState extends ConsumerState<PDAAlgorithmPanel> {
       width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3),
+        color:
+            Theme.of(context).colorScheme.primaryContainer.withValues(alpha: 0.3),
         border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.3),
+          color: Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
         ),
         borderRadius: BorderRadius.circular(8),
       ),


### PR DESCRIPTION
## Summary
- replace legacy `withOpacity` color adjustments in the PDA algorithm panel with `withValues`
- switch panel surfaces to use `colorScheme.surfaceContainerHighest`

## Testing
- Not run (Flutter SDK not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68db13b9e158832ea3b2085218f3baae