### PR TITLE
data: guard ExamplesLibraryStats toString for empty maps

### DIFF
--- a/lib/data/services/examples_service.dart
+++ b/lib/data/services/examples_service.dart
@@ -267,11 +267,16 @@ class ExamplesLibraryStats {
 
   @override
   String toString() {
+    final difficultyCount =
+        examplesByDifficulty.values.fold<int>(0, (sum, value) => sum + value);
+    final complexityCount =
+        examplesByComplexity.values.fold<int>(0, (sum, value) => sum + value);
+
     return 'ExamplesLibraryStats('
         'total: $totalExamples, '
         'categories: ${examplesByCategory.length}, '
-        'difficulties: ${examplesByDifficulty.values.reduce((a, b) => a + b)}, '
-        'complexities: ${examplesByComplexity.values.reduce((a, b) => a + b)}, '
+        'difficulties: $difficultyCount, '
+        'complexities: $complexityCount, '
         'topTags: ${mostCommonTags.take(3).join(", ")}'
         ')';
   }

--- a/test/unit/data/services/examples_library_stats_test.dart
+++ b/test/unit/data/services/examples_library_stats_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';
+import 'package:jflutter/data/services/examples_service.dart';
+import 'package:jflutter/core/repositories/automaton_repository.dart';
+
+void main() {
+  group('ExamplesLibraryStats toString', () {
+    test('handles empty stats without errors', () {
+      final stats = ExamplesLibraryStats.empty();
+
+      expect(
+        stats.toString(),
+        'ExamplesLibraryStats(total: 0, categories: 0, difficulties: 0, complexities: 0, topTags: )',
+      );
+    });
+
+    test('computes sums safely for partially empty maps', () {
+      final stats = ExamplesLibraryStats(
+        totalExamples: 5,
+        examplesByCategory: {ExampleCategory.dfa: 5},
+        examplesByDifficulty: const {},
+        examplesByComplexity: const {ComplexityLevel.low: 3},
+        mostCommonTags: const ['dfa', 'automaton'],
+      );
+
+      final description = stats.toString();
+
+      expect(description, contains('total: 5'));
+      expect(description, contains('categories: 1'));
+      expect(description, contains('difficulties: 0'));
+      expect(description, contains('complexities: 3'));
+      expect(description, contains('topTags: dfa, automaton'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ensure `ExamplesLibraryStats.toString` accumulates counts safely when maps are empty
- add unit coverage for the empty factory and partially empty count maps

## Testing
- `flutter analyze` *(fails: `flutter` is not available in the execution environment)*
- `flutter test test/unit/data/services/examples_library_stats_test.dart` *(fails: `flutter` is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e0d5c84832ebf20d32657232c7a