### PR TITLE
Update pumping lemma widgets to new color APIs

### DIFF
--- a/lib/presentation/widgets/pumping_lemma_game.dart
+++ b/lib/presentation/widgets/pumping_lemma_game.dart
@@ -206,7 +206,7 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -254,7 +254,7 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -302,11 +302,14 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
       child: Container(
         padding: const EdgeInsets.all(12),
         decoration: BoxDecoration(
-          color: isSelected ? color.withOpacity(0.1) : null,
+          color: isSelected ? color.withValues(alpha: 0.1) : null,
           border: Border.all(
             color: isSelected
                 ? color
-                : Theme.of(context).colorScheme.outline.withOpacity(0.3),
+                : Theme.of(context)
+                    .colorScheme
+                    .outline
+                    .withValues(alpha: 0.3),
             width: isSelected ? 2 : 1,
           ),
           borderRadius: BorderRadius.circular(8),
@@ -317,7 +320,10 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
               icon,
               color: isSelected
                   ? color
-                  : Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                  : Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.6),
               size: 24,
             ),
             const SizedBox(width: 12),
@@ -337,7 +343,10 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
             else
               Icon(
                 Icons.radio_button_unchecked,
-                color: Theme.of(context).colorScheme.onSurface.withOpacity(0.6),
+                color: Theme.of(context)
+                    .colorScheme
+                    .onSurface
+                    .withValues(alpha: 0.6),
               ),
           ],
         ),
@@ -369,8 +378,8 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
       constraints: const BoxConstraints(minHeight: 200),
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(

--- a/lib/presentation/widgets/pumping_lemma_help.dart
+++ b/lib/presentation/widgets/pumping_lemma_help.dart
@@ -53,7 +53,10 @@ class _PumpingLemmaHelpState extends ConsumerState<PumpingLemmaHelp> {
       decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(
-            color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+            color: Theme.of(context)
+                .colorScheme
+                .outline
+                .withValues(alpha: 0.2),
           ),
         ),
       ),
@@ -94,7 +97,7 @@ class _PumpingLemmaHelpState extends ConsumerState<PumpingLemmaHelp> {
                       : Theme.of(context)
                           .colorScheme
                           .onSurface
-                          .withOpacity(0.6),
+                          .withValues(alpha: 0.6),
                   fontWeight: isSelected ? FontWeight.w600 : null,
                 ),
           ),
@@ -253,7 +256,7 @@ class _PumpingLemmaHelpState extends ConsumerState<PumpingLemmaHelp> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -285,7 +288,7 @@ class _PumpingLemmaHelpState extends ConsumerState<PumpingLemmaHelp> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -352,8 +355,8 @@ class _PumpingLemmaHelpState extends ConsumerState<PumpingLemmaHelp> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(

--- a/lib/presentation/widgets/pumping_lemma_progress.dart
+++ b/lib/presentation/widgets/pumping_lemma_progress.dart
@@ -59,7 +59,7 @@ class PumpingLemmaProgress extends ConsumerWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -75,7 +75,10 @@ class PumpingLemmaProgress extends ConsumerWidget {
           LinearProgressIndicator(
             value: ratio,
             backgroundColor:
-                Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                Theme.of(context)
+                    .colorScheme
+                    .outline
+                    .withValues(alpha: 0.2),
             valueColor: AlwaysStoppedAnimation<Color>(
               Theme.of(context).colorScheme.primary,
             ),
@@ -112,7 +115,7 @@ class PumpingLemmaProgress extends ConsumerWidget {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -187,8 +190,8 @@ class PumpingLemmaProgress extends ConsumerWidget {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -305,8 +308,8 @@ class PumpingLemmaProgress extends ConsumerWidget {
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
@@ -383,8 +386,8 @@ class PumpingLemmaProgress extends ConsumerWidget {
       margin: const EdgeInsets.only(bottom: 8),
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(


### PR DESCRIPTION
## Summary
- update pumping lemma widgets to use `surfaceContainerHighest` instead of the deprecated `surfaceVariant`
- replace `withOpacity` calls with `withValues` to adopt the latest `Color` API

## Testing
- flutter analyze lib/presentation/widgets/pumping_lemma_game.dart lib/presentation/widgets/pumping_lemma_help.dart lib/presentation/widgets/pumping_lemma_progress.dart *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13bbc914832e95e38a315fc41361