### PR TITLE
core: remove unnecessary non-null assertion

### DIFF
--- a/lib/core/algorithms/grammar_analyzer.dart
+++ b/lib/core/algorithms/grammar_analyzer.dart
@@ -637,7 +637,7 @@ _FactoringResult? _findCommonPrefix(List<List<String>> alternatives) {
         continue;
       }
 
-      if (best == null || prefix.length > best!.prefix.length) {
+      if (best == null || prefix.length > best.prefix.length) {
         best = _FactoringResult(prefix: prefix, alternatives: group);
       }
     }


### PR DESCRIPTION
## Summary
- remove the unnecessary non-null assertion when comparing prefix lengths in the factoring helper

## Testing
- flutter analyze *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db14727030832ea31c094678b36368