### PR TITLE
Fix NFA→DFA guard handling

### DIFF
--- a/lib/core/algorithms/nfa_to_dfa_converter.dart
+++ b/lib/core/algorithms/nfa_to_dfa_converter.dart
@@ -159,7 +159,7 @@ class NFAToDFAConverter {
     // Process each state set
     int stateCounter = 1;
     const int maxStates = 1000; // Performance safeguard
-    while (queue.isNotEmpty && stateCounter < maxStates) {
+    while (queue.isNotEmpty) {
       final currentStateKey = queue.removeAt(0);
       if (processed.contains(currentStateKey)) continue;
       processed.add(currentStateKey);
@@ -196,6 +196,11 @@ class NFAToDFAConverter {
           if (dfaStates.containsKey(nextStateKey)) {
             nextDFAState = dfaStates[nextStateKey]!;
           } else {
+            if (stateCounter >= maxStates) {
+              throw StateError(
+                'Exceeded maximum number of DFA states ($maxStates) during subset construction.',
+              );
+            }
             nextDFAState = _createDFAState(nextStateSet, stateCounter++);
             dfaStates[nextStateKey] = nextDFAState;
             stateSetMap[nextStateKey] = nextStateSet;

--- a/test/unit/core/automata/fa_algorithms_test.dart
+++ b/test/unit/core/automata/fa_algorithms_test.dart
@@ -214,5 +214,48 @@ void main() {
       );
       expect(fa.FAAlgorithms.areEquivalent(dfa1, dfa2), isTrue);
     });
+
+    test('NFA→DFA conversion reports guard exhaustion as failure', () {
+      const largeStateCount = 1001;
+      final states = List.generate(largeStateCount, (index) {
+        return State(
+          id: 'q$index',
+          label: 'q$index',
+          position: Vector2(index * 5.0, 0.0),
+          isInitial: index == 0,
+          isAccepting: index == largeStateCount - 1,
+        );
+      });
+
+      final transitions = <FSATransition>{
+        for (var i = 0; i < largeStateCount - 1; i++)
+          FSATransition.deterministic(
+            id: 't_${states[i].id}_${states[i + 1].id}',
+            fromState: states[i],
+            toState: states[i + 1],
+            symbol: 'a',
+          ),
+      };
+
+      final nfa = FSA(
+        id: 'large_nfa',
+        name: 'Large NFA',
+        states: states.toSet(),
+        transitions: transitions,
+        alphabet: {'a'},
+        initialState: states.first,
+        acceptingStates: {states.last},
+        created: DateTime.now(),
+        modified: DateTime.now(),
+        bounds: const math.Rectangle(0, 0, 800, 600),
+      );
+
+      final result = fa.FAAlgorithms.nfaToDfa(nfa);
+      expect(result.isFailure, isTrue);
+      expect(
+        result.error,
+        contains('Exceeded maximum number of DFA states'),
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- ensure the NFA→DFA subset construction throws when the maximum DFA state guard is exceeded so the conversion reports a failure instead of returning a partial automaton
- add a regression test covering oversized NFAs to verify the guard failure is surfaced through the FAAlgorithms facade

## Testing
- dart test *(fails: `dart: command not found` in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68db4ecd8264832e9e35ab7d8d9ee148