### PR TITLE
Mark streak icon as const in pumping lemma game

### DIFF
--- a/lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart
+++ b/lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart
@@ -290,7 +290,7 @@ class _PumpingLemmaGameState extends ConsumerState<PumpingLemmaGame> {
             ),
             const SizedBox(width: 16),
             if (_streakCount > 0) ...[
-              Icon(
+              const Icon(
                 Icons.local_fire_department,
                 color: Colors.orange,
                 size: 20,


### PR DESCRIPTION
## Summary
- make the streak fire icon constant in the Pumping Lemma game header to avoid unnecessary rebuild work

## Testing
- `flutter analyze lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13bd4770832ebe117fb99be6fc80