### PR TITLE
core: remove unnecessary transition casts

### DIFF
--- a/lib/core/models/fsa.dart
+++ b/lib/core/models/fsa.dart
@@ -128,7 +128,7 @@ class FSA extends Automaton {
       if (transition is! FSATransition) {
         errors.add('FSA can only contain FSA transitions');
       } else {
-        final fsaTransition = transition as FSATransition;
+        final FSATransition fsaTransition = transition;
         final transitionErrors = fsaTransition.validate();
         errors.addAll(
             transitionErrors.map((e) => 'Transition ${fsaTransition.id}: $e'));

--- a/lib/core/models/pda.dart
+++ b/lib/core/models/pda.dart
@@ -155,7 +155,7 @@ class PDA extends Automaton {
       if (transition is! PDATransition) {
         errors.add('PDA can only contain PDA transitions');
       } else {
-        final pdaTransition = transition as PDATransition;
+        final PDATransition pdaTransition = transition;
         final transitionErrors = pdaTransition.validate();
         errors.addAll(
             transitionErrors.map((e) => 'Transition ${pdaTransition.id}: $e'));

--- a/lib/core/models/tm.dart
+++ b/lib/core/models/tm.dart
@@ -167,7 +167,7 @@ class TM extends Automaton {
       if (transition is! TMTransition) {
         errors.add('TM can only contain TM transitions');
       } else {
-        final tmTransition = transition as TMTransition;
+        final TMTransition tmTransition = transition;
         final transitionErrors = tmTransition.validate();
         errors.addAll(
             transitionErrors.map((e) => 'Transition ${tmTransition.id}: $e'));


### PR DESCRIPTION
## Summary
- update FSA, PDA, and TM validation loops to use direct transition type promotion without redundant casts

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1470d020832ebf25981064d5abad