### PR TITLE
Update TM widgets to newer material APIs

### DIFF
--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -152,16 +152,16 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
         decoration: BoxDecoration(
           border: Border.all(
             color: _isAnalyzing
-                ? colorScheme.outline.withOpacity(0.3)
+                ? colorScheme.outline.withValues(alpha: 0.3)
                 : isSelected
                     ? colorScheme.primary
-                    : colorScheme.primary.withOpacity(0.3),
+                    : colorScheme.primary.withValues(alpha: 0.3),
           ),
           borderRadius: BorderRadius.circular(8),
           color: _isAnalyzing
-              ? colorScheme.surfaceVariant.withOpacity(0.5)
+              ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.5)
               : isSelected
-                  ? colorScheme.primaryContainer.withOpacity(0.35)
+                  ? colorScheme.primaryContainer.withValues(alpha: 0.35)
                   : null,
         ),
         child: Row(
@@ -189,7 +189,7 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
                   Text(
                     description,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.7),
+                          color: colorScheme.onSurface.withValues(alpha: 0.7),
                         ),
                   ),
                 ],
@@ -204,7 +204,7 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
             else
               Icon(
                 Icons.arrow_forward_ios,
-                color: colorScheme.primary.withOpacity(0.5),
+                color: colorScheme.primary.withValues(alpha: 0.5),
                 size: 16,
               ),
           ],
@@ -240,10 +240,10 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),
       ),
       child: Column(
@@ -282,8 +282,8 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
           borderRadius: BorderRadius.circular(8),
-          border: Border.all(color: colorScheme.error.withOpacity(0.2)),
-          color: colorScheme.errorContainer.withOpacity(0.4),
+          border: Border.all(color: colorScheme.error.withValues(alpha: 0.2)),
+          color: colorScheme.errorContainer.withValues(alpha: 0.4),
         ),
         child: Row(
           crossAxisAlignment: CrossAxisAlignment.start,
@@ -512,9 +512,9 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: colorScheme.surfaceVariant,
+        color: colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
-        border: Border.all(color: colorScheme.outline.withOpacity(0.4)),
+        border: Border.all(color: colorScheme.outline.withValues(alpha: 0.4)),
       ),
       child: SingleChildScrollView(
         child: Column(
@@ -573,7 +573,7 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: colorScheme.primaryContainer.withOpacity(0.5),
+        color: colorScheme.primaryContainer.withValues(alpha: 0.5),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Row(
@@ -627,10 +627,10 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
         border: Border.all(
           color: highlight
               ? colorScheme.primary
-              : colorScheme.outline.withOpacity(0.4),
+              : colorScheme.outline.withValues(alpha: 0.4),
         ),
         color: highlight
-            ? colorScheme.primaryContainer.withOpacity(0.35)
+            ? colorScheme.primaryContainer.withValues(alpha: 0.35)
             : colorScheme.surface,
       ),
       child: Column(
@@ -749,12 +749,12 @@ class _TMAlgorithmPanelState extends ConsumerState<TMAlgorithmPanel> {
                   (value) => Chip(
                     label: Text(value),
                     backgroundColor: isWarning
-                        ? colorScheme.errorContainer.withOpacity(0.5)
-                        : colorScheme.secondaryContainer.withOpacity(0.4),
+                        ? colorScheme.errorContainer.withValues(alpha: 0.5)
+                        : colorScheme.secondaryContainer.withValues(alpha: 0.4),
                     side: BorderSide(
                       color: isWarning
                           ? colorScheme.error
-                          : colorScheme.secondary.withOpacity(0.5),
+                          : colorScheme.secondary.withValues(alpha: 0.5),
                     ),
                   ),
                 )

--- a/lib/presentation/widgets/tm_canvas.dart
+++ b/lib/presentation/widgets/tm_canvas.dart
@@ -58,7 +58,7 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
                 color: Theme.of(context).colorScheme.surface,
                 borderRadius: BorderRadius.circular(8),
                 border: Border.all(
-                  color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+                  color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
                 ),
               ),
               child: ClipRRect(
@@ -326,55 +326,61 @@ class _TMCanvasState extends ConsumerState<TMCanvas> {
     final result = await showDialog<TMTransition>(
       context: context,
       builder: (context) {
-        return AlertDialog(
-          title: const Text('Edit Transition'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              _buildTextField(readController, 'Read Symbol'),
-              const SizedBox(height: 12),
-              _buildTextField(writeController, 'Write Symbol'),
-              const SizedBox(height: 12),
-              DropdownButtonFormField<TapeDirection>(
-                value: direction,
-                items: TapeDirection.values
-                    .map(
-                      (dir) => DropdownMenuItem(
-                        value: dir,
-                        child: Text(dir.name.toUpperCase()),
-                      ),
-                    )
-                    .toList(),
-                onChanged: (value) {
-                  if (value != null) {
-                    direction = value;
-                  }
-                },
-                decoration: const InputDecoration(
-                  labelText: 'Direction',
-                  border: OutlineInputBorder(),
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.of(context).pop(),
-              child: const Text('Cancel'),
-            ),
-            FilledButton(
-              onPressed: () {
-                Navigator.of(context).pop(
-                  transition.copyWith(
-                    readSymbol: readController.text.trim(),
-                    writeSymbol: writeController.text.trim(),
-                    direction: direction,
+        return StatefulBuilder(
+          builder: (context, setDialogState) {
+            return AlertDialog(
+              title: const Text('Edit Transition'),
+              content: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  _buildTextField(readController, 'Read Symbol'),
+                  const SizedBox(height: 12),
+                  _buildTextField(writeController, 'Write Symbol'),
+                  const SizedBox(height: 12),
+                  DropdownButtonFormField<TapeDirection>(
+                    initialValue: direction,
+                    items: TapeDirection.values
+                        .map(
+                          (dir) => DropdownMenuItem(
+                            value: dir,
+                            child: Text(dir.name.toUpperCase()),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (value) {
+                      if (value != null) {
+                        setDialogState(() {
+                          direction = value;
+                        });
+                      }
+                    },
+                    decoration: const InputDecoration(
+                      labelText: 'Direction',
+                      border: OutlineInputBorder(),
+                    ),
                   ),
-                );
-              },
-              child: const Text('Save'),
-            ),
-          ],
+                ],
+              ),
+              actions: [
+                TextButton(
+                  onPressed: () => Navigator.of(context).pop(),
+                  child: const Text('Cancel'),
+                ),
+                FilledButton(
+                  onPressed: () {
+                    Navigator.of(context).pop(
+                      transition.copyWith(
+                        readSymbol: readController.text.trim(),
+                        writeSymbol: writeController.text.trim(),
+                        direction: direction,
+                      ),
+                    );
+                  },
+                  child: const Text('Save'),
+                ),
+              ],
+            );
+          },
         );
       },
     );
@@ -444,8 +450,8 @@ class _TMCanvasPainter extends CustomPainter {
   void _drawState(Canvas canvas, automaton_state.State state) {
     final paint = Paint()
       ..color = state == selectedState
-          ? Colors.blue.withOpacity(0.3)
-          : Colors.grey.withOpacity(0.2)
+          ? Colors.blue.withValues(alpha: 0.3)
+          : Colors.grey.withValues(alpha: 0.2)
       ..style = PaintingStyle.fill;
 
     final strokePaint = Paint()

--- a/lib/presentation/widgets/tm_simulation_panel.dart
+++ b/lib/presentation/widgets/tm_simulation_panel.dart
@@ -73,7 +73,7 @@ class _TMSimulationPanelState extends ConsumerState<TMSimulationPanel> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -99,7 +99,7 @@ class _TMSimulationPanelState extends ConsumerState<TMSimulationPanel> {
             'Examples: 101 (binary), 1100 (palindrome), 111 (counting)',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
                   color:
-                      Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                      Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.7),
                 ),
           ),
         ],
@@ -151,10 +151,10 @@ class _TMSimulationPanelState extends ConsumerState<TMSimulationPanel> {
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          color: Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),
       ),
       child: Column(
@@ -192,7 +192,7 @@ class _TMSimulationPanelState extends ConsumerState<TMSimulationPanel> {
         padding: const EdgeInsets.all(16),
         decoration: BoxDecoration(
           color: colorScheme.errorContainer,
-          border: Border.all(color: colorScheme.error.withOpacity(0.4)),
+          border: Border.all(color: colorScheme.error.withValues(alpha: 0.4)),
           borderRadius: BorderRadius.circular(8),
         ),
         child: Row(
@@ -221,8 +221,8 @@ class _TMSimulationPanelState extends ConsumerState<TMSimulationPanel> {
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(


### PR DESCRIPTION
## Summary
- replace deprecated `withOpacity` usages with `withValues` and adopt `surfaceContainerHighest`
- update Turing Machine widget styling to align with the latest Material color scheme
- refactor the TM canvas transition dialog to use `DropdownButtonFormField.initialValue` with local dialog state

## Testing
- Not run (flutter is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68db13beffdc832e8c5f3c465cce7e30