### PR TITLE
Regenerate grammar and TM DTO codegen outputs

### DIFF
--- a/lib/data/models/grammar_dto.freezed.dart
+++ b/lib/data/models/grammar_dto.freezed.dart
@@ -1,0 +1,1153 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'grammar_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$GrammarDto {
+
+ String get id; String get name; String get type; List<String> get terminals; List<String> get variables; String get initialSymbol; Map<String, List<String>> get productions;
+/// Create a copy of GrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$GrammarDtoCopyWith<GrammarDto> get copyWith => _$GrammarDtoCopyWithImpl<GrammarDto>(this as GrammarDto, _$identity);
+
+  /// Serializes this GrammarDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is GrammarDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.terminals, terminals)&&const DeepCollectionEquality().equals(other.variables, variables)&&(identical(other.initialSymbol, initialSymbol) || other.initialSymbol == initialSymbol)&&const DeepCollectionEquality().equals(other.productions, productions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,type,const DeepCollectionEquality().hash(terminals),const DeepCollectionEquality().hash(variables),initialSymbol,const DeepCollectionEquality().hash(productions));
+
+@override
+String toString() {
+  return 'GrammarDto(id: $id, name: $name, type: $type, terminals: $terminals, variables: $variables, initialSymbol: $initialSymbol, productions: $productions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $GrammarDtoCopyWith<$Res>  {
+  factory $GrammarDtoCopyWith(GrammarDto value, $Res Function(GrammarDto) _then) = _$GrammarDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String type, List<String> terminals, List<String> variables, String initialSymbol, Map<String, List<String>> productions
+});
+
+
+
+
+}
+/// @nodoc
+class _$GrammarDtoCopyWithImpl<$Res>
+    implements $GrammarDtoCopyWith<$Res> {
+  _$GrammarDtoCopyWithImpl(this._self, this._then);
+
+  final GrammarDto _self;
+  final $Res Function(GrammarDto) _then;
+
+/// Create a copy of GrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? terminals = null,Object? variables = null,Object? initialSymbol = null,Object? productions = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,terminals: null == terminals ? _self.terminals : terminals // ignore: cast_nullable_to_non_nullable
+as List<String>,variables: null == variables ? _self.variables : variables // ignore: cast_nullable_to_non_nullable
+as List<String>,initialSymbol: null == initialSymbol ? _self.initialSymbol : initialSymbol // ignore: cast_nullable_to_non_nullable
+as String,productions: null == productions ? _self.productions : productions // ignore: cast_nullable_to_non_nullable
+as Map<String, List<String>>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [GrammarDto].
+extension GrammarDtoPatterns on GrammarDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _GrammarDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _GrammarDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _GrammarDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _GrammarDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _GrammarDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _GrammarDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String type,  List<String> terminals,  List<String> variables,  String initialSymbol,  Map<String, List<String>> productions)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _GrammarDto() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.terminals,_that.variables,_that.initialSymbol,_that.productions);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String type,  List<String> terminals,  List<String> variables,  String initialSymbol,  Map<String, List<String>> productions)  $default,) {final _that = this;
+switch (_that) {
+case _GrammarDto():
+return $default(_that.id,_that.name,_that.type,_that.terminals,_that.variables,_that.initialSymbol,_that.productions);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String type,  List<String> terminals,  List<String> variables,  String initialSymbol,  Map<String, List<String>> productions)?  $default,) {final _that = this;
+switch (_that) {
+case _GrammarDto() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.terminals,_that.variables,_that.initialSymbol,_that.productions);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _GrammarDto implements GrammarDto {
+  const _GrammarDto({required this.id, required this.name, required this.type, required final  List<String> terminals, required final  List<String> variables, required this.initialSymbol, required final  Map<String, List<String>> productions}): _terminals = terminals,_variables = variables,_productions = productions;
+  factory _GrammarDto.fromJson(Map<String, dynamic> json) => _$GrammarDtoFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override final  String type;
+ final  List<String> _terminals;
+@override List<String> get terminals {
+  if (_terminals is EqualUnmodifiableListView) return _terminals;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_terminals);
+}
+
+ final  List<String> _variables;
+@override List<String> get variables {
+  if (_variables is EqualUnmodifiableListView) return _variables;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_variables);
+}
+
+@override final  String initialSymbol;
+ final  Map<String, List<String>> _productions;
+@override Map<String, List<String>> get productions {
+  if (_productions is EqualUnmodifiableMapView) return _productions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_productions);
+}
+
+
+/// Create a copy of GrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$GrammarDtoCopyWith<_GrammarDto> get copyWith => __$GrammarDtoCopyWithImpl<_GrammarDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$GrammarDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _GrammarDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other._terminals, _terminals)&&const DeepCollectionEquality().equals(other._variables, _variables)&&(identical(other.initialSymbol, initialSymbol) || other.initialSymbol == initialSymbol)&&const DeepCollectionEquality().equals(other._productions, _productions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,type,const DeepCollectionEquality().hash(_terminals),const DeepCollectionEquality().hash(_variables),initialSymbol,const DeepCollectionEquality().hash(_productions));
+
+@override
+String toString() {
+  return 'GrammarDto(id: $id, name: $name, type: $type, terminals: $terminals, variables: $variables, initialSymbol: $initialSymbol, productions: $productions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$GrammarDtoCopyWith<$Res> implements $GrammarDtoCopyWith<$Res> {
+  factory _$GrammarDtoCopyWith(_GrammarDto value, $Res Function(_GrammarDto) _then) = __$GrammarDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, String type, List<String> terminals, List<String> variables, String initialSymbol, Map<String, List<String>> productions
+});
+
+
+
+
+}
+/// @nodoc
+class __$GrammarDtoCopyWithImpl<$Res>
+    implements _$GrammarDtoCopyWith<$Res> {
+  __$GrammarDtoCopyWithImpl(this._self, this._then);
+
+  final _GrammarDto _self;
+  final $Res Function(_GrammarDto) _then;
+
+/// Create a copy of GrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? terminals = null,Object? variables = null,Object? initialSymbol = null,Object? productions = null,}) {
+  return _then(_GrammarDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,terminals: null == terminals ? _self._terminals : terminals // ignore: cast_nullable_to_non_nullable
+as List<String>,variables: null == variables ? _self._variables : variables // ignore: cast_nullable_to_non_nullable
+as List<String>,initialSymbol: null == initialSymbol ? _self.initialSymbol : initialSymbol // ignore: cast_nullable_to_non_nullable
+as String,productions: null == productions ? _self._productions : productions // ignore: cast_nullable_to_non_nullable
+as Map<String, List<String>>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$JflapGrammarDto {
+
+ String get type; JflapGrammarStructureDto get structure;
+/// Create a copy of JflapGrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JflapGrammarDtoCopyWith<JflapGrammarDto> get copyWith => _$JflapGrammarDtoCopyWithImpl<JflapGrammarDto>(this as JflapGrammarDto, _$identity);
+
+  /// Serializes this JflapGrammarDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JflapGrammarDto&&(identical(other.type, type) || other.type == type)&&(identical(other.structure, structure) || other.structure == structure));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,structure);
+
+@override
+String toString() {
+  return 'JflapGrammarDto(type: $type, structure: $structure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JflapGrammarDtoCopyWith<$Res>  {
+  factory $JflapGrammarDtoCopyWith(JflapGrammarDto value, $Res Function(JflapGrammarDto) _then) = _$JflapGrammarDtoCopyWithImpl;
+@useResult
+$Res call({
+ String type, JflapGrammarStructureDto structure
+});
+
+
+$JflapGrammarStructureDtoCopyWith<$Res> get structure;
+
+}
+/// @nodoc
+class _$JflapGrammarDtoCopyWithImpl<$Res>
+    implements $JflapGrammarDtoCopyWith<$Res> {
+  _$JflapGrammarDtoCopyWithImpl(this._self, this._then);
+
+  final JflapGrammarDto _self;
+  final $Res Function(JflapGrammarDto) _then;
+
+/// Create a copy of JflapGrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? structure = null,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,structure: null == structure ? _self.structure : structure // ignore: cast_nullable_to_non_nullable
+as JflapGrammarStructureDto,
+  ));
+}
+/// Create a copy of JflapGrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$JflapGrammarStructureDtoCopyWith<$Res> get structure {
+  
+  return $JflapGrammarStructureDtoCopyWith<$Res>(_self.structure, (value) {
+    return _then(_self.copyWith(structure: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [JflapGrammarDto].
+extension JflapGrammarDtoPatterns on JflapGrammarDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JflapGrammarDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JflapGrammarDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JflapGrammarDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _JflapGrammarDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JflapGrammarDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JflapGrammarDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String type,  JflapGrammarStructureDto structure)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JflapGrammarDto() when $default != null:
+return $default(_that.type,_that.structure);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String type,  JflapGrammarStructureDto structure)  $default,) {final _that = this;
+switch (_that) {
+case _JflapGrammarDto():
+return $default(_that.type,_that.structure);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String type,  JflapGrammarStructureDto structure)?  $default,) {final _that = this;
+switch (_that) {
+case _JflapGrammarDto() when $default != null:
+return $default(_that.type,_that.structure);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JflapGrammarDto implements JflapGrammarDto {
+  const _JflapGrammarDto({required this.type, required this.structure});
+  factory _JflapGrammarDto.fromJson(Map<String, dynamic> json) => _$JflapGrammarDtoFromJson(json);
+
+@override final  String type;
+@override final  JflapGrammarStructureDto structure;
+
+/// Create a copy of JflapGrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JflapGrammarDtoCopyWith<_JflapGrammarDto> get copyWith => __$JflapGrammarDtoCopyWithImpl<_JflapGrammarDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JflapGrammarDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JflapGrammarDto&&(identical(other.type, type) || other.type == type)&&(identical(other.structure, structure) || other.structure == structure));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,structure);
+
+@override
+String toString() {
+  return 'JflapGrammarDto(type: $type, structure: $structure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JflapGrammarDtoCopyWith<$Res> implements $JflapGrammarDtoCopyWith<$Res> {
+  factory _$JflapGrammarDtoCopyWith(_JflapGrammarDto value, $Res Function(_JflapGrammarDto) _then) = __$JflapGrammarDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String type, JflapGrammarStructureDto structure
+});
+
+
+@override $JflapGrammarStructureDtoCopyWith<$Res> get structure;
+
+}
+/// @nodoc
+class __$JflapGrammarDtoCopyWithImpl<$Res>
+    implements _$JflapGrammarDtoCopyWith<$Res> {
+  __$JflapGrammarDtoCopyWithImpl(this._self, this._then);
+
+  final _JflapGrammarDto _self;
+  final $Res Function(_JflapGrammarDto) _then;
+
+/// Create a copy of JflapGrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? structure = null,}) {
+  return _then(_JflapGrammarDto(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,structure: null == structure ? _self.structure : structure // ignore: cast_nullable_to_non_nullable
+as JflapGrammarStructureDto,
+  ));
+}
+
+/// Create a copy of JflapGrammarDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$JflapGrammarStructureDtoCopyWith<$Res> get structure {
+  
+  return $JflapGrammarStructureDtoCopyWith<$Res>(_self.structure, (value) {
+    return _then(_self.copyWith(structure: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$JflapGrammarStructureDto {
+
+ List<String> get terminals; List<String> get variables; String get startVariable; List<JflapProductionDto> get productions;
+/// Create a copy of JflapGrammarStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JflapGrammarStructureDtoCopyWith<JflapGrammarStructureDto> get copyWith => _$JflapGrammarStructureDtoCopyWithImpl<JflapGrammarStructureDto>(this as JflapGrammarStructureDto, _$identity);
+
+  /// Serializes this JflapGrammarStructureDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JflapGrammarStructureDto&&const DeepCollectionEquality().equals(other.terminals, terminals)&&const DeepCollectionEquality().equals(other.variables, variables)&&(identical(other.startVariable, startVariable) || other.startVariable == startVariable)&&const DeepCollectionEquality().equals(other.productions, productions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(terminals),const DeepCollectionEquality().hash(variables),startVariable,const DeepCollectionEquality().hash(productions));
+
+@override
+String toString() {
+  return 'JflapGrammarStructureDto(terminals: $terminals, variables: $variables, startVariable: $startVariable, productions: $productions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JflapGrammarStructureDtoCopyWith<$Res>  {
+  factory $JflapGrammarStructureDtoCopyWith(JflapGrammarStructureDto value, $Res Function(JflapGrammarStructureDto) _then) = _$JflapGrammarStructureDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<String> terminals, List<String> variables, String startVariable, List<JflapProductionDto> productions
+});
+
+
+
+
+}
+/// @nodoc
+class _$JflapGrammarStructureDtoCopyWithImpl<$Res>
+    implements $JflapGrammarStructureDtoCopyWith<$Res> {
+  _$JflapGrammarStructureDtoCopyWithImpl(this._self, this._then);
+
+  final JflapGrammarStructureDto _self;
+  final $Res Function(JflapGrammarStructureDto) _then;
+
+/// Create a copy of JflapGrammarStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? terminals = null,Object? variables = null,Object? startVariable = null,Object? productions = null,}) {
+  return _then(_self.copyWith(
+terminals: null == terminals ? _self.terminals : terminals // ignore: cast_nullable_to_non_nullable
+as List<String>,variables: null == variables ? _self.variables : variables // ignore: cast_nullable_to_non_nullable
+as List<String>,startVariable: null == startVariable ? _self.startVariable : startVariable // ignore: cast_nullable_to_non_nullable
+as String,productions: null == productions ? _self.productions : productions // ignore: cast_nullable_to_non_nullable
+as List<JflapProductionDto>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [JflapGrammarStructureDto].
+extension JflapGrammarStructureDtoPatterns on JflapGrammarStructureDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JflapGrammarStructureDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JflapGrammarStructureDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JflapGrammarStructureDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _JflapGrammarStructureDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JflapGrammarStructureDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JflapGrammarStructureDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<String> terminals,  List<String> variables,  String startVariable,  List<JflapProductionDto> productions)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JflapGrammarStructureDto() when $default != null:
+return $default(_that.terminals,_that.variables,_that.startVariable,_that.productions);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<String> terminals,  List<String> variables,  String startVariable,  List<JflapProductionDto> productions)  $default,) {final _that = this;
+switch (_that) {
+case _JflapGrammarStructureDto():
+return $default(_that.terminals,_that.variables,_that.startVariable,_that.productions);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<String> terminals,  List<String> variables,  String startVariable,  List<JflapProductionDto> productions)?  $default,) {final _that = this;
+switch (_that) {
+case _JflapGrammarStructureDto() when $default != null:
+return $default(_that.terminals,_that.variables,_that.startVariable,_that.productions);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JflapGrammarStructureDto implements JflapGrammarStructureDto {
+  const _JflapGrammarStructureDto({required final  List<String> terminals, required final  List<String> variables, required this.startVariable, required final  List<JflapProductionDto> productions}): _terminals = terminals,_variables = variables,_productions = productions;
+  factory _JflapGrammarStructureDto.fromJson(Map<String, dynamic> json) => _$JflapGrammarStructureDtoFromJson(json);
+
+ final  List<String> _terminals;
+@override List<String> get terminals {
+  if (_terminals is EqualUnmodifiableListView) return _terminals;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_terminals);
+}
+
+ final  List<String> _variables;
+@override List<String> get variables {
+  if (_variables is EqualUnmodifiableListView) return _variables;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_variables);
+}
+
+@override final  String startVariable;
+ final  List<JflapProductionDto> _productions;
+@override List<JflapProductionDto> get productions {
+  if (_productions is EqualUnmodifiableListView) return _productions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_productions);
+}
+
+
+/// Create a copy of JflapGrammarStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JflapGrammarStructureDtoCopyWith<_JflapGrammarStructureDto> get copyWith => __$JflapGrammarStructureDtoCopyWithImpl<_JflapGrammarStructureDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JflapGrammarStructureDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JflapGrammarStructureDto&&const DeepCollectionEquality().equals(other._terminals, _terminals)&&const DeepCollectionEquality().equals(other._variables, _variables)&&(identical(other.startVariable, startVariable) || other.startVariable == startVariable)&&const DeepCollectionEquality().equals(other._productions, _productions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_terminals),const DeepCollectionEquality().hash(_variables),startVariable,const DeepCollectionEquality().hash(_productions));
+
+@override
+String toString() {
+  return 'JflapGrammarStructureDto(terminals: $terminals, variables: $variables, startVariable: $startVariable, productions: $productions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JflapGrammarStructureDtoCopyWith<$Res> implements $JflapGrammarStructureDtoCopyWith<$Res> {
+  factory _$JflapGrammarStructureDtoCopyWith(_JflapGrammarStructureDto value, $Res Function(_JflapGrammarStructureDto) _then) = __$JflapGrammarStructureDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<String> terminals, List<String> variables, String startVariable, List<JflapProductionDto> productions
+});
+
+
+
+
+}
+/// @nodoc
+class __$JflapGrammarStructureDtoCopyWithImpl<$Res>
+    implements _$JflapGrammarStructureDtoCopyWith<$Res> {
+  __$JflapGrammarStructureDtoCopyWithImpl(this._self, this._then);
+
+  final _JflapGrammarStructureDto _self;
+  final $Res Function(_JflapGrammarStructureDto) _then;
+
+/// Create a copy of JflapGrammarStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? terminals = null,Object? variables = null,Object? startVariable = null,Object? productions = null,}) {
+  return _then(_JflapGrammarStructureDto(
+terminals: null == terminals ? _self._terminals : terminals // ignore: cast_nullable_to_non_nullable
+as List<String>,variables: null == variables ? _self._variables : variables // ignore: cast_nullable_to_non_nullable
+as List<String>,startVariable: null == startVariable ? _self.startVariable : startVariable // ignore: cast_nullable_to_non_nullable
+as String,productions: null == productions ? _self._productions : productions // ignore: cast_nullable_to_non_nullable
+as List<JflapProductionDto>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$JflapProductionDto {
+
+ String get left; String get right;
+/// Create a copy of JflapProductionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JflapProductionDtoCopyWith<JflapProductionDto> get copyWith => _$JflapProductionDtoCopyWithImpl<JflapProductionDto>(this as JflapProductionDto, _$identity);
+
+  /// Serializes this JflapProductionDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JflapProductionDto&&(identical(other.left, left) || other.left == left)&&(identical(other.right, right) || other.right == right));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,left,right);
+
+@override
+String toString() {
+  return 'JflapProductionDto(left: $left, right: $right)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JflapProductionDtoCopyWith<$Res>  {
+  factory $JflapProductionDtoCopyWith(JflapProductionDto value, $Res Function(JflapProductionDto) _then) = _$JflapProductionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String left, String right
+});
+
+
+
+
+}
+/// @nodoc
+class _$JflapProductionDtoCopyWithImpl<$Res>
+    implements $JflapProductionDtoCopyWith<$Res> {
+  _$JflapProductionDtoCopyWithImpl(this._self, this._then);
+
+  final JflapProductionDto _self;
+  final $Res Function(JflapProductionDto) _then;
+
+/// Create a copy of JflapProductionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? left = null,Object? right = null,}) {
+  return _then(_self.copyWith(
+left: null == left ? _self.left : left // ignore: cast_nullable_to_non_nullable
+as String,right: null == right ? _self.right : right // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [JflapProductionDto].
+extension JflapProductionDtoPatterns on JflapProductionDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JflapProductionDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JflapProductionDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JflapProductionDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _JflapProductionDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JflapProductionDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JflapProductionDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String left,  String right)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JflapProductionDto() when $default != null:
+return $default(_that.left,_that.right);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String left,  String right)  $default,) {final _that = this;
+switch (_that) {
+case _JflapProductionDto():
+return $default(_that.left,_that.right);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String left,  String right)?  $default,) {final _that = this;
+switch (_that) {
+case _JflapProductionDto() when $default != null:
+return $default(_that.left,_that.right);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JflapProductionDto implements JflapProductionDto {
+  const _JflapProductionDto({required this.left, required this.right});
+  factory _JflapProductionDto.fromJson(Map<String, dynamic> json) => _$JflapProductionDtoFromJson(json);
+
+@override final  String left;
+@override final  String right;
+
+/// Create a copy of JflapProductionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JflapProductionDtoCopyWith<_JflapProductionDto> get copyWith => __$JflapProductionDtoCopyWithImpl<_JflapProductionDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JflapProductionDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JflapProductionDto&&(identical(other.left, left) || other.left == left)&&(identical(other.right, right) || other.right == right));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,left,right);
+
+@override
+String toString() {
+  return 'JflapProductionDto(left: $left, right: $right)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JflapProductionDtoCopyWith<$Res> implements $JflapProductionDtoCopyWith<$Res> {
+  factory _$JflapProductionDtoCopyWith(_JflapProductionDto value, $Res Function(_JflapProductionDto) _then) = __$JflapProductionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String left, String right
+});
+
+
+
+
+}
+/// @nodoc
+class __$JflapProductionDtoCopyWithImpl<$Res>
+    implements _$JflapProductionDtoCopyWith<$Res> {
+  __$JflapProductionDtoCopyWithImpl(this._self, this._then);
+
+  final _JflapProductionDto _self;
+  final $Res Function(_JflapProductionDto) _then;
+
+/// Create a copy of JflapProductionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? left = null,Object? right = null,}) {
+  return _then(_JflapProductionDto(
+left: null == left ? _self.left : left // ignore: cast_nullable_to_non_nullable
+as String,right: null == right ? _self.right : right // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/models/grammar_dto.g.dart
+++ b/lib/data/models/grammar_dto.g.dart
@@ -1,0 +1,86 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'grammar_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_GrammarDto _$GrammarDtoFromJson(Map json) => _GrammarDto(
+  id: json['id'] as String,
+  name: json['name'] as String,
+  type: json['type'] as String,
+  terminals: (json['terminals'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  variables: (json['variables'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  initialSymbol: json['initialSymbol'] as String,
+  productions: (json['productions'] as Map).map(
+    (k, e) => MapEntry(
+      k as String,
+      (e as List<dynamic>).map((e) => e as String).toList(),
+    ),
+  ),
+);
+
+Map<String, dynamic> _$GrammarDtoToJson(_GrammarDto instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'type': instance.type,
+      'terminals': instance.terminals,
+      'variables': instance.variables,
+      'initialSymbol': instance.initialSymbol,
+      'productions': instance.productions,
+    };
+
+_JflapGrammarDto _$JflapGrammarDtoFromJson(Map json) => _JflapGrammarDto(
+  type: json['type'] as String,
+  structure: JflapGrammarStructureDto.fromJson(
+    Map<String, dynamic>.from(json['structure'] as Map),
+  ),
+);
+
+Map<String, dynamic> _$JflapGrammarDtoToJson(_JflapGrammarDto instance) =>
+    <String, dynamic>{
+      'type': instance.type,
+      'structure': instance.structure.toJson(),
+    };
+
+_JflapGrammarStructureDto _$JflapGrammarStructureDtoFromJson(Map json) =>
+    _JflapGrammarStructureDto(
+      terminals: (json['terminals'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      variables: (json['variables'] as List<dynamic>)
+          .map((e) => e as String)
+          .toList(),
+      startVariable: json['startVariable'] as String,
+      productions: (json['productions'] as List<dynamic>)
+          .map(
+            (e) => JflapProductionDto.fromJson(
+              Map<String, dynamic>.from(e as Map),
+            ),
+          )
+          .toList(),
+    );
+
+Map<String, dynamic> _$JflapGrammarStructureDtoToJson(
+  _JflapGrammarStructureDto instance,
+) => <String, dynamic>{
+  'terminals': instance.terminals,
+  'variables': instance.variables,
+  'startVariable': instance.startVariable,
+  'productions': instance.productions.map((e) => e.toJson()).toList(),
+};
+
+_JflapProductionDto _$JflapProductionDtoFromJson(Map json) =>
+    _JflapProductionDto(
+      left: json['left'] as String,
+      right: json['right'] as String,
+    );
+
+Map<String, dynamic> _$JflapProductionDtoToJson(_JflapProductionDto instance) =>
+    <String, dynamic>{'left': instance.left, 'right': instance.right};

--- a/lib/data/models/turing_machine_dto.freezed.dart
+++ b/lib/data/models/turing_machine_dto.freezed.dart
@@ -1,0 +1,1473 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// coverage:ignore-file
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'turing_machine_dto.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+// dart format off
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+mixin _$TuringMachineDto {
+
+ String get id; String get name; String get type; List<String> get inputAlphabet; List<String> get tapeAlphabet; List<String> get states; String get initialState; List<String> get finalStates; String get blankSymbol; Map<String, Map<String, TuringTransitionDto>> get transitions;
+/// Create a copy of TuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TuringMachineDtoCopyWith<TuringMachineDto> get copyWith => _$TuringMachineDtoCopyWithImpl<TuringMachineDto>(this as TuringMachineDto, _$identity);
+
+  /// Serializes this TuringMachineDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TuringMachineDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other.inputAlphabet, inputAlphabet)&&const DeepCollectionEquality().equals(other.tapeAlphabet, tapeAlphabet)&&const DeepCollectionEquality().equals(other.states, states)&&(identical(other.initialState, initialState) || other.initialState == initialState)&&const DeepCollectionEquality().equals(other.finalStates, finalStates)&&(identical(other.blankSymbol, blankSymbol) || other.blankSymbol == blankSymbol)&&const DeepCollectionEquality().equals(other.transitions, transitions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,type,const DeepCollectionEquality().hash(inputAlphabet),const DeepCollectionEquality().hash(tapeAlphabet),const DeepCollectionEquality().hash(states),initialState,const DeepCollectionEquality().hash(finalStates),blankSymbol,const DeepCollectionEquality().hash(transitions));
+
+@override
+String toString() {
+  return 'TuringMachineDto(id: $id, name: $name, type: $type, inputAlphabet: $inputAlphabet, tapeAlphabet: $tapeAlphabet, states: $states, initialState: $initialState, finalStates: $finalStates, blankSymbol: $blankSymbol, transitions: $transitions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TuringMachineDtoCopyWith<$Res>  {
+  factory $TuringMachineDtoCopyWith(TuringMachineDto value, $Res Function(TuringMachineDto) _then) = _$TuringMachineDtoCopyWithImpl;
+@useResult
+$Res call({
+ String id, String name, String type, List<String> inputAlphabet, List<String> tapeAlphabet, List<String> states, String initialState, List<String> finalStates, String blankSymbol, Map<String, Map<String, TuringTransitionDto>> transitions
+});
+
+
+
+
+}
+/// @nodoc
+class _$TuringMachineDtoCopyWithImpl<$Res>
+    implements $TuringMachineDtoCopyWith<$Res> {
+  _$TuringMachineDtoCopyWithImpl(this._self, this._then);
+
+  final TuringMachineDto _self;
+  final $Res Function(TuringMachineDto) _then;
+
+/// Create a copy of TuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? id = null,Object? name = null,Object? type = null,Object? inputAlphabet = null,Object? tapeAlphabet = null,Object? states = null,Object? initialState = null,Object? finalStates = null,Object? blankSymbol = null,Object? transitions = null,}) {
+  return _then(_self.copyWith(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,inputAlphabet: null == inputAlphabet ? _self.inputAlphabet : inputAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,tapeAlphabet: null == tapeAlphabet ? _self.tapeAlphabet : tapeAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,states: null == states ? _self.states : states // ignore: cast_nullable_to_non_nullable
+as List<String>,initialState: null == initialState ? _self.initialState : initialState // ignore: cast_nullable_to_non_nullable
+as String,finalStates: null == finalStates ? _self.finalStates : finalStates // ignore: cast_nullable_to_non_nullable
+as List<String>,blankSymbol: null == blankSymbol ? _self.blankSymbol : blankSymbol // ignore: cast_nullable_to_non_nullable
+as String,transitions: null == transitions ? _self.transitions : transitions // ignore: cast_nullable_to_non_nullable
+as Map<String, Map<String, TuringTransitionDto>>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TuringMachineDto].
+extension TuringMachineDtoPatterns on TuringMachineDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TuringMachineDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TuringMachineDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TuringMachineDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _TuringMachineDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TuringMachineDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TuringMachineDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String id,  String name,  String type,  List<String> inputAlphabet,  List<String> tapeAlphabet,  List<String> states,  String initialState,  List<String> finalStates,  String blankSymbol,  Map<String, Map<String, TuringTransitionDto>> transitions)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TuringMachineDto() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.inputAlphabet,_that.tapeAlphabet,_that.states,_that.initialState,_that.finalStates,_that.blankSymbol,_that.transitions);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String id,  String name,  String type,  List<String> inputAlphabet,  List<String> tapeAlphabet,  List<String> states,  String initialState,  List<String> finalStates,  String blankSymbol,  Map<String, Map<String, TuringTransitionDto>> transitions)  $default,) {final _that = this;
+switch (_that) {
+case _TuringMachineDto():
+return $default(_that.id,_that.name,_that.type,_that.inputAlphabet,_that.tapeAlphabet,_that.states,_that.initialState,_that.finalStates,_that.blankSymbol,_that.transitions);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String id,  String name,  String type,  List<String> inputAlphabet,  List<String> tapeAlphabet,  List<String> states,  String initialState,  List<String> finalStates,  String blankSymbol,  Map<String, Map<String, TuringTransitionDto>> transitions)?  $default,) {final _that = this;
+switch (_that) {
+case _TuringMachineDto() when $default != null:
+return $default(_that.id,_that.name,_that.type,_that.inputAlphabet,_that.tapeAlphabet,_that.states,_that.initialState,_that.finalStates,_that.blankSymbol,_that.transitions);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TuringMachineDto implements TuringMachineDto {
+  const _TuringMachineDto({required this.id, required this.name, required this.type, required final  List<String> inputAlphabet, required final  List<String> tapeAlphabet, required final  List<String> states, required this.initialState, required final  List<String> finalStates, required this.blankSymbol, required final  Map<String, Map<String, TuringTransitionDto>> transitions}): _inputAlphabet = inputAlphabet,_tapeAlphabet = tapeAlphabet,_states = states,_finalStates = finalStates,_transitions = transitions;
+  factory _TuringMachineDto.fromJson(Map<String, dynamic> json) => _$TuringMachineDtoFromJson(json);
+
+@override final  String id;
+@override final  String name;
+@override final  String type;
+ final  List<String> _inputAlphabet;
+@override List<String> get inputAlphabet {
+  if (_inputAlphabet is EqualUnmodifiableListView) return _inputAlphabet;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_inputAlphabet);
+}
+
+ final  List<String> _tapeAlphabet;
+@override List<String> get tapeAlphabet {
+  if (_tapeAlphabet is EqualUnmodifiableListView) return _tapeAlphabet;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_tapeAlphabet);
+}
+
+ final  List<String> _states;
+@override List<String> get states {
+  if (_states is EqualUnmodifiableListView) return _states;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_states);
+}
+
+@override final  String initialState;
+ final  List<String> _finalStates;
+@override List<String> get finalStates {
+  if (_finalStates is EqualUnmodifiableListView) return _finalStates;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_finalStates);
+}
+
+@override final  String blankSymbol;
+ final  Map<String, Map<String, TuringTransitionDto>> _transitions;
+@override Map<String, Map<String, TuringTransitionDto>> get transitions {
+  if (_transitions is EqualUnmodifiableMapView) return _transitions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableMapView(_transitions);
+}
+
+
+/// Create a copy of TuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TuringMachineDtoCopyWith<_TuringMachineDto> get copyWith => __$TuringMachineDtoCopyWithImpl<_TuringMachineDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TuringMachineDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TuringMachineDto&&(identical(other.id, id) || other.id == id)&&(identical(other.name, name) || other.name == name)&&(identical(other.type, type) || other.type == type)&&const DeepCollectionEquality().equals(other._inputAlphabet, _inputAlphabet)&&const DeepCollectionEquality().equals(other._tapeAlphabet, _tapeAlphabet)&&const DeepCollectionEquality().equals(other._states, _states)&&(identical(other.initialState, initialState) || other.initialState == initialState)&&const DeepCollectionEquality().equals(other._finalStates, _finalStates)&&(identical(other.blankSymbol, blankSymbol) || other.blankSymbol == blankSymbol)&&const DeepCollectionEquality().equals(other._transitions, _transitions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,id,name,type,const DeepCollectionEquality().hash(_inputAlphabet),const DeepCollectionEquality().hash(_tapeAlphabet),const DeepCollectionEquality().hash(_states),initialState,const DeepCollectionEquality().hash(_finalStates),blankSymbol,const DeepCollectionEquality().hash(_transitions));
+
+@override
+String toString() {
+  return 'TuringMachineDto(id: $id, name: $name, type: $type, inputAlphabet: $inputAlphabet, tapeAlphabet: $tapeAlphabet, states: $states, initialState: $initialState, finalStates: $finalStates, blankSymbol: $blankSymbol, transitions: $transitions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TuringMachineDtoCopyWith<$Res> implements $TuringMachineDtoCopyWith<$Res> {
+  factory _$TuringMachineDtoCopyWith(_TuringMachineDto value, $Res Function(_TuringMachineDto) _then) = __$TuringMachineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String id, String name, String type, List<String> inputAlphabet, List<String> tapeAlphabet, List<String> states, String initialState, List<String> finalStates, String blankSymbol, Map<String, Map<String, TuringTransitionDto>> transitions
+});
+
+
+
+
+}
+/// @nodoc
+class __$TuringMachineDtoCopyWithImpl<$Res>
+    implements _$TuringMachineDtoCopyWith<$Res> {
+  __$TuringMachineDtoCopyWithImpl(this._self, this._then);
+
+  final _TuringMachineDto _self;
+  final $Res Function(_TuringMachineDto) _then;
+
+/// Create a copy of TuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? id = null,Object? name = null,Object? type = null,Object? inputAlphabet = null,Object? tapeAlphabet = null,Object? states = null,Object? initialState = null,Object? finalStates = null,Object? blankSymbol = null,Object? transitions = null,}) {
+  return _then(_TuringMachineDto(
+id: null == id ? _self.id : id // ignore: cast_nullable_to_non_nullable
+as String,name: null == name ? _self.name : name // ignore: cast_nullable_to_non_nullable
+as String,type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,inputAlphabet: null == inputAlphabet ? _self._inputAlphabet : inputAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,tapeAlphabet: null == tapeAlphabet ? _self._tapeAlphabet : tapeAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,states: null == states ? _self._states : states // ignore: cast_nullable_to_non_nullable
+as List<String>,initialState: null == initialState ? _self.initialState : initialState // ignore: cast_nullable_to_non_nullable
+as String,finalStates: null == finalStates ? _self._finalStates : finalStates // ignore: cast_nullable_to_non_nullable
+as List<String>,blankSymbol: null == blankSymbol ? _self.blankSymbol : blankSymbol // ignore: cast_nullable_to_non_nullable
+as String,transitions: null == transitions ? _self._transitions : transitions // ignore: cast_nullable_to_non_nullable
+as Map<String, Map<String, TuringTransitionDto>>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$TuringTransitionDto {
+
+ String get newState; String get writeSymbol; String get direction;
+/// Create a copy of TuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$TuringTransitionDtoCopyWith<TuringTransitionDto> get copyWith => _$TuringTransitionDtoCopyWithImpl<TuringTransitionDto>(this as TuringTransitionDto, _$identity);
+
+  /// Serializes this TuringTransitionDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is TuringTransitionDto&&(identical(other.newState, newState) || other.newState == newState)&&(identical(other.writeSymbol, writeSymbol) || other.writeSymbol == writeSymbol)&&(identical(other.direction, direction) || other.direction == direction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newState,writeSymbol,direction);
+
+@override
+String toString() {
+  return 'TuringTransitionDto(newState: $newState, writeSymbol: $writeSymbol, direction: $direction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $TuringTransitionDtoCopyWith<$Res>  {
+  factory $TuringTransitionDtoCopyWith(TuringTransitionDto value, $Res Function(TuringTransitionDto) _then) = _$TuringTransitionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String newState, String writeSymbol, String direction
+});
+
+
+
+
+}
+/// @nodoc
+class _$TuringTransitionDtoCopyWithImpl<$Res>
+    implements $TuringTransitionDtoCopyWith<$Res> {
+  _$TuringTransitionDtoCopyWithImpl(this._self, this._then);
+
+  final TuringTransitionDto _self;
+  final $Res Function(TuringTransitionDto) _then;
+
+/// Create a copy of TuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? newState = null,Object? writeSymbol = null,Object? direction = null,}) {
+  return _then(_self.copyWith(
+newState: null == newState ? _self.newState : newState // ignore: cast_nullable_to_non_nullable
+as String,writeSymbol: null == writeSymbol ? _self.writeSymbol : writeSymbol // ignore: cast_nullable_to_non_nullable
+as String,direction: null == direction ? _self.direction : direction // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [TuringTransitionDto].
+extension TuringTransitionDtoPatterns on TuringTransitionDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _TuringTransitionDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _TuringTransitionDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _TuringTransitionDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _TuringTransitionDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _TuringTransitionDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _TuringTransitionDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String newState,  String writeSymbol,  String direction)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _TuringTransitionDto() when $default != null:
+return $default(_that.newState,_that.writeSymbol,_that.direction);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String newState,  String writeSymbol,  String direction)  $default,) {final _that = this;
+switch (_that) {
+case _TuringTransitionDto():
+return $default(_that.newState,_that.writeSymbol,_that.direction);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String newState,  String writeSymbol,  String direction)?  $default,) {final _that = this;
+switch (_that) {
+case _TuringTransitionDto() when $default != null:
+return $default(_that.newState,_that.writeSymbol,_that.direction);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _TuringTransitionDto implements TuringTransitionDto {
+  const _TuringTransitionDto({required this.newState, required this.writeSymbol, required this.direction});
+  factory _TuringTransitionDto.fromJson(Map<String, dynamic> json) => _$TuringTransitionDtoFromJson(json);
+
+@override final  String newState;
+@override final  String writeSymbol;
+@override final  String direction;
+
+/// Create a copy of TuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$TuringTransitionDtoCopyWith<_TuringTransitionDto> get copyWith => __$TuringTransitionDtoCopyWithImpl<_TuringTransitionDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$TuringTransitionDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _TuringTransitionDto&&(identical(other.newState, newState) || other.newState == newState)&&(identical(other.writeSymbol, writeSymbol) || other.writeSymbol == writeSymbol)&&(identical(other.direction, direction) || other.direction == direction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,newState,writeSymbol,direction);
+
+@override
+String toString() {
+  return 'TuringTransitionDto(newState: $newState, writeSymbol: $writeSymbol, direction: $direction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$TuringTransitionDtoCopyWith<$Res> implements $TuringTransitionDtoCopyWith<$Res> {
+  factory _$TuringTransitionDtoCopyWith(_TuringTransitionDto value, $Res Function(_TuringTransitionDto) _then) = __$TuringTransitionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String newState, String writeSymbol, String direction
+});
+
+
+
+
+}
+/// @nodoc
+class __$TuringTransitionDtoCopyWithImpl<$Res>
+    implements _$TuringTransitionDtoCopyWith<$Res> {
+  __$TuringTransitionDtoCopyWithImpl(this._self, this._then);
+
+  final _TuringTransitionDto _self;
+  final $Res Function(_TuringTransitionDto) _then;
+
+/// Create a copy of TuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? newState = null,Object? writeSymbol = null,Object? direction = null,}) {
+  return _then(_TuringTransitionDto(
+newState: null == newState ? _self.newState : newState // ignore: cast_nullable_to_non_nullable
+as String,writeSymbol: null == writeSymbol ? _self.writeSymbol : writeSymbol // ignore: cast_nullable_to_non_nullable
+as String,direction: null == direction ? _self.direction : direction // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$JflapTuringMachineDto {
+
+ String get type; JflapTuringStructureDto get structure;
+/// Create a copy of JflapTuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JflapTuringMachineDtoCopyWith<JflapTuringMachineDto> get copyWith => _$JflapTuringMachineDtoCopyWithImpl<JflapTuringMachineDto>(this as JflapTuringMachineDto, _$identity);
+
+  /// Serializes this JflapTuringMachineDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JflapTuringMachineDto&&(identical(other.type, type) || other.type == type)&&(identical(other.structure, structure) || other.structure == structure));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,structure);
+
+@override
+String toString() {
+  return 'JflapTuringMachineDto(type: $type, structure: $structure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JflapTuringMachineDtoCopyWith<$Res>  {
+  factory $JflapTuringMachineDtoCopyWith(JflapTuringMachineDto value, $Res Function(JflapTuringMachineDto) _then) = _$JflapTuringMachineDtoCopyWithImpl;
+@useResult
+$Res call({
+ String type, JflapTuringStructureDto structure
+});
+
+
+$JflapTuringStructureDtoCopyWith<$Res> get structure;
+
+}
+/// @nodoc
+class _$JflapTuringMachineDtoCopyWithImpl<$Res>
+    implements $JflapTuringMachineDtoCopyWith<$Res> {
+  _$JflapTuringMachineDtoCopyWithImpl(this._self, this._then);
+
+  final JflapTuringMachineDto _self;
+  final $Res Function(JflapTuringMachineDto) _then;
+
+/// Create a copy of JflapTuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? type = null,Object? structure = null,}) {
+  return _then(_self.copyWith(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,structure: null == structure ? _self.structure : structure // ignore: cast_nullable_to_non_nullable
+as JflapTuringStructureDto,
+  ));
+}
+/// Create a copy of JflapTuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$JflapTuringStructureDtoCopyWith<$Res> get structure {
+  
+  return $JflapTuringStructureDtoCopyWith<$Res>(_self.structure, (value) {
+    return _then(_self.copyWith(structure: value));
+  });
+}
+}
+
+
+/// Adds pattern-matching-related methods to [JflapTuringMachineDto].
+extension JflapTuringMachineDtoPatterns on JflapTuringMachineDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JflapTuringMachineDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JflapTuringMachineDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JflapTuringMachineDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _JflapTuringMachineDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JflapTuringMachineDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JflapTuringMachineDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String type,  JflapTuringStructureDto structure)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JflapTuringMachineDto() when $default != null:
+return $default(_that.type,_that.structure);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String type,  JflapTuringStructureDto structure)  $default,) {final _that = this;
+switch (_that) {
+case _JflapTuringMachineDto():
+return $default(_that.type,_that.structure);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String type,  JflapTuringStructureDto structure)?  $default,) {final _that = this;
+switch (_that) {
+case _JflapTuringMachineDto() when $default != null:
+return $default(_that.type,_that.structure);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JflapTuringMachineDto implements JflapTuringMachineDto {
+  const _JflapTuringMachineDto({required this.type, required this.structure});
+  factory _JflapTuringMachineDto.fromJson(Map<String, dynamic> json) => _$JflapTuringMachineDtoFromJson(json);
+
+@override final  String type;
+@override final  JflapTuringStructureDto structure;
+
+/// Create a copy of JflapTuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JflapTuringMachineDtoCopyWith<_JflapTuringMachineDto> get copyWith => __$JflapTuringMachineDtoCopyWithImpl<_JflapTuringMachineDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JflapTuringMachineDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JflapTuringMachineDto&&(identical(other.type, type) || other.type == type)&&(identical(other.structure, structure) || other.structure == structure));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,type,structure);
+
+@override
+String toString() {
+  return 'JflapTuringMachineDto(type: $type, structure: $structure)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JflapTuringMachineDtoCopyWith<$Res> implements $JflapTuringMachineDtoCopyWith<$Res> {
+  factory _$JflapTuringMachineDtoCopyWith(_JflapTuringMachineDto value, $Res Function(_JflapTuringMachineDto) _then) = __$JflapTuringMachineDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String type, JflapTuringStructureDto structure
+});
+
+
+@override $JflapTuringStructureDtoCopyWith<$Res> get structure;
+
+}
+/// @nodoc
+class __$JflapTuringMachineDtoCopyWithImpl<$Res>
+    implements _$JflapTuringMachineDtoCopyWith<$Res> {
+  __$JflapTuringMachineDtoCopyWithImpl(this._self, this._then);
+
+  final _JflapTuringMachineDto _self;
+  final $Res Function(_JflapTuringMachineDto) _then;
+
+/// Create a copy of JflapTuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? type = null,Object? structure = null,}) {
+  return _then(_JflapTuringMachineDto(
+type: null == type ? _self.type : type // ignore: cast_nullable_to_non_nullable
+as String,structure: null == structure ? _self.structure : structure // ignore: cast_nullable_to_non_nullable
+as JflapTuringStructureDto,
+  ));
+}
+
+/// Create a copy of JflapTuringMachineDto
+/// with the given fields replaced by the non-null parameter values.
+@override
+@pragma('vm:prefer-inline')
+$JflapTuringStructureDtoCopyWith<$Res> get structure {
+  
+  return $JflapTuringStructureDtoCopyWith<$Res>(_self.structure, (value) {
+    return _then(_self.copyWith(structure: value));
+  });
+}
+}
+
+
+/// @nodoc
+mixin _$JflapTuringStructureDto {
+
+ List<String> get states; List<String> get inputAlphabet; List<String> get tapeAlphabet; String get initialState; List<String> get finalStates; String get blankSymbol; List<JflapTuringTransitionDto> get transitions;
+/// Create a copy of JflapTuringStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JflapTuringStructureDtoCopyWith<JflapTuringStructureDto> get copyWith => _$JflapTuringStructureDtoCopyWithImpl<JflapTuringStructureDto>(this as JflapTuringStructureDto, _$identity);
+
+  /// Serializes this JflapTuringStructureDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JflapTuringStructureDto&&const DeepCollectionEquality().equals(other.states, states)&&const DeepCollectionEquality().equals(other.inputAlphabet, inputAlphabet)&&const DeepCollectionEquality().equals(other.tapeAlphabet, tapeAlphabet)&&(identical(other.initialState, initialState) || other.initialState == initialState)&&const DeepCollectionEquality().equals(other.finalStates, finalStates)&&(identical(other.blankSymbol, blankSymbol) || other.blankSymbol == blankSymbol)&&const DeepCollectionEquality().equals(other.transitions, transitions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(states),const DeepCollectionEquality().hash(inputAlphabet),const DeepCollectionEquality().hash(tapeAlphabet),initialState,const DeepCollectionEquality().hash(finalStates),blankSymbol,const DeepCollectionEquality().hash(transitions));
+
+@override
+String toString() {
+  return 'JflapTuringStructureDto(states: $states, inputAlphabet: $inputAlphabet, tapeAlphabet: $tapeAlphabet, initialState: $initialState, finalStates: $finalStates, blankSymbol: $blankSymbol, transitions: $transitions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JflapTuringStructureDtoCopyWith<$Res>  {
+  factory $JflapTuringStructureDtoCopyWith(JflapTuringStructureDto value, $Res Function(JflapTuringStructureDto) _then) = _$JflapTuringStructureDtoCopyWithImpl;
+@useResult
+$Res call({
+ List<String> states, List<String> inputAlphabet, List<String> tapeAlphabet, String initialState, List<String> finalStates, String blankSymbol, List<JflapTuringTransitionDto> transitions
+});
+
+
+
+
+}
+/// @nodoc
+class _$JflapTuringStructureDtoCopyWithImpl<$Res>
+    implements $JflapTuringStructureDtoCopyWith<$Res> {
+  _$JflapTuringStructureDtoCopyWithImpl(this._self, this._then);
+
+  final JflapTuringStructureDto _self;
+  final $Res Function(JflapTuringStructureDto) _then;
+
+/// Create a copy of JflapTuringStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? states = null,Object? inputAlphabet = null,Object? tapeAlphabet = null,Object? initialState = null,Object? finalStates = null,Object? blankSymbol = null,Object? transitions = null,}) {
+  return _then(_self.copyWith(
+states: null == states ? _self.states : states // ignore: cast_nullable_to_non_nullable
+as List<String>,inputAlphabet: null == inputAlphabet ? _self.inputAlphabet : inputAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,tapeAlphabet: null == tapeAlphabet ? _self.tapeAlphabet : tapeAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,initialState: null == initialState ? _self.initialState : initialState // ignore: cast_nullable_to_non_nullable
+as String,finalStates: null == finalStates ? _self.finalStates : finalStates // ignore: cast_nullable_to_non_nullable
+as List<String>,blankSymbol: null == blankSymbol ? _self.blankSymbol : blankSymbol // ignore: cast_nullable_to_non_nullable
+as String,transitions: null == transitions ? _self.transitions : transitions // ignore: cast_nullable_to_non_nullable
+as List<JflapTuringTransitionDto>,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [JflapTuringStructureDto].
+extension JflapTuringStructureDtoPatterns on JflapTuringStructureDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JflapTuringStructureDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JflapTuringStructureDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JflapTuringStructureDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _JflapTuringStructureDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JflapTuringStructureDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JflapTuringStructureDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( List<String> states,  List<String> inputAlphabet,  List<String> tapeAlphabet,  String initialState,  List<String> finalStates,  String blankSymbol,  List<JflapTuringTransitionDto> transitions)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JflapTuringStructureDto() when $default != null:
+return $default(_that.states,_that.inputAlphabet,_that.tapeAlphabet,_that.initialState,_that.finalStates,_that.blankSymbol,_that.transitions);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( List<String> states,  List<String> inputAlphabet,  List<String> tapeAlphabet,  String initialState,  List<String> finalStates,  String blankSymbol,  List<JflapTuringTransitionDto> transitions)  $default,) {final _that = this;
+switch (_that) {
+case _JflapTuringStructureDto():
+return $default(_that.states,_that.inputAlphabet,_that.tapeAlphabet,_that.initialState,_that.finalStates,_that.blankSymbol,_that.transitions);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( List<String> states,  List<String> inputAlphabet,  List<String> tapeAlphabet,  String initialState,  List<String> finalStates,  String blankSymbol,  List<JflapTuringTransitionDto> transitions)?  $default,) {final _that = this;
+switch (_that) {
+case _JflapTuringStructureDto() when $default != null:
+return $default(_that.states,_that.inputAlphabet,_that.tapeAlphabet,_that.initialState,_that.finalStates,_that.blankSymbol,_that.transitions);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JflapTuringStructureDto implements JflapTuringStructureDto {
+  const _JflapTuringStructureDto({required final  List<String> states, required final  List<String> inputAlphabet, required final  List<String> tapeAlphabet, required this.initialState, required final  List<String> finalStates, required this.blankSymbol, required final  List<JflapTuringTransitionDto> transitions}): _states = states,_inputAlphabet = inputAlphabet,_tapeAlphabet = tapeAlphabet,_finalStates = finalStates,_transitions = transitions;
+  factory _JflapTuringStructureDto.fromJson(Map<String, dynamic> json) => _$JflapTuringStructureDtoFromJson(json);
+
+ final  List<String> _states;
+@override List<String> get states {
+  if (_states is EqualUnmodifiableListView) return _states;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_states);
+}
+
+ final  List<String> _inputAlphabet;
+@override List<String> get inputAlphabet {
+  if (_inputAlphabet is EqualUnmodifiableListView) return _inputAlphabet;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_inputAlphabet);
+}
+
+ final  List<String> _tapeAlphabet;
+@override List<String> get tapeAlphabet {
+  if (_tapeAlphabet is EqualUnmodifiableListView) return _tapeAlphabet;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_tapeAlphabet);
+}
+
+@override final  String initialState;
+ final  List<String> _finalStates;
+@override List<String> get finalStates {
+  if (_finalStates is EqualUnmodifiableListView) return _finalStates;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_finalStates);
+}
+
+@override final  String blankSymbol;
+ final  List<JflapTuringTransitionDto> _transitions;
+@override List<JflapTuringTransitionDto> get transitions {
+  if (_transitions is EqualUnmodifiableListView) return _transitions;
+  // ignore: implicit_dynamic_type
+  return EqualUnmodifiableListView(_transitions);
+}
+
+
+/// Create a copy of JflapTuringStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JflapTuringStructureDtoCopyWith<_JflapTuringStructureDto> get copyWith => __$JflapTuringStructureDtoCopyWithImpl<_JflapTuringStructureDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JflapTuringStructureDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JflapTuringStructureDto&&const DeepCollectionEquality().equals(other._states, _states)&&const DeepCollectionEquality().equals(other._inputAlphabet, _inputAlphabet)&&const DeepCollectionEquality().equals(other._tapeAlphabet, _tapeAlphabet)&&(identical(other.initialState, initialState) || other.initialState == initialState)&&const DeepCollectionEquality().equals(other._finalStates, _finalStates)&&(identical(other.blankSymbol, blankSymbol) || other.blankSymbol == blankSymbol)&&const DeepCollectionEquality().equals(other._transitions, _transitions));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,const DeepCollectionEquality().hash(_states),const DeepCollectionEquality().hash(_inputAlphabet),const DeepCollectionEquality().hash(_tapeAlphabet),initialState,const DeepCollectionEquality().hash(_finalStates),blankSymbol,const DeepCollectionEquality().hash(_transitions));
+
+@override
+String toString() {
+  return 'JflapTuringStructureDto(states: $states, inputAlphabet: $inputAlphabet, tapeAlphabet: $tapeAlphabet, initialState: $initialState, finalStates: $finalStates, blankSymbol: $blankSymbol, transitions: $transitions)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JflapTuringStructureDtoCopyWith<$Res> implements $JflapTuringStructureDtoCopyWith<$Res> {
+  factory _$JflapTuringStructureDtoCopyWith(_JflapTuringStructureDto value, $Res Function(_JflapTuringStructureDto) _then) = __$JflapTuringStructureDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ List<String> states, List<String> inputAlphabet, List<String> tapeAlphabet, String initialState, List<String> finalStates, String blankSymbol, List<JflapTuringTransitionDto> transitions
+});
+
+
+
+
+}
+/// @nodoc
+class __$JflapTuringStructureDtoCopyWithImpl<$Res>
+    implements _$JflapTuringStructureDtoCopyWith<$Res> {
+  __$JflapTuringStructureDtoCopyWithImpl(this._self, this._then);
+
+  final _JflapTuringStructureDto _self;
+  final $Res Function(_JflapTuringStructureDto) _then;
+
+/// Create a copy of JflapTuringStructureDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? states = null,Object? inputAlphabet = null,Object? tapeAlphabet = null,Object? initialState = null,Object? finalStates = null,Object? blankSymbol = null,Object? transitions = null,}) {
+  return _then(_JflapTuringStructureDto(
+states: null == states ? _self._states : states // ignore: cast_nullable_to_non_nullable
+as List<String>,inputAlphabet: null == inputAlphabet ? _self._inputAlphabet : inputAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,tapeAlphabet: null == tapeAlphabet ? _self._tapeAlphabet : tapeAlphabet // ignore: cast_nullable_to_non_nullable
+as List<String>,initialState: null == initialState ? _self.initialState : initialState // ignore: cast_nullable_to_non_nullable
+as String,finalStates: null == finalStates ? _self._finalStates : finalStates // ignore: cast_nullable_to_non_nullable
+as List<String>,blankSymbol: null == blankSymbol ? _self.blankSymbol : blankSymbol // ignore: cast_nullable_to_non_nullable
+as String,transitions: null == transitions ? _self._transitions : transitions // ignore: cast_nullable_to_non_nullable
+as List<JflapTuringTransitionDto>,
+  ));
+}
+
+
+}
+
+
+/// @nodoc
+mixin _$JflapTuringTransitionDto {
+
+ String get from; String get to; String get read; String get write; String get direction;
+/// Create a copy of JflapTuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+$JflapTuringTransitionDtoCopyWith<JflapTuringTransitionDto> get copyWith => _$JflapTuringTransitionDtoCopyWithImpl<JflapTuringTransitionDto>(this as JflapTuringTransitionDto, _$identity);
+
+  /// Serializes this JflapTuringTransitionDto to a JSON map.
+  Map<String, dynamic> toJson();
+
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is JflapTuringTransitionDto&&(identical(other.from, from) || other.from == from)&&(identical(other.to, to) || other.to == to)&&(identical(other.read, read) || other.read == read)&&(identical(other.write, write) || other.write == write)&&(identical(other.direction, direction) || other.direction == direction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,from,to,read,write,direction);
+
+@override
+String toString() {
+  return 'JflapTuringTransitionDto(from: $from, to: $to, read: $read, write: $write, direction: $direction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class $JflapTuringTransitionDtoCopyWith<$Res>  {
+  factory $JflapTuringTransitionDtoCopyWith(JflapTuringTransitionDto value, $Res Function(JflapTuringTransitionDto) _then) = _$JflapTuringTransitionDtoCopyWithImpl;
+@useResult
+$Res call({
+ String from, String to, String read, String write, String direction
+});
+
+
+
+
+}
+/// @nodoc
+class _$JflapTuringTransitionDtoCopyWithImpl<$Res>
+    implements $JflapTuringTransitionDtoCopyWith<$Res> {
+  _$JflapTuringTransitionDtoCopyWithImpl(this._self, this._then);
+
+  final JflapTuringTransitionDto _self;
+  final $Res Function(JflapTuringTransitionDto) _then;
+
+/// Create a copy of JflapTuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@pragma('vm:prefer-inline') @override $Res call({Object? from = null,Object? to = null,Object? read = null,Object? write = null,Object? direction = null,}) {
+  return _then(_self.copyWith(
+from: null == from ? _self.from : from // ignore: cast_nullable_to_non_nullable
+as String,to: null == to ? _self.to : to // ignore: cast_nullable_to_non_nullable
+as String,read: null == read ? _self.read : read // ignore: cast_nullable_to_non_nullable
+as String,write: null == write ? _self.write : write // ignore: cast_nullable_to_non_nullable
+as String,direction: null == direction ? _self.direction : direction // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+}
+
+
+/// Adds pattern-matching-related methods to [JflapTuringTransitionDto].
+extension JflapTuringTransitionDtoPatterns on JflapTuringTransitionDto {
+/// A variant of `map` that fallback to returning `orElse`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeMap<TResult extends Object?>(TResult Function( _JflapTuringTransitionDto value)?  $default,{required TResult orElse(),}){
+final _that = this;
+switch (_that) {
+case _JflapTuringTransitionDto() when $default != null:
+return $default(_that);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// Callbacks receives the raw object, upcasted.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case final Subclass2 value:
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult map<TResult extends Object?>(TResult Function( _JflapTuringTransitionDto value)  $default,){
+final _that = this;
+switch (_that) {
+case _JflapTuringTransitionDto():
+return $default(_that);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `map` that fallback to returning `null`.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case final Subclass value:
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? mapOrNull<TResult extends Object?>(TResult? Function( _JflapTuringTransitionDto value)?  $default,){
+final _that = this;
+switch (_that) {
+case _JflapTuringTransitionDto() when $default != null:
+return $default(_that);case _:
+  return null;
+
+}
+}
+/// A variant of `when` that fallback to an `orElse` callback.
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return orElse();
+/// }
+/// ```
+
+@optionalTypeArgs TResult maybeWhen<TResult extends Object?>(TResult Function( String from,  String to,  String read,  String write,  String direction)?  $default,{required TResult orElse(),}) {final _that = this;
+switch (_that) {
+case _JflapTuringTransitionDto() when $default != null:
+return $default(_that.from,_that.to,_that.read,_that.write,_that.direction);case _:
+  return orElse();
+
+}
+}
+/// A `switch`-like method, using callbacks.
+///
+/// As opposed to `map`, this offers destructuring.
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case Subclass2(:final field2):
+///     return ...;
+/// }
+/// ```
+
+@optionalTypeArgs TResult when<TResult extends Object?>(TResult Function( String from,  String to,  String read,  String write,  String direction)  $default,) {final _that = this;
+switch (_that) {
+case _JflapTuringTransitionDto():
+return $default(_that.from,_that.to,_that.read,_that.write,_that.direction);case _:
+  throw StateError('Unexpected subclass');
+
+}
+}
+/// A variant of `when` that fallback to returning `null`
+///
+/// It is equivalent to doing:
+/// ```dart
+/// switch (sealedClass) {
+///   case Subclass(:final field):
+///     return ...;
+///   case _:
+///     return null;
+/// }
+/// ```
+
+@optionalTypeArgs TResult? whenOrNull<TResult extends Object?>(TResult? Function( String from,  String to,  String read,  String write,  String direction)?  $default,) {final _that = this;
+switch (_that) {
+case _JflapTuringTransitionDto() when $default != null:
+return $default(_that.from,_that.to,_that.read,_that.write,_that.direction);case _:
+  return null;
+
+}
+}
+
+}
+
+/// @nodoc
+@JsonSerializable()
+
+class _JflapTuringTransitionDto implements JflapTuringTransitionDto {
+  const _JflapTuringTransitionDto({required this.from, required this.to, required this.read, required this.write, required this.direction});
+  factory _JflapTuringTransitionDto.fromJson(Map<String, dynamic> json) => _$JflapTuringTransitionDtoFromJson(json);
+
+@override final  String from;
+@override final  String to;
+@override final  String read;
+@override final  String write;
+@override final  String direction;
+
+/// Create a copy of JflapTuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @JsonKey(includeFromJson: false, includeToJson: false)
+@pragma('vm:prefer-inline')
+_$JflapTuringTransitionDtoCopyWith<_JflapTuringTransitionDto> get copyWith => __$JflapTuringTransitionDtoCopyWithImpl<_JflapTuringTransitionDto>(this, _$identity);
+
+@override
+Map<String, dynamic> toJson() {
+  return _$JflapTuringTransitionDtoToJson(this, );
+}
+
+@override
+bool operator ==(Object other) {
+  return identical(this, other) || (other.runtimeType == runtimeType&&other is _JflapTuringTransitionDto&&(identical(other.from, from) || other.from == from)&&(identical(other.to, to) || other.to == to)&&(identical(other.read, read) || other.read == read)&&(identical(other.write, write) || other.write == write)&&(identical(other.direction, direction) || other.direction == direction));
+}
+
+@JsonKey(includeFromJson: false, includeToJson: false)
+@override
+int get hashCode => Object.hash(runtimeType,from,to,read,write,direction);
+
+@override
+String toString() {
+  return 'JflapTuringTransitionDto(from: $from, to: $to, read: $read, write: $write, direction: $direction)';
+}
+
+
+}
+
+/// @nodoc
+abstract mixin class _$JflapTuringTransitionDtoCopyWith<$Res> implements $JflapTuringTransitionDtoCopyWith<$Res> {
+  factory _$JflapTuringTransitionDtoCopyWith(_JflapTuringTransitionDto value, $Res Function(_JflapTuringTransitionDto) _then) = __$JflapTuringTransitionDtoCopyWithImpl;
+@override @useResult
+$Res call({
+ String from, String to, String read, String write, String direction
+});
+
+
+
+
+}
+/// @nodoc
+class __$JflapTuringTransitionDtoCopyWithImpl<$Res>
+    implements _$JflapTuringTransitionDtoCopyWith<$Res> {
+  __$JflapTuringTransitionDtoCopyWithImpl(this._self, this._then);
+
+  final _JflapTuringTransitionDto _self;
+  final $Res Function(_JflapTuringTransitionDto) _then;
+
+/// Create a copy of JflapTuringTransitionDto
+/// with the given fields replaced by the non-null parameter values.
+@override @pragma('vm:prefer-inline') $Res call({Object? from = null,Object? to = null,Object? read = null,Object? write = null,Object? direction = null,}) {
+  return _then(_JflapTuringTransitionDto(
+from: null == from ? _self.from : from // ignore: cast_nullable_to_non_nullable
+as String,to: null == to ? _self.to : to // ignore: cast_nullable_to_non_nullable
+as String,read: null == read ? _self.read : read // ignore: cast_nullable_to_non_nullable
+as String,write: null == write ? _self.write : write // ignore: cast_nullable_to_non_nullable
+as String,direction: null == direction ? _self.direction : direction // ignore: cast_nullable_to_non_nullable
+as String,
+  ));
+}
+
+
+}
+
+// dart format on

--- a/lib/data/models/turing_machine_dto.g.dart
+++ b/lib/data/models/turing_machine_dto.g.dart
@@ -1,0 +1,137 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'turing_machine_dto.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_TuringMachineDto _$TuringMachineDtoFromJson(Map json) => _TuringMachineDto(
+  id: json['id'] as String,
+  name: json['name'] as String,
+  type: json['type'] as String,
+  inputAlphabet: (json['inputAlphabet'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  tapeAlphabet: (json['tapeAlphabet'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  states: (json['states'] as List<dynamic>).map((e) => e as String).toList(),
+  initialState: json['initialState'] as String,
+  finalStates: (json['finalStates'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  blankSymbol: json['blankSymbol'] as String,
+  transitions: (json['transitions'] as Map).map(
+    (k, e) => MapEntry(
+      k as String,
+      (e as Map).map(
+        (k, e) => MapEntry(
+          k as String,
+          TuringTransitionDto.fromJson(Map<String, dynamic>.from(e as Map)),
+        ),
+      ),
+    ),
+  ),
+);
+
+Map<String, dynamic> _$TuringMachineDtoToJson(_TuringMachineDto instance) =>
+    <String, dynamic>{
+      'id': instance.id,
+      'name': instance.name,
+      'type': instance.type,
+      'inputAlphabet': instance.inputAlphabet,
+      'tapeAlphabet': instance.tapeAlphabet,
+      'states': instance.states,
+      'initialState': instance.initialState,
+      'finalStates': instance.finalStates,
+      'blankSymbol': instance.blankSymbol,
+      'transitions': instance.transitions.map(
+        (k, e) => MapEntry(k, e.map((k, e) => MapEntry(k, e.toJson()))),
+      ),
+    };
+
+_TuringTransitionDto _$TuringTransitionDtoFromJson(Map json) =>
+    _TuringTransitionDto(
+      newState: json['newState'] as String,
+      writeSymbol: json['writeSymbol'] as String,
+      direction: json['direction'] as String,
+    );
+
+Map<String, dynamic> _$TuringTransitionDtoToJson(
+  _TuringTransitionDto instance,
+) => <String, dynamic>{
+  'newState': instance.newState,
+  'writeSymbol': instance.writeSymbol,
+  'direction': instance.direction,
+};
+
+_JflapTuringMachineDto _$JflapTuringMachineDtoFromJson(Map json) =>
+    _JflapTuringMachineDto(
+      type: json['type'] as String,
+      structure: JflapTuringStructureDto.fromJson(
+        Map<String, dynamic>.from(json['structure'] as Map),
+      ),
+    );
+
+Map<String, dynamic> _$JflapTuringMachineDtoToJson(
+  _JflapTuringMachineDto instance,
+) => <String, dynamic>{
+  'type': instance.type,
+  'structure': instance.structure.toJson(),
+};
+
+_JflapTuringStructureDto _$JflapTuringStructureDtoFromJson(
+  Map json,
+) => _JflapTuringStructureDto(
+  states: (json['states'] as List<dynamic>).map((e) => e as String).toList(),
+  inputAlphabet: (json['inputAlphabet'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  tapeAlphabet: (json['tapeAlphabet'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  initialState: json['initialState'] as String,
+  finalStates: (json['finalStates'] as List<dynamic>)
+      .map((e) => e as String)
+      .toList(),
+  blankSymbol: json['blankSymbol'] as String,
+  transitions: (json['transitions'] as List<dynamic>)
+      .map(
+        (e) => JflapTuringTransitionDto.fromJson(
+          Map<String, dynamic>.from(e as Map),
+        ),
+      )
+      .toList(),
+);
+
+Map<String, dynamic> _$JflapTuringStructureDtoToJson(
+  _JflapTuringStructureDto instance,
+) => <String, dynamic>{
+  'states': instance.states,
+  'inputAlphabet': instance.inputAlphabet,
+  'tapeAlphabet': instance.tapeAlphabet,
+  'initialState': instance.initialState,
+  'finalStates': instance.finalStates,
+  'blankSymbol': instance.blankSymbol,
+  'transitions': instance.transitions.map((e) => e.toJson()).toList(),
+};
+
+_JflapTuringTransitionDto _$JflapTuringTransitionDtoFromJson(Map json) =>
+    _JflapTuringTransitionDto(
+      from: json['from'] as String,
+      to: json['to'] as String,
+      read: json['read'] as String,
+      write: json['write'] as String,
+      direction: json['direction'] as String,
+    );
+
+Map<String, dynamic> _$JflapTuringTransitionDtoToJson(
+  _JflapTuringTransitionDto instance,
+) => <String, dynamic>{
+  'from': instance.from,
+  'to': instance.to,
+  'read': instance.read,
+  'write': instance.write,
+  'direction': instance.direction,
+};

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -476,10 +476,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -849,26 +849,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,8 +24,8 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ^3.0.0
-  flutter: ^3.16.0
+  sdk: ^3.8.0
+  flutter: ">=3.24.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions


### PR DESCRIPTION
## Summary
- regenerate the Freezed/json_serializable outputs for the grammar and Turing machine DTOs
- bump the Dart/Flutter SDK constraints so the current code generators run on modern toolchains
- refresh pubspec.lock after fetching the updated dependencies

## Testing
- flutter pub run build_runner build --delete-conflicting-outputs
- flutter analyze *(fails: existing lint/type issues in the project unrelated to the regenerated files)*

------
https://chatgpt.com/codex/tasks/task_e_68db14684dd0832e8ae500db2c47dc96