### PR TITLE
Add DFA set operations and closures to algorithm panel

### DIFF
--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../../core/entities/automaton_entity.dart';
 import '../../core/models/fsa.dart';
+import '../providers/algorithm_provider.dart';
 import '../providers/automaton_provider.dart';
 import '../widgets/algorithm_panel.dart';
 import '../widgets/automaton_canvas.dart';
@@ -19,14 +21,273 @@ class FSAPage extends ConsumerStatefulWidget {
 class _FSAPageState extends ConsumerState<FSAPage> {
   final GlobalKey _canvasKey = GlobalKey();
 
+  void _showSnack(String message, {bool isError = false}) {
+    final theme = Theme.of(context);
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(
+          message,
+          style: isError
+              ? TextStyle(color: theme.colorScheme.onErrorContainer)
+              : null,
+        ),
+        backgroundColor:
+            isError ? theme.colorScheme.errorContainer : null,
+        behavior: SnackBarBehavior.floating,
+      ),
+    );
+  }
+
+  FSA? _requireAutomaton({
+    bool requireDfa = false,
+    bool requireLambda = false,
+    String? missingMessage,
+    String? invalidMessage,
+  }) {
+    final automaton = ref.read(automatonProvider).currentAutomaton;
+    if (automaton == null) {
+      _showSnack(
+        missingMessage ?? 'Load an automaton before running this operation.',
+        isError: true,
+      );
+      return null;
+    }
+
+    if (requireDfa &&
+        !(automaton.isDeterministic && !automaton.hasEpsilonTransitions)) {
+      _showSnack(
+        invalidMessage ??
+            'This operation requires a deterministic automaton without ε-transitions.',
+        isError: true,
+      );
+      return null;
+    }
+
+    if (requireLambda && !automaton.hasEpsilonTransitions) {
+      _showSnack(
+        invalidMessage ??
+            'The current automaton does not contain λ-transitions.',
+        isError: true,
+      );
+      return null;
+    }
+
+    return automaton;
+  }
+
+  Future<void> _applyAlgorithmResult({required String successMessage}) async {
+    final algorithmState = ref.read(algorithmProvider);
+    final notifier = ref.read(algorithmProvider.notifier);
+    final error = algorithmState.error;
+    final result = algorithmState.result;
+
+    if (error != null) {
+      _showSnack(error, isError: true);
+      notifier.clearResult();
+      return;
+    }
+
+    if (result is AutomatonEntity) {
+      ref.read(automatonProvider.notifier).replaceCurrentAutomaton(result);
+      _showSnack(successMessage);
+      notifier.clearResult();
+      return;
+    }
+
+    notifier.clearResult();
+    if (result != null) {
+      _showSnack('Unexpected result returned by the algorithm.', isError: true);
+    }
+  }
+
+  Future<void> _runUnaryAlgorithm({
+    required Future<void> Function(
+      AlgorithmProvider notifier,
+      AutomatonEntity entity,
+    )
+        algorithm,
+    required String successMessage,
+    bool requireDfa = false,
+    bool requireLambda = false,
+    String? invalidMessage,
+  }) async {
+    final automaton = _requireAutomaton(
+      requireDfa: requireDfa,
+      requireLambda: requireLambda,
+      invalidMessage: invalidMessage,
+    );
+    if (automaton == null) return;
+
+    final automatonNotifier = ref.read(automatonProvider.notifier);
+    final entity = automatonNotifier.currentAutomatonEntity;
+    if (entity == null) {
+      _showSnack(
+        'Unable to prepare the current automaton for processing.',
+        isError: true,
+      );
+      return;
+    }
+
+    await algorithm(ref.read(algorithmProvider.notifier), entity);
+    if (!mounted) return;
+    await _applyAlgorithmResult(successMessage: successMessage);
+  }
+
+  Future<void> _runBinaryAlgorithm({
+    required FSA other,
+    required Future<void> Function(
+      AlgorithmProvider notifier,
+      AutomatonEntity current,
+      AutomatonEntity other,
+    )
+        algorithm,
+    required String successMessage,
+    bool requireDfa = false,
+    String? invalidMessage,
+  }) async {
+    final automaton = _requireAutomaton(
+      requireDfa: requireDfa,
+      invalidMessage: invalidMessage,
+    );
+    if (automaton == null) return;
+
+    final automatonNotifier = ref.read(automatonProvider.notifier);
+    final currentEntity = automatonNotifier.currentAutomatonEntity;
+    if (currentEntity == null) {
+      _showSnack(
+        'Unable to prepare the current automaton for processing.',
+        isError: true,
+      );
+      return;
+    }
+
+    final otherEntity = automatonNotifier.convertFsaToEntity(other);
+
+    await algorithm(
+      ref.read(algorithmProvider.notifier),
+      currentEntity,
+      otherEntity,
+    );
+    if (!mounted) return;
+    await _applyAlgorithmResult(successMessage: successMessage);
+  }
+
+  Future<void> _handleRemoveLambda() async {
+    await _runUnaryAlgorithm(
+      algorithm: (notifier, entity) => notifier.removeLambdaTransitions(entity),
+      successMessage: 'λ-transitions removed successfully.',
+      requireLambda: true,
+      invalidMessage:
+          'The current automaton must contain λ-transitions to remove them.',
+    );
+  }
+
+  Future<void> _handleComplementDfa() async {
+    await _runUnaryAlgorithm(
+      algorithm: (notifier, entity) => notifier.complementDfa(entity),
+      successMessage: 'Complement computed successfully.',
+      requireDfa: true,
+      invalidMessage:
+          'Complement is only available for deterministic automata without ε-transitions.',
+    );
+  }
+
+  Future<void> _handlePrefixClosure() async {
+    await _runUnaryAlgorithm(
+      algorithm: (notifier, entity) => notifier.prefixClosureDfa(entity),
+      successMessage: 'Prefix closure computed successfully.',
+      requireDfa: true,
+      invalidMessage:
+          'Prefix closure is only available for deterministic automata without ε-transitions.',
+    );
+  }
+
+  Future<void> _handleSuffixClosure() async {
+    await _runUnaryAlgorithm(
+      algorithm: (notifier, entity) => notifier.suffixClosureDfa(entity),
+      successMessage: 'Suffix closure computed successfully.',
+      requireDfa: true,
+      invalidMessage:
+          'Suffix closure is only available for deterministic automata without ε-transitions.',
+    );
+  }
+
+  Future<void> _handleUnionDfa(FSA other) async {
+    await _runBinaryAlgorithm(
+      other: other,
+      algorithm: (notifier, current, loaded) => notifier.unionDfa(current, loaded),
+      successMessage: 'Union computed successfully.',
+      requireDfa: true,
+      invalidMessage:
+          'Binary DFA operations require a deterministic automaton without ε-transitions.',
+    );
+  }
+
+  Future<void> _handleIntersectionDfa(FSA other) async {
+    await _runBinaryAlgorithm(
+      other: other,
+      algorithm: (notifier, current, loaded) =>
+          notifier.intersectionDfa(current, loaded),
+      successMessage: 'Intersection computed successfully.',
+      requireDfa: true,
+      invalidMessage:
+          'Binary DFA operations require a deterministic automaton without ε-transitions.',
+    );
+  }
+
+  Future<void> _handleDifferenceDfa(FSA other) async {
+    await _runBinaryAlgorithm(
+      other: other,
+      algorithm: (notifier, current, loaded) =>
+          notifier.differenceDfa(current, loaded),
+      successMessage: 'Difference computed successfully.',
+      requireDfa: true,
+      invalidMessage:
+          'Binary DFA operations require a deterministic automaton without ε-transitions.',
+    );
+  }
+
+  AlgorithmPanel _buildAlgorithmPanelForState(AutomatonState state) {
+    final automatonNotifier = ref.read(automatonProvider.notifier);
+    final automaton = state.currentAutomaton;
+    final hasAutomaton = automaton != null;
+    final hasLambda = automaton?.hasEpsilonTransitions ?? false;
+    final isDfa = automaton != null &&
+        automaton.isDeterministic &&
+        !automaton.hasEpsilonTransitions;
+
+    return AlgorithmPanel(
+      onNfaToDfa:
+          hasAutomaton ? () => automatonNotifier.convertNfaToDfa() : null,
+      onRemoveLambda: hasLambda ? _handleRemoveLambda : null,
+      onMinimizeDfa: isDfa ? () => automatonNotifier.minimizeDfa() : null,
+      onCompleteDfa: isDfa ? () => automatonNotifier.completeDfa() : null,
+      onComplementDfa: isDfa ? _handleComplementDfa : null,
+      onUnionDfa: isDfa ? _handleUnionDfa : null,
+      onIntersectionDfa: isDfa ? _handleIntersectionDfa : null,
+      onDifferenceDfa: isDfa ? _handleDifferenceDfa : null,
+      onPrefixClosure: isDfa ? _handlePrefixClosure : null,
+      onSuffixClosure: isDfa ? _handleSuffixClosure : null,
+      onFsaToGrammar: hasAutomaton ? _handleFsaToGrammar : null,
+      onAutoLayout:
+          hasAutomaton ? () => automatonNotifier.applyAutoLayout() : null,
+      onClear: () => automatonNotifier.clearAutomaton(),
+      onRegexToNfa: (regex) => ref
+          .read(automatonProvider.notifier)
+          .convertRegexToNfa(regex),
+      onFaToRegex: hasAutomaton ? _handleFaToRegex : null,
+      onCompareEquivalence: isDfa ? _handleCompareEquivalence : null,
+      equivalenceResult: state.equivalenceResult,
+      equivalenceDetails: state.equivalenceDetails,
+    );
+  }
+
   Future<void> _handleFaToRegex() async {
     final notifier = ref.read(automatonProvider.notifier);
     final regex = await notifier.convertFaToRegex();
     if (!mounted || regex == null) {
       if (mounted && ref.read(automatonProvider).error != null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(ref.read(automatonProvider).error!)),
-        );
+        _showSnack(ref.read(automatonProvider).error!, isError: true);
       }
       return;
     }
@@ -42,9 +303,7 @@ class _FSAPageState extends ConsumerState<FSAPage> {
     final grammar = await notifier.convertFsaToGrammar();
     if (!mounted || grammar == null) {
       if (mounted && ref.read(automatonProvider).error != null) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text(ref.read(automatonProvider).error!)),
-        );
+        _showSnack(ref.read(automatonProvider).error!, isError: true);
       }
       return;
     }
@@ -60,9 +319,7 @@ class _FSAPageState extends ConsumerState<FSAPage> {
     if (!mounted) return;
     final message = ref.read(automatonProvider).equivalenceDetails;
     if (message != null) {
-      ScaffoldMessenger.of(
-        context,
-      ).showSnackBar(SnackBar(content: Text(message)));
+      _showSnack(message);
     }
   }
 
@@ -135,29 +392,11 @@ class _FSAPageState extends ConsumerState<FSAPage> {
                 controller: scrollController,
                 child: Padding(
                   padding: const EdgeInsets.all(16),
-                  child: AlgorithmPanel(
-                    onNfaToDfa: () =>
-                        ref.read(automatonProvider.notifier).convertNfaToDfa(),
-                    onMinimizeDfa: () =>
-                        ref.read(automatonProvider.notifier).minimizeDfa(),
-                    onCompleteDfa: () =>
-                        ref.read(automatonProvider.notifier).completeDfa(),
-                    onFsaToGrammar: _handleFsaToGrammar,
-                    onAutoLayout: () =>
-                        ref.read(automatonProvider.notifier).applyAutoLayout(),
-                    onClear: () =>
-                        ref.read(automatonProvider.notifier).clearAutomaton(),
-                    onRegexToNfa: (regex) => ref
-                        .read(automatonProvider.notifier)
-                        .convertRegexToNfa(regex),
-                    onFaToRegex: _handleFaToRegex,
-                    onCompareEquivalence: _handleCompareEquivalence,
-                    equivalenceResult: ref
-                        .read(automatonProvider)
-                        .equivalenceResult,
-                    equivalenceDetails: ref
-                        .read(automatonProvider)
-                        .equivalenceDetails,
+                  child: Consumer(
+                    builder: (context, sheetRef, _) {
+                      final sheetState = sheetRef.watch(automatonProvider);
+                      return _buildAlgorithmPanelForState(sheetState);
+                    },
                   ),
                 ),
               );
@@ -210,26 +449,7 @@ class _FSAPageState extends ConsumerState<FSAPage> {
           flex: 2,
           child: Column(
             children: [
-              AlgorithmPanel(
-                onNfaToDfa: () =>
-                    ref.read(automatonProvider.notifier).convertNfaToDfa(),
-                onMinimizeDfa: () =>
-                    ref.read(automatonProvider.notifier).minimizeDfa(),
-                onCompleteDfa: () =>
-                    ref.read(automatonProvider.notifier).completeDfa(),
-                onFsaToGrammar: _handleFsaToGrammar,
-                onAutoLayout: () =>
-                    ref.read(automatonProvider.notifier).applyAutoLayout(),
-                onClear: () =>
-                    ref.read(automatonProvider.notifier).clearAutomaton(),
-                onRegexToNfa: (regex) => ref
-                    .read(automatonProvider.notifier)
-                    .convertRegexToNfa(regex),
-                onFaToRegex: _handleFaToRegex,
-                onCompareEquivalence: _handleCompareEquivalence,
-                equivalenceResult: state.equivalenceResult,
-                equivalenceDetails: state.equivalenceDetails,
-              ),
+              _buildAlgorithmPanelForState(state),
             ],
           ),
         ),

--- a/lib/presentation/providers/algorithm_provider.dart
+++ b/lib/presentation/providers/algorithm_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/use_cases/algorithm_use_cases.dart';
 import '../../core/entities/automaton_entity.dart';
+import '../../data/repositories/algorithm_repository_impl.dart';
 
 /// Provider for algorithm operations
 class AlgorithmProvider extends StateNotifier<AlgorithmState> {
@@ -306,3 +307,30 @@ class AlgorithmState {
     );
   }
 }
+
+/// Provider instance for algorithm operations
+final algorithmProvider =
+    StateNotifierProvider<AlgorithmProvider, AlgorithmState>((ref) {
+      final repository = AlgorithmRepositoryImpl();
+
+      return AlgorithmProvider(
+        nfaToDfaUseCase: NfaToDfaUseCase(repository),
+        removeLambdaTransitionsUseCase:
+            RemoveLambdaTransitionsUseCase(repository),
+        minimizeDfaUseCase: MinimizeDfaUseCase(repository),
+        completeDfaUseCase: CompleteDfaUseCase(repository),
+        complementDfaUseCase: ComplementDfaUseCase(repository),
+        unionDfaUseCase: UnionDfaUseCase(repository),
+        intersectionDfaUseCase: IntersectionDfaUseCase(repository),
+        differenceDfaUseCase: DifferenceDfaUseCase(repository),
+        prefixClosureUseCase: PrefixClosureUseCase(repository),
+        suffixClosureUseCase: SuffixClosureUseCase(repository),
+        regexToNfaUseCase: RegexToNfaUseCase(repository),
+        dfaToRegexUseCase: DfaToRegexUseCase(repository),
+        fsaToGrammarUseCase: FsaToGrammarUseCase(repository),
+        checkEquivalenceUseCase: CheckEquivalenceUseCase(repository),
+        simulateWordUseCase: SimulateWordUseCase(repository),
+        createStepByStepSimulationUseCase:
+            CreateStepByStepSimulationUseCase(repository),
+      );
+    });

--- a/lib/presentation/providers/automaton_provider.dart
+++ b/lib/presentation/providers/automaton_provider.dart
@@ -265,6 +265,38 @@ class AutomatonProvider extends StateNotifier<AutomatonState> {
     }
   }
 
+  /// Returns the current automaton as a domain entity when available.
+  AutomatonEntity? get currentAutomatonEntity {
+    final current = state.currentAutomaton;
+    if (current == null) return null;
+    return _convertFsaToEntity(current);
+  }
+
+  /// Converts the provided FSA to its [AutomatonEntity] representation.
+  AutomatonEntity convertFsaToEntity(FSA automaton) {
+    return _convertFsaToEntity(automaton);
+  }
+
+  /// Converts the provided [AutomatonEntity] back to an [FSA].
+  FSA convertEntityToFsa(AutomatonEntity entity) {
+    return _convertEntityToFsa(entity);
+  }
+
+  /// Replaces the current automaton with the one represented by [entity].
+  void replaceCurrentAutomaton(AutomatonEntity entity) {
+    final updated = _convertEntityToFsa(entity);
+    state = state.copyWith(
+      currentAutomaton: updated,
+      simulationResult: null,
+      regexResult: null,
+      grammarResult: null,
+      equivalenceResult: null,
+      equivalenceDetails: null,
+      error: null,
+      isLoading: false,
+    );
+  }
+
   /// Converts regex to NFA
   Future<void> convertRegexToNfa(String regex) async {
     state = state.copyWith(


### PR DESCRIPTION
## Summary
- extend the algorithm panel with lambda removal, complement, set operations, and closure actions plus binary automaton loading workflow
- expose a Riverpod provider for algorithm use cases and drive the new callbacks from the FSA editor with consistent snackbar feedback
- add conversion helpers in the automaton provider to translate between UI FSAs and domain entities when applying algorithm results

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd4caf0604832eac3c32afe5f03650