### PR TITLE
core: remove unused imports from automaton modules

### DIFF
--- a/lib/core/algorithms/automaton_simulator.dart
+++ b/lib/core/algorithms/automaton_simulator.dart
@@ -1,12 +1,9 @@
-import 'dart:async';
-
 import '../models/fsa.dart';
 import '../models/state.dart';
 import '../models/fsa_transition.dart';
 import '../models/simulation_result.dart';
 import '../models/simulation_step.dart';
 import '../result.dart';
-import 'common/throttling.dart';
 
 /// Simulates Finite Automata (FA) with input strings
 class AutomatonSimulator {

--- a/lib/core/algorithms/grammar_to_pda_converter.dart
+++ b/lib/core/algorithms/grammar_to_pda_converter.dart
@@ -1,10 +1,8 @@
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 import '../models/grammar.dart';
-import '../models/production.dart';
 import '../models/pda.dart';
 import '../models/state.dart';
-import '../models/transition.dart';
 import '../models/pda_transition.dart';
 import '../result.dart';
 

--- a/lib/core/algorithms/nfa_to_dfa_converter.dart
+++ b/lib/core/algorithms/nfa_to_dfa_converter.dart
@@ -1,4 +1,3 @@
-import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 import '../models/fsa.dart';
 import '../models/state.dart';

--- a/lib/core/algorithms/pda_simulator.dart
+++ b/lib/core/algorithms/pda_simulator.dart
@@ -4,7 +4,6 @@ import '../models/pda.dart';
 import '../models/state.dart';
 import '../models/pda_transition.dart';
 import '../models/fsa_transition.dart';
-import '../models/simulation_result.dart';
 import '../models/simulation_step.dart';
 import '../models/transition.dart';
 import '../result.dart';

--- a/lib/core/algorithms/tm_simulator.dart
+++ b/lib/core/algorithms/tm_simulator.dart
@@ -1,5 +1,4 @@
 import '../models/fsa_transition.dart';
-import '../models/simulation_result.dart';
 import '../models/simulation_step.dart';
 import '../models/state.dart';
 import '../models/tm.dart';

--- a/lib/core/entities/automaton_entity.dart
+++ b/lib/core/entities/automaton_entity.dart
@@ -1,5 +1,3 @@
-import '../result.dart';
-
 /// Core domain entity representing an automaton
 /// This is the central business entity that all other layers depend on
 class AutomatonEntity {


### PR DESCRIPTION
## Summary
- remove unused imports from automaton and simulator implementations
- clean up grammar converter and automaton entity modules by eliminating unused dependencies

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db14709e10832eb78e9da265ee9ed7