### PR TITLE
Fix FlutterError message handling in examples data source

### DIFF
--- a/lib/data/data_sources/examples_data_source.dart
+++ b/lib/data/data_sources/examples_data_source.dart
@@ -60,13 +60,14 @@ class ExamplesDataSource {
 
       return Success(example);
     } on foundation.FlutterError catch (e) {
-      final message = e.message ?? e.toString();
-      if (message.contains('Unable to load asset')) {
+      final message = e.message;
+      final resolvedMessage = message.isEmpty ? e.toString() : message;
+      if (resolvedMessage.contains('Unable to load asset')) {
         return Failure(
           'Example asset not found for $name. Expected at jflutter_js/examples/$fileName',
         );
       }
-      return Failure('Error loading example $name: $e');
+      return Failure('Error loading example $name: $resolvedMessage');
     }
   }
 


### PR DESCRIPTION
## Summary
- avoid relying on the null-coalescing operator when reading FlutterError messages
- fall back to the string representation when the message is empty to keep detailed errors

## Testing
- flutter analyze *(fails: Flutter SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db146b9174832eb341c65f66dcda5a