### PR TITLE
Update trace viewer empty state styling

### DIFF
--- a/lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
@@ -63,7 +63,7 @@ class _BaseTraceViewerState extends State<BaseTraceViewer> {
             width: double.infinity,
             padding: const EdgeInsets.all(12),
             decoration: BoxDecoration(
-              color: Theme.of(context).colorScheme.surfaceVariant,
+              color: Theme.of(context).colorScheme.surfaceContainerHighest,
               borderRadius: BorderRadius.circular(8),
             ),
             child: Text(
@@ -94,7 +94,7 @@ class _BaseTraceViewerState extends State<BaseTraceViewer> {
                     color: Theme.of(context)
                         .colorScheme
                         .onSurface
-                        .withOpacity(0.6),
+                        .withValues(alpha: 0.6),
                   ),
             ),
           ),


### PR DESCRIPTION
## Summary
- use the newer `surfaceContainerHighest` color for the empty trace container background
- adjust the hidden steps label color to call `withValues` for alpha modification

## Testing
- flutter analyze lib/presentation/widgets/trace_viewers/base_trace_viewer.dart *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13c0524c832ebfa2500914f8e5f9