### PR TITLE
Add Turing machine entity for SVG exports

### DIFF
--- a/lib/core/entities/turing_machine_entity.dart
+++ b/lib/core/entities/turing_machine_entity.dart
@@ -1,0 +1,84 @@
+/// Core domain entity representing a Turing machine
+class TuringMachineEntity {
+  final String id;
+  final String name;
+  final Set<String> inputAlphabet;
+  final Set<String> tapeAlphabet;
+  final String blankSymbol;
+  final List<TuringStateEntity> states;
+  final List<TuringTransitionEntity> transitions;
+  final String initialStateId;
+  final Set<String> acceptingStateIds;
+  final Set<String> rejectingStateIds;
+  final int nextStateIndex;
+
+  const TuringMachineEntity({
+    required this.id,
+    required this.name,
+    required this.inputAlphabet,
+    required this.tapeAlphabet,
+    required this.blankSymbol,
+    required this.states,
+    required this.transitions,
+    required this.initialStateId,
+    required this.acceptingStateIds,
+    required this.rejectingStateIds,
+    this.nextStateIndex = 0,
+  });
+
+  TuringStateEntity? getStateById(String stateId) {
+    try {
+      return states.firstWhere((state) => state.id == stateId);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  Iterable<TuringTransitionEntity> transitionsFrom(String stateId) =>
+      transitions.where((transition) => transition.fromStateId == stateId);
+
+  bool get hasStates => states.isNotEmpty;
+}
+
+/// Represents a state in a Turing machine
+class TuringStateEntity {
+  final String id;
+  final String name;
+  final bool isInitial;
+  final bool isAccepting;
+  final bool isRejecting;
+
+  const TuringStateEntity({
+    required this.id,
+    required this.name,
+    this.isInitial = false,
+    this.isAccepting = false,
+    this.isRejecting = false,
+  });
+}
+
+/// Represents a transition in a Turing machine
+class TuringTransitionEntity {
+  final String id;
+  final String fromStateId;
+  final String toStateId;
+  final String readSymbol;
+  final String writeSymbol;
+  final TuringMoveDirection moveDirection;
+
+  const TuringTransitionEntity({
+    required this.id,
+    required this.fromStateId,
+    required this.toStateId,
+    required this.readSymbol,
+    required this.writeSymbol,
+    required this.moveDirection,
+  });
+}
+
+/// Directions the Turing machine head can move
+enum TuringMoveDirection {
+  left,
+  right,
+  stay,
+}

--- a/lib/data/services/file_operations_service.dart
+++ b/lib/data/services/file_operations_service.dart
@@ -10,14 +10,13 @@ import 'package:xml/xml.dart';
 import '../../core/entities/automaton_entity.dart';
 import '../../core/entities/grammar_entity.dart';
 import '../../core/entities/turing_machine_entity.dart';
-import '../../core/models/automaton_type.dart';
 import '../../core/models/fsa.dart';
 import '../../core/models/grammar.dart';
 import '../../core/models/production.dart';
 import '../../core/models/state.dart' as automaton_state;
 import '../../core/models/fsa_transition.dart';
 import '../../core/result.dart';
-import '../widgets/export/svg_exporter.dart';
+import '../../presentation/widgets/export/svg_exporter.dart';
 
 /// Service for file operations including JFLAP format support
 class FileOperationsService {
@@ -330,7 +329,7 @@ class FileOperationsService {
       builder.attribute('type', 'grammar');
       builder.element('grammar', nest: () {
         builder.attribute('type', grammar.type.name);
-        builder.element('start', nest: grammar.startSymbol ?? '');
+        builder.element('start', nest: grammar.startSymbol);
 
         for (final production in grammar.productions) {
           builder.element('production', nest: () {


### PR DESCRIPTION
## Summary
- add an immutable `TuringMachineEntity` with state and transition metadata required for exports
- update the file operations service imports and grammar XML writer to match the new presentation layout
- type the SVG exporter Turing machine path and derive an automaton visualization from the entity data

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1468edbc832eb58c87c7d5642235