### PR TITLE
Fix Result.mapOrElse failure handling

### DIFF
--- a/lib/core/result.dart
+++ b/lib/core/result.dart
@@ -28,11 +28,11 @@ sealed class Result<T> {
   /// Maps the result to another type, handling both success and failure
   Result<R> mapOrElse<R>(
     R Function(T) onSuccess,
-    R Function(String) onFailure,
+    String Function(String) onFailure,
   ) {
     return switch (this) {
       Success<T>(data: final data) => Success(onSuccess(data)),
-      Failure<T>(message: final message) => Success(onFailure(message)),
+      Failure<T>(message: final message) => Failure(onFailure(message)),
     };
   }
 

--- a/test/unit/core/result_test.dart
+++ b/test/unit/core/result_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/result.dart';
+
+void main() {
+  group('Result.mapOrElse', () {
+    test('preserves failure state and message', () {
+      const failure = Failure<int>('original error');
+
+      final result = failure.mapOrElse(
+        (value) => value.toString(),
+        (message) => message,
+      );
+
+      expect(result.isFailure, isTrue);
+      expect(result, isA<Failure<String>>());
+      expect(result.error, equals('original error'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ensure Result.mapOrElse returns a Failure when invoked on a failed result and allows transforming the error message
- add a unit test covering mapOrElse failure behaviour to verify the failure state and message are preserved

## Testing
- flutter analyze *(fails: command not found: flutter)*
- flutter test test/unit/core/result_test.dart *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e0e1fd0832e845984d6ade453ec