### PR TITLE
Modernize regex NFA builder pattern matching

### DIFF
--- a/lib/core/algorithms/regex_to_nfa_converter.dart
+++ b/lib/core/algorithms/regex_to_nfa_converter.dart
@@ -260,34 +260,29 @@ class RegexToNFAConverter {
 
   /// Builds NFA from regex node
   static FSA _buildNFA(RegexNode node, {Set<String>? contextAlphabet}) {
-    switch (node.runtimeType) {
-      case SymbolNode:
-        return _buildSymbolNFA((node as SymbolNode).symbol);
-      case DotNode:
+    switch (node) {
+      case SymbolNode(:final symbol):
+        return _buildSymbolNFA(symbol);
+      case DotNode():
         return _buildDotNFA(contextAlphabet: contextAlphabet);
-      case UnionNode:
-        return _buildUnionNFA(
-            (node as UnionNode).left, (node as UnionNode).right,
+      case UnionNode(:final left, :final right):
+        return _buildUnionNFA(left, right, contextAlphabet: contextAlphabet);
+      case ConcatenationNode(:final left, :final right):
+        return _buildConcatenationNFA(left, right,
             contextAlphabet: contextAlphabet);
-      case ConcatenationNode:
-        return _buildConcatenationNFA(
-            (node as ConcatenationNode).left, (node as ConcatenationNode).right,
+      case KleeneStarNode(:final child):
+        return _buildKleeneStarNFA(child,
             contextAlphabet: contextAlphabet);
-      case KleeneStarNode:
-        return _buildKleeneStarNFA((node as KleeneStarNode).child,
+      case PlusNode(:final child):
+        return _buildPlusNFA(child, contextAlphabet: contextAlphabet);
+      case QuestionNode(:final child):
+        return _buildQuestionNFA(child,
             contextAlphabet: contextAlphabet);
-      case PlusNode:
-        return _buildPlusNFA((node as PlusNode).child,
-            contextAlphabet: contextAlphabet);
-      case QuestionNode:
-        return _buildQuestionNFA((node as QuestionNode).child,
-            contextAlphabet: contextAlphabet);
-      case SetNode:
-        return _buildSetNFA((node as SetNode).symbols);
-      case ShortcutNode:
-        return _buildSetNFA(
-            _expandShortcut((node as ShortcutNode).code, contextAlphabet));
-      default:
+      case SetNode(:final symbols):
+        return _buildSetNFA(symbols);
+      case ShortcutNode(:final code):
+        return _buildSetNFA(_expandShortcut(code, contextAlphabet));
+      case _:
         throw ArgumentError('Unknown regex node type: ${node.runtimeType}');
     }
   }


### PR DESCRIPTION
## Summary
- replace runtimeType checks in `_buildNFA` with modern pattern matching on `RegexNode`
- remove explicit casts while preserving propagation of `contextAlphabet`

## Testing
- flutter analyze *(fails: `flutter` command not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db14712480832e92c73e0a470d76ee