### PR TITLE
Add grammar-to-PDA conversion workflows

### DIFF
--- a/lib/presentation/providers/home_navigation_provider.dart
+++ b/lib/presentation/providers/home_navigation_provider.dart
@@ -32,6 +32,9 @@ class HomeNavigationNotifier extends StateNotifier<int> {
 
   /// Convenience method that switches to the FSA workspace.
   void goToFsa() => setIndex(fsaIndex);
+
+  /// Convenience method that switches to the PDA workspace.
+  void goToPda() => setIndex(pdaIndex);
 }
 
 /// Provides the current navigation index for the home page.


### PR DESCRIPTION
## Summary
- extend the grammar state to track conversion progress and last PDA results
- add GrammarProvider helpers for the three grammar-to-PDA conversion variants
- expose the new conversions in the grammar algorithm panel and load the resulting PDA in the editor, including PDA navigation support

## Testing
- Not run (flutter is not available in the container)

------
https://chatgpt.com/codex/tasks/task_e_68dd4caeb060832ea4e7fe7cce6d5a00