### PR TITLE
data: validate example asset loading

### DIFF
--- a/test/unit/data/examples_asset_data_source_test.dart
+++ b/test/unit/data/examples_asset_data_source_test.dart
@@ -1,0 +1,108 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/repositories/automaton_repository.dart';
+import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';
+
+void main() {
+  group('ExamplesAssetDataSource JSON validation', () {
+    late ExamplesAssetDataSource dataSource;
+
+    setUp(() {
+      dataSource = ExamplesAssetDataSource();
+    });
+
+    ExampleMetadata _metadataFor({
+      required ExampleCategory category,
+      required String fileName,
+    }) {
+      return ExampleMetadata(
+        fileName: fileName,
+        category: category,
+        subcategory: 'Test',
+        difficulty: DifficultyLevel.medium,
+        description: 'Test metadata',
+        tags: const ['test'],
+        estimatedComplexity: ComplexityLevel.medium,
+      );
+    }
+
+    Map<String, dynamic> _loadExample(String fileName) {
+      final file = File('jflutter_js/examples/' + fileName);
+      final jsonString = file.readAsStringSync();
+      final decoded = jsonDecode(jsonString);
+      expect(decoded, isA<Map<String, dynamic>>(),
+          reason: 'Fixture $fileName must decode to a JSON object');
+      return decoded as Map<String, dynamic>;
+    }
+
+    test('Returns failure when DFA example is missing states', () {
+      final json = _loadExample('afd_ends_with_a.json');
+      final metadata =
+          _metadataFor(category: ExampleCategory.dfa, fileName: 'afd_ends_with_a.json');
+
+      json.remove('states');
+
+      final result = dataSource.convertJsonForTesting(
+        json,
+        metadata,
+        'AFD - Termina com A',
+      );
+
+      expect(result.isFailure, isTrue);
+      expect(result.error, contains('states'));
+    });
+
+    test('Validates CFG example without producing an automaton model', () {
+      final json = _loadExample('glc_balanced_parentheses.json');
+      final metadata = _metadataFor(
+        category: ExampleCategory.cfg,
+        fileName: 'glc_balanced_parentheses.json',
+      );
+
+      final result = dataSource.convertJsonForTesting(
+        json,
+        metadata,
+        'GLC - Parênteses balanceados',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.data, isNull);
+    });
+
+    test('Validates PDA example structure', () {
+      final json = _loadExample('apda_palindrome.json');
+      final metadata = _metadataFor(
+        category: ExampleCategory.pda,
+        fileName: 'apda_palindrome.json',
+      );
+
+      final result = dataSource.convertJsonForTesting(
+        json,
+        metadata,
+        'APD - Palíndromo',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.data, isNull);
+    });
+
+    test('Validates TM example structure', () {
+      final json = _loadExample('tm_binary_to_unary.json');
+      final metadata = _metadataFor(
+        category: ExampleCategory.tm,
+        fileName: 'tm_binary_to_unary.json',
+      );
+
+      final result = dataSource.convertJsonForTesting(
+        json,
+        metadata,
+        'MT - Binário para unário',
+      );
+
+      expect(result.isSuccess, isTrue);
+      expect(result.data, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- validate example assets before conversion and return descriptive failures for malformed DFA/NFA data
- add category-specific checks for CFG, PDA, and TM examples so they don't trigger cast errors
- expose a testing hook and add unit tests covering the balanced parentheses grammar, PDA palindrome, and Turing machine fixtures

## Testing
- flutter analyze *(fails: flutter command not available in container)*
- flutter test test/unit/data/examples_asset_data_source_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db1e0e31c4832e874ace293b2326af