### PR TITLE
Remove unused imports in pumping lemma algorithms

### DIFF
--- a/lib/core/algorithms/pumping_lemma_game.dart
+++ b/lib/core/algorithms/pumping_lemma_game.dart
@@ -1,6 +1,5 @@
 import '../models/fsa.dart';
 import '../models/state.dart';
-import '../models/fsa_transition.dart';
 import '../models/pumping_lemma_game.dart' as models;
 import '../models/pumping_attempt.dart';
 import '../result.dart';
@@ -72,8 +71,6 @@ class PumpingLemmaGame {
     int maxPumpingLength,
     Duration timeout,
   ) {
-    final startTime = DateTime.now();
-
     // Find the pumping length
     final pumpingLength =
         _findPumpingLength(automaton, maxPumpingLength, timeout);

--- a/lib/core/algorithms/pumping_lemma_prover.dart
+++ b/lib/core/algorithms/pumping_lemma_prover.dart
@@ -1,6 +1,5 @@
 import '../models/fsa.dart';
 import '../models/state.dart';
-import '../models/fsa_transition.dart';
 import '../result.dart';
 
 /// Proves or disproves the pumping lemma for regular languages
@@ -465,8 +464,6 @@ class PumpingLemmaProver {
     int maxPumpingLength,
     Duration timeout,
   ) {
-    final startTime = DateTime.now();
-
     // Find the pumping length
     final pumpingLength =
         _findPumpingLength(automaton, maxPumpingLength, timeout);


### PR DESCRIPTION
## Summary
- remove unused `fsa_transition` imports from pumping lemma game and prover
- drop unused start time variables in game creation and regularity test helpers

## Testing
- `flutter analyze` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db146d0314832e89f5adf11439b5dc