### PR TITLE
Fix ambiguous PDA simulator import

### DIFF
--- a/lib/presentation/providers/pda_trace_provider.dart
+++ b/lib/presentation/providers/pda_trace_provider.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
 import '../../core/algorithms/pda/pda_simulator_facade.dart';
-import '../../core/algorithms/pda_simulator.dart';
 
 /// Immutable state holding the latest PDA simulation result and flags.
 class PDATraceState {


### PR DESCRIPTION
## Summary
- rely exclusively on the PDA simulator facade inside the PDA trace provider to avoid duplicate imports

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68db224dcffc832e83675786c26fc4a5