### PR TITLE
Fix numeric parsing for automaton JSON deserializers

### DIFF
--- a/lib/core/models/fsa.dart
+++ b/lib/core/models/fsa.dart
@@ -83,6 +83,11 @@ class FSA extends Automaton {
 
   /// Creates an FSA from a JSON representation
   factory FSA.fromJson(Map<String, dynamic> json) {
+    final boundsData =
+        (json['bounds'] as Map?)?.cast<String, dynamic>();
+    final panOffsetData =
+        (json['panOffset'] as Map?)?.cast<String, dynamic>();
+
     return FSA(
       id: json['id'] as String,
       name: json['name'] as String,
@@ -102,15 +107,15 @@ class FSA extends Automaton {
       created: DateTime.parse(json['created'] as String),
       modified: DateTime.parse(json['modified'] as String),
       bounds: math.Rectangle(
-        (json['bounds'] as Map<String, dynamic>)['x'] as double,
-        (json['bounds'] as Map<String, dynamic>)['y'] as double,
-        (json['bounds'] as Map<String, dynamic>)['width'] as double,
-        (json['bounds'] as Map<String, dynamic>)['height'] as double,
+        (boundsData?['x'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['y'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['width'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['height'] as num?)?.toDouble() ?? 0.0,
       ),
-      zoomLevel: json['zoomLevel'] as double? ?? 1.0,
+      zoomLevel: (json['zoomLevel'] as num?)?.toDouble() ?? 1.0,
       panOffset: Vector2(
-        (json['panOffset'] as Map<String, dynamic>)['x'] as double,
-        (json['panOffset'] as Map<String, dynamic>)['y'] as double,
+        (panOffsetData?['x'] as num?)?.toDouble() ?? 0.0,
+        (panOffsetData?['y'] as num?)?.toDouble() ?? 0.0,
       ),
     );
   }

--- a/lib/core/models/fsa_transition.dart
+++ b/lib/core/models/fsa_transition.dart
@@ -70,15 +70,17 @@ class FSATransition extends Transition {
 
   /// Creates an FSA transition from a JSON representation
   factory FSATransition.fromJson(Map<String, dynamic> json) {
+    final controlPointData =
+        (json['controlPoint'] as Map?)?.cast<String, dynamic>();
+    final controlPointX = (controlPointData?['x'] as num?)?.toDouble() ?? 0.0;
+    final controlPointY = (controlPointData?['y'] as num?)?.toDouble() ?? 0.0;
+
     return FSATransition(
       id: json['id'] as String,
       fromState: State.fromJson(json['fromState'] as Map<String, dynamic>),
       toState: State.fromJson(json['toState'] as Map<String, dynamic>),
       label: json['label'] as String,
-      controlPoint: Vector2(
-        (json['controlPoint'] as Map<String, dynamic>)['x'] as double,
-        (json['controlPoint'] as Map<String, dynamic>)['y'] as double,
-      ),
+      controlPoint: Vector2(controlPointX, controlPointY),
       type: TransitionType.values.firstWhere(
         (e) => e.name == json['type'],
         orElse: () => TransitionType.deterministic,

--- a/lib/core/models/layout_settings.dart
+++ b/lib/core/models/layout_settings.dart
@@ -74,24 +74,60 @@ class LayoutSettings {
 
   /// Creates layout settings from a JSON representation
   factory LayoutSettings.fromJson(Map<String, dynamic> json) {
-    final colorSchemeData = json['colorScheme'] as Map<String, dynamic>;
+    const defaultScheme = ColorScheme.light();
+    final colorSchemeData =
+        (json['colorScheme'] as Map?)?.cast<String, dynamic>();
 
     return LayoutSettings(
-      nodeRadius: json['nodeRadius'] as double? ?? 20.0,
-      edgeThickness: json['edgeThickness'] as double? ?? 2.0,
-      colorScheme: ColorScheme.light(
-        primary: Color(colorSchemeData['primary'] as int),
-        secondary: Color(colorSchemeData['secondary'] as int),
-        surface: Color(colorSchemeData['surface'] as int),
-        error: Color(colorSchemeData['error'] as int),
-        onPrimary: Color(colorSchemeData['onPrimary'] as int),
-        onSecondary: Color(colorSchemeData['onSecondary'] as int),
-        onSurface: Color(colorSchemeData['onSurface'] as int),
-        onError: Color(colorSchemeData['onError'] as int),
-      ),
+      nodeRadius: (json['nodeRadius'] as num?)?.toDouble() ?? 20.0,
+      edgeThickness: (json['edgeThickness'] as num?)?.toDouble() ?? 2.0,
+      colorScheme: colorSchemeData == null
+          ? defaultScheme
+          : ColorScheme.light(
+              primary: _colorFromJson(
+                colorSchemeData,
+                'primary',
+                defaultScheme.primary,
+              ),
+              secondary: _colorFromJson(
+                colorSchemeData,
+                'secondary',
+                defaultScheme.secondary,
+              ),
+              surface: _colorFromJson(
+                colorSchemeData,
+                'surface',
+                defaultScheme.surface,
+              ),
+              error: _colorFromJson(
+                colorSchemeData,
+                'error',
+                defaultScheme.error,
+              ),
+              onPrimary: _colorFromJson(
+                colorSchemeData,
+                'onPrimary',
+                defaultScheme.onPrimary,
+              ),
+              onSecondary: _colorFromJson(
+                colorSchemeData,
+                'onSecondary',
+                defaultScheme.onSecondary,
+              ),
+              onSurface: _colorFromJson(
+                colorSchemeData,
+                'onSurface',
+                defaultScheme.onSurface,
+              ),
+              onError: _colorFromJson(
+                colorSchemeData,
+                'onError',
+                defaultScheme.onError,
+              ),
+            ),
       showGrid: json['showGrid'] as bool? ?? false,
       snapToGrid: json['snapToGrid'] as bool? ?? false,
-      gridSize: json['gridSize'] as double? ?? 20.0,
+      gridSize: (json['gridSize'] as num?)?.toDouble() ?? 20.0,
     );
   }
 
@@ -235,4 +271,16 @@ class LayoutSettings {
       gridSize: 30.0,
     );
   }
+}
+
+Color _colorFromJson(
+  Map<String, dynamic>? data,
+  String key,
+  Color fallback,
+) {
+  final value = data?[key];
+  if (value is int) {
+    return Color(value);
+  }
+  return fallback;
 }

--- a/lib/core/models/pda.dart
+++ b/lib/core/models/pda.dart
@@ -96,6 +96,11 @@ class PDA extends Automaton {
 
   /// Creates a PDA from a JSON representation
   factory PDA.fromJson(Map<String, dynamic> json) {
+    final boundsData =
+        (json['bounds'] as Map?)?.cast<String, dynamic>();
+    final panOffsetData =
+        (json['panOffset'] as Map?)?.cast<String, dynamic>();
+
     return PDA(
       id: json['id'] as String,
       name: json['name'] as String,
@@ -115,15 +120,15 @@ class PDA extends Automaton {
       created: DateTime.parse(json['created'] as String),
       modified: DateTime.parse(json['modified'] as String),
       bounds: math.Rectangle(
-        (json['bounds'] as Map<String, dynamic>)['x'] as double,
-        (json['bounds'] as Map<String, dynamic>)['y'] as double,
-        (json['bounds'] as Map<String, dynamic>)['width'] as double,
-        (json['bounds'] as Map<String, dynamic>)['height'] as double,
+        (boundsData?['x'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['y'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['width'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['height'] as num?)?.toDouble() ?? 0.0,
       ),
-      zoomLevel: json['zoomLevel'] as double? ?? 1.0,
+      zoomLevel: (json['zoomLevel'] as num?)?.toDouble() ?? 1.0,
       panOffset: Vector2(
-        (json['panOffset'] as Map<String, dynamic>)['x'] as double,
-        (json['panOffset'] as Map<String, dynamic>)['y'] as double,
+        (panOffsetData?['x'] as num?)?.toDouble() ?? 0.0,
+        (panOffsetData?['y'] as num?)?.toDouble() ?? 0.0,
       ),
       stackAlphabet: Set<String>.from(json['stackAlphabet'] as List),
       initialStackSymbol: json['initialStackSymbol'] as String? ?? 'Z',

--- a/lib/core/models/pda_transition.dart
+++ b/lib/core/models/pda_transition.dart
@@ -100,15 +100,17 @@ class PDATransition extends Transition {
 
   /// Creates a PDA transition from a JSON representation
   factory PDATransition.fromJson(Map<String, dynamic> json) {
+    final controlPointData =
+        (json['controlPoint'] as Map?)?.cast<String, dynamic>();
+    final controlPointX = (controlPointData?['x'] as num?)?.toDouble() ?? 0.0;
+    final controlPointY = (controlPointData?['y'] as num?)?.toDouble() ?? 0.0;
+
     return PDATransition(
       id: json['id'] as String,
       fromState: State.fromJson(json['fromState'] as Map<String, dynamic>),
       toState: State.fromJson(json['toState'] as Map<String, dynamic>),
       label: json['label'] as String,
-      controlPoint: Vector2(
-        (json['controlPoint'] as Map<String, dynamic>)['x'] as double,
-        (json['controlPoint'] as Map<String, dynamic>)['y'] as double,
-      ),
+      controlPoint: Vector2(controlPointX, controlPointY),
       type: TransitionType.values.firstWhere(
         (e) => e.name == json['type'],
         orElse: () => TransitionType.deterministic,

--- a/lib/core/models/state.dart
+++ b/lib/core/models/state.dart
@@ -72,13 +72,15 @@ class State {
 
   /// Creates a state from a JSON representation
   factory State.fromJson(Map<String, dynamic> json) {
+    final positionData =
+        (json['position'] as Map?)?.cast<String, dynamic>();
+    final positionX = (positionData?['x'] as num?)?.toDouble() ?? 0.0;
+    final positionY = (positionData?['y'] as num?)?.toDouble() ?? 0.0;
+
     return State(
       id: json['id'] as String,
       label: json['label'] as String,
-      position: Vector2(
-        (json['position'] as Map<String, dynamic>)['x'] as double,
-        (json['position'] as Map<String, dynamic>)['y'] as double,
-      ),
+      position: Vector2(positionX, positionY),
       isInitial: json['isInitial'] as bool? ?? false,
       isAccepting: json['isAccepting'] as bool? ?? false,
       type: StateType.values.firstWhere(

--- a/lib/core/models/tm.dart
+++ b/lib/core/models/tm.dart
@@ -103,6 +103,11 @@ class TM extends Automaton {
 
   /// Creates a TM from a JSON representation
   factory TM.fromJson(Map<String, dynamic> json) {
+    final boundsData =
+        (json['bounds'] as Map?)?.cast<String, dynamic>();
+    final panOffsetData =
+        (json['panOffset'] as Map?)?.cast<String, dynamic>();
+
     return TM(
       id: json['id'] as String,
       name: json['name'] as String,
@@ -122,15 +127,15 @@ class TM extends Automaton {
       created: DateTime.parse(json['created'] as String),
       modified: DateTime.parse(json['modified'] as String),
       bounds: math.Rectangle(
-        (json['bounds'] as Map<String, dynamic>)['x'] as double,
-        (json['bounds'] as Map<String, dynamic>)['y'] as double,
-        (json['bounds'] as Map<String, dynamic>)['width'] as double,
-        (json['bounds'] as Map<String, dynamic>)['height'] as double,
+        (boundsData?['x'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['y'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['width'] as num?)?.toDouble() ?? 0.0,
+        (boundsData?['height'] as num?)?.toDouble() ?? 0.0,
       ),
-      zoomLevel: json['zoomLevel'] as double? ?? 1.0,
+      zoomLevel: (json['zoomLevel'] as num?)?.toDouble() ?? 1.0,
       panOffset: Vector2(
-        (json['panOffset'] as Map<String, dynamic>)['x'] as double,
-        (json['panOffset'] as Map<String, dynamic>)['y'] as double,
+        (panOffsetData?['x'] as num?)?.toDouble() ?? 0.0,
+        (panOffsetData?['y'] as num?)?.toDouble() ?? 0.0,
       ),
       tapeAlphabet: Set<String>.from(json['tapeAlphabet'] as List),
       blankSymbol: json['blankSymbol'] as String? ?? 'B',

--- a/lib/core/models/tm_transition.dart
+++ b/lib/core/models/tm_transition.dart
@@ -80,15 +80,17 @@ class TMTransition extends Transition {
 
   /// Creates a TM transition from a JSON representation
   factory TMTransition.fromJson(Map<String, dynamic> json) {
+    final controlPointData =
+        (json['controlPoint'] as Map?)?.cast<String, dynamic>();
+    final controlPointX = (controlPointData?['x'] as num?)?.toDouble() ?? 0.0;
+    final controlPointY = (controlPointData?['y'] as num?)?.toDouble() ?? 0.0;
+
     return TMTransition(
       id: json['id'] as String,
       fromState: State.fromJson(json['fromState'] as Map<String, dynamic>),
       toState: State.fromJson(json['toState'] as Map<String, dynamic>),
       label: json['label'] as String,
-      controlPoint: Vector2(
-        (json['controlPoint'] as Map<String, dynamic>)['x'] as double,
-        (json['controlPoint'] as Map<String, dynamic>)['y'] as double,
-      ),
+      controlPoint: Vector2(controlPointX, controlPointY),
       type: TransitionType.values.firstWhere(
         (e) => e.name == json['type'],
         orElse: () => TransitionType.deterministic,

--- a/lib/core/models/touch_interaction.dart
+++ b/lib/core/models/touch_interaction.dart
@@ -55,15 +55,17 @@ class TouchInteraction {
 
   /// Creates a touch interaction from a JSON representation
   factory TouchInteraction.fromJson(Map<String, dynamic> json) {
+    final positionData =
+        (json['position'] as Map?)?.cast<String, dynamic>();
+    final positionX = (positionData?['x'] as num?)?.toDouble() ?? 0.0;
+    final positionY = (positionData?['y'] as num?)?.toDouble() ?? 0.0;
+
     return TouchInteraction(
       type: InteractionType.values.firstWhere(
         (e) => e.name == json['type'],
         orElse: () => InteractionType.tap,
       ),
-      position: Vector2(
-        (json['position'] as Map<String, dynamic>)['x'] as double,
-        (json['position'] as Map<String, dynamic>)['y'] as double,
-      ),
+      position: Vector2(positionX, positionY),
       selectedStates: Set<String>.from(json['selectedStates'] as List),
       selectedTransitions: Set<String>.from(
         json['selectedTransitions'] as List,


### PR DESCRIPTION
## Summary
- coerce numeric JSON fields to doubles when recreating automata, transitions, and touch interactions
- add null-safe parsing for layout color schemes and numeric configuration values

## Testing
- dart format . *(fails: dart command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db4ecbb768832ea17820b8594274f9