### PR TITLE
Update grammar widgets for Material 3 color changes

### DIFF
--- a/lib/presentation/widgets/grammar_algorithm_panel.dart
+++ b/lib/presentation/widgets/grammar_algorithm_panel.dart
@@ -156,7 +156,7 @@ class _GrammarAlgorithmPanelState extends ConsumerState<GrammarAlgorithmPanel> {
                     color: Theme.of(context)
                         .colorScheme
                         .onSurface
-                        .withOpacity(0.7),
+                        .withValues(alpha: 0.7),
                   ),
             ),
           ),
@@ -191,12 +191,13 @@ class _GrammarAlgorithmPanelState extends ConsumerState<GrammarAlgorithmPanel> {
         decoration: BoxDecoration(
           border: Border.all(
             color: _isAnalyzing
-                ? colorScheme.outline.withOpacity(0.3)
-                : colorScheme.primary.withOpacity(0.3),
+                ? colorScheme.outline.withValues(alpha: 0.3)
+                : colorScheme.primary.withValues(alpha: 0.3),
           ),
           borderRadius: BorderRadius.circular(8),
-          color:
-              _isAnalyzing ? colorScheme.surfaceVariant.withOpacity(0.5) : null,
+          color: _isAnalyzing
+              ? colorScheme.surfaceContainerHighest.withValues(alpha: 0.5)
+              : null,
         ),
         child: Row(
           children: [
@@ -223,7 +224,7 @@ class _GrammarAlgorithmPanelState extends ConsumerState<GrammarAlgorithmPanel> {
                   Text(
                     description,
                     style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                          color: colorScheme.onSurface.withOpacity(0.7),
+                          color: colorScheme.onSurface.withValues(alpha: 0.7),
                         ),
                   ),
                 ],
@@ -238,7 +239,7 @@ class _GrammarAlgorithmPanelState extends ConsumerState<GrammarAlgorithmPanel> {
             else
               Icon(
                 Icons.arrow_forward_ios,
-                color: colorScheme.primary.withOpacity(0.5),
+                color: colorScheme.primary.withValues(alpha: 0.5),
                 size: 16,
               ),
           ],
@@ -306,10 +307,11 @@ class _GrammarAlgorithmPanelState extends ConsumerState<GrammarAlgorithmPanel> {
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          color:
+              Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),
       ),
       child: Column(
@@ -345,9 +347,13 @@ class _GrammarAlgorithmPanelState extends ConsumerState<GrammarAlgorithmPanel> {
       width: double.infinity,
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.primaryContainer.withOpacity(0.3),
+        color: Theme.of(context)
+            .colorScheme
+            .primaryContainer
+            .withValues(alpha: 0.3),
         border: Border.all(
-          color: Theme.of(context).colorScheme.primary.withOpacity(0.3),
+          color:
+              Theme.of(context).colorScheme.primary.withValues(alpha: 0.3),
         ),
         borderRadius: BorderRadius.circular(8),
       ),

--- a/lib/presentation/widgets/grammar_editor.dart
+++ b/lib/presentation/widgets/grammar_editor.dart
@@ -164,7 +164,7 @@ class _GrammarEditorState extends ConsumerState<GrammarEditor> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -253,7 +253,7 @@ class _GrammarEditorState extends ConsumerState<GrammarEditor> {
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -411,16 +411,17 @@ class _GrammarEditorState extends ConsumerState<GrammarEditor> {
               ),
         ),
         const SizedBox(height: 8),
-        productions.isEmpty
-            ? _buildEmptyState(context)
-            : Column(
-                mainAxisSize: MainAxisSize.min,
-                children: productions.asMap().entries.map((entry) {
-                  final index = entry.key;
-                  final production = entry.value;
-                  return _buildProductionItem(context, production, index);
-                }).toList(),
-              ),
+        if (productions.isEmpty)
+          _buildEmptyState(context)
+        else
+          Column(
+            mainAxisSize: MainAxisSize.min,
+            children: productions.asMap().entries.map((entry) {
+              final index = entry.key;
+              final production = entry.value;
+              return _buildProductionItem(context, production, index);
+            }).toList(),
+          ),
       ],
     );
   }
@@ -467,7 +468,10 @@ class _GrammarEditorState extends ConsumerState<GrammarEditor> {
         border: Border.all(
           color: isSelected
               ? Theme.of(context).colorScheme.primary
-              : Theme.of(context).colorScheme.outline.withOpacity(0.2),
+              : Theme.of(context)
+                  .colorScheme
+                  .outline
+                  .withValues(alpha: 0.2),
         ),
         borderRadius: BorderRadius.circular(8),
       ),

--- a/lib/presentation/widgets/grammar_simulation_panel.dart
+++ b/lib/presentation/widgets/grammar_simulation_panel.dart
@@ -76,7 +76,7 @@ class _GrammarSimulationPanelState
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -90,7 +90,7 @@ class _GrammarSimulationPanelState
           ),
           const SizedBox(height: 8),
           DropdownButtonFormField<String>(
-            value: _selectedAlgorithm,
+            initialValue: _selectedAlgorithm,
             decoration: const InputDecoration(
               border: OutlineInputBorder(),
               isDense: true,
@@ -102,8 +102,11 @@ class _GrammarSimulationPanelState
               DropdownMenuItem(value: 'LR', child: Text('LR Parser')),
             ],
             onChanged: (value) {
+              if (value == null) {
+                return;
+              }
               setState(() {
-                _selectedAlgorithm = value!;
+                _selectedAlgorithm = value;
               });
             },
           ),
@@ -116,7 +119,7 @@ class _GrammarSimulationPanelState
     return Container(
       padding: const EdgeInsets.all(12),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(
@@ -142,8 +145,10 @@ class _GrammarSimulationPanelState
           Text(
             'Examples: aabb, abab, aabbb (for S → aSb | ab)',
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
-                  color:
-                      Theme.of(context).colorScheme.onSurface.withOpacity(0.7),
+                  color: Theme.of(context)
+                      .colorScheme
+                      .onSurface
+                      .withValues(alpha: 0.7),
                 ),
           ),
         ],
@@ -195,10 +200,11 @@ class _GrammarSimulationPanelState
       width: double.infinity,
       padding: const EdgeInsets.all(24),
       decoration: BoxDecoration(
-        color: Theme.of(context).colorScheme.surfaceVariant,
+        color: Theme.of(context).colorScheme.surfaceContainerHighest,
         borderRadius: BorderRadius.circular(8),
         border: Border.all(
-          color: Theme.of(context).colorScheme.outline.withOpacity(0.2),
+          color:
+              Theme.of(context).colorScheme.outline.withValues(alpha: 0.2),
         ),
       ),
       child: Column(
@@ -236,8 +242,8 @@ class _GrammarSimulationPanelState
     return Container(
       padding: const EdgeInsets.all(16),
       decoration: BoxDecoration(
-        color: color.withOpacity(0.1),
-        border: Border.all(color: color.withOpacity(0.3)),
+        color: color.withValues(alpha: 0.1),
+        border: Border.all(color: color.withValues(alpha: 0.3)),
         borderRadius: BorderRadius.circular(8),
       ),
       child: Column(


### PR DESCRIPTION
## Summary
- replace deprecated color APIs in grammar algorithm, editor, and simulation panels
- convert conditional widget lists to collection `if` blocks and clean up lints in the grammar editor
- refresh the grammar simulation dropdown to use `initialValue` and modern Material colors

## Testing
- flutter analyze lib/presentation/widgets/grammar_algorithm_panel.dart lib/presentation/widgets/grammar_editor.dart lib/presentation/widgets/grammar_simulation_panel.dart *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db13b85298832eb5955a911b26e3b0