### PR TITLE
Update simulation panel color handling

### DIFF
--- a/lib/presentation/widgets/simulation_panel.dart
+++ b/lib/presentation/widgets/simulation_panel.dart
@@ -230,13 +230,13 @@ class _SimulationPanelState extends State<SimulationPanel> {
   Widget _buildResultCard(BuildContext context, SimulationResult result) {
     final colorScheme = Theme.of(context).colorScheme;
     final isAccepted = result.isAccepted;
-    final color = isAccepted ? Colors.green : Colors.red;
+    final color = isAccepted ? colorScheme.tertiary : colorScheme.error;
 
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -286,8 +286,8 @@ class _SimulationPanelState extends State<SimulationPanel> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: colorScheme.primary.withOpacity(0.1),
-        border: Border.all(color: colorScheme.primary.withOpacity(0.3)),
+        color: colorScheme.primary.withValues(alpha: 0.1),
+        border: Border.all(color: colorScheme.primary.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -405,7 +405,7 @@ class _SimulationPanelState extends State<SimulationPanel> {
                       color: Theme.of(context)
                           .colorScheme
                           .onSurface
-                          .withOpacity(0.7),
+                          .withValues(alpha: 0.7),
                     ),
               ),
             ],
@@ -433,9 +433,10 @@ class _SimulationPanelState extends State<SimulationPanel> {
   Widget _buildCurrentStep(BuildContext context, SimulationStep step) {
     final bool isFinal = _currentStepIndex == _simulationSteps.length - 1;
     final bool accepted = widget.simulationResult?.isAccepted ?? false;
+    final colorScheme = Theme.of(context).colorScheme;
     final color = isFinal
-        ? (accepted ? Colors.green : Colors.red)
-        : Theme.of(context).colorScheme.primary;
+        ? (accepted ? colorScheme.tertiary : colorScheme.error)
+        : colorScheme.primary;
     final icon = isFinal
         ? (accepted ? Icons.check_circle : Icons.cancel)
         : Icons.play_circle;
@@ -447,8 +448,8 @@ class _SimulationPanelState extends State<SimulationPanel> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.12),
-        border: Border.all(color: color.withOpacity(0.35)),
+        color: color.withValues(alpha: 0.12),
+        border: Border.all(color: color.withValues(alpha: 0.35)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -539,13 +540,15 @@ class _SimulationPanelState extends State<SimulationPanel> {
         color: Theme.of(context).colorScheme.surface,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          color: Theme.of(context)
+              .colorScheme
+              .outline
+              .withValues(alpha: 0.2),
         ),
       ),
       child: ListView.builder(
         itemCount: _simulationSteps.length,
         itemBuilder: (context, index) {
-          final step = _simulationSteps[index];
           final isCurrentStep = index == _currentStepIndex;
           final isFinal = index == _simulationSteps.length - 1;
           final isAcceptedStep =
@@ -559,7 +562,7 @@ class _SimulationPanelState extends State<SimulationPanel> {
                   ? Theme.of(context)
                       .colorScheme
                       .primaryContainer
-                      .withOpacity(0.3)
+                      .withValues(alpha: 0.3)
                   : null,
               borderRadius: BorderRadius.circular(4),
             ),
@@ -569,7 +572,10 @@ class _SimulationPanelState extends State<SimulationPanel> {
                   radius: 12,
                   backgroundColor: isCurrentStep
                       ? Theme.of(context).colorScheme.primary
-                      : Theme.of(context).colorScheme.outline.withOpacity(0.3),
+                      : Theme.of(context)
+                          .colorScheme
+                          .outline
+                          .withValues(alpha: 0.3),
                   child: Text(
                     '${index + 1}',
                     style: TextStyle(
@@ -593,7 +599,7 @@ class _SimulationPanelState extends State<SimulationPanel> {
                 if (isAcceptedStep)
                   Icon(
                     Icons.check_circle,
-                    color: Colors.green,
+                    color: Theme.of(context).colorScheme.tertiary,
                     size: 16,
                   ),
               ],


### PR DESCRIPTION
## Summary
- replace deprecated `withOpacity` calls with the new `withValues` API
- align success and error tones with the active `ColorScheme`
- remove the unused step variable from the step list builder

## Testing
- flutter analyze lib/presentation/widgets/simulation_panel.dart *(fails: flutter not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db13bdf360832eb2ac33eefd06aa47