### PR TITLE
test: fix pumping lemma imports

### DIFF
--- a/test/unit/presentation/pumping_lemma_game_test.dart
+++ b/test/unit/presentation/pumping_lemma_game_test.dart
@@ -1,9 +1,8 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../../../lib/presentation/providers/pumping_lemma_progress_provider.dart';
-import '../../../lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart';
+import 'package:jflutter/presentation/providers/pumping_lemma_progress_provider.dart';
+import 'package:jflutter/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart';
 
 void main() {
   group('Pumping lemma game mode', () {


### PR DESCRIPTION
## Summary
- replace the pumping lemma game test's relative imports with package imports
- remove the unused material import from the pumping lemma game test

## Testing
- `flutter analyze test/unit/presentation/pumping_lemma_game_test.dart` *(fails: flutter command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db13c4df18832eb2fd7a027a812ed6