### PR TITLE
Fix PDA simulator facade alias conflicts

### DIFF
--- a/lib/core/algorithms/pda/pda_simulator_facade.dart
+++ b/lib/core/algorithms/pda/pda_simulator_facade.dart
@@ -1,16 +1,16 @@
 import '../../models/pda.dart';
 import '../../result.dart';
-import '../../models/simulation_step.dart';
-import '../../models/simulation_result.dart';
 import '../pda_simulator.dart' as pda;
 
 /// Acceptance mode for PDA: by final state, empty stack, or both.
 typedef PDAAcceptanceMode = pda.PDAAcceptanceMode;
 
+typedef PDASimulationResult = pda.PDASimulationResult;
+
 /// High-level PDA simulator facade supporting different acceptance modes.
 class PDASimulatorFacade {
   static Result<PDASimulationResult> run(
-    PDA pda,
+    PDA automaton,
     String input, {
     PDAAcceptanceMode mode = PDAAcceptanceMode.finalState,
     bool stepByStep = false,
@@ -18,7 +18,7 @@ class PDASimulatorFacade {
   }) {
     // Route to NPDA engine which supports modes and ε/branching.
     return pda.PDASimulator.simulateNPDA(
-      pda,
+      automaton,
       input,
       stepByStep: stepByStep,
       timeout: timeout,


### PR DESCRIPTION
## Summary
- remove unused simulation imports from the PDA simulator facade
- rename the PDA argument to avoid shadowing the module alias
- expose a PDASimulationResult typedef that references the simulator implementation

## Testing
- flutter analyze *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db146c67a8832eb2b56cdaafd9b154