### PR TITLE
Add interaction modes to touch gesture handler

### DIFF
--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -4,6 +4,7 @@ import 'package:vector_math/vector_math_64.dart' hide Colors;
 import '../../core/models/fsa.dart';
 import '../../core/models/state.dart' as automaton_state;
 import '../../core/models/fsa_transition.dart';
+import '../../core/models/transition.dart';
 import '../../core/models/simulation_result.dart';
 import '../../core/models/simulation_step.dart';
 import 'touch_gesture_handler.dart';
@@ -42,6 +43,16 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
   automaton_state.State? _transitionStart;
   Offset? _transitionPreviewPosition;
   final FrameThrottler _pointerThrottler = FrameThrottler();
+
+  CanvasInteractionMode get _interactionMode {
+    if (_isAddingTransition) {
+      return CanvasInteractionMode.addTransition;
+    }
+    if (_isAddingState) {
+      return CanvasInteractionMode.addState;
+    }
+    return CanvasInteractionMode.none;
+  }
 
   @override
   void initState() {
@@ -111,6 +122,7 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
       _isAddingTransition = true;
       _isAddingState = false;
       _selectedState = null;
+      _transitionStart = null;
       _transitionPreviewPosition = null;
     });
   }
@@ -129,6 +141,30 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
       _isAddingState = false;
     });
 
+    _notifyAutomatonChanged();
+  }
+
+  Future<void> _addTransitionFromHandler(Transition transition) async {
+    final symbolInput = await _showSymbolDialog();
+    if (symbolInput == null) {
+      return;
+    }
+
+    final newTransition = FSATransition(
+      id: 't${_transitions.length + 1}',
+      fromState: transition.fromState,
+      toState: transition.toState,
+      label: symbolInput.label,
+      inputSymbols: symbolInput.inputSymbols,
+      lambdaSymbol: symbolInput.lambdaSymbol,
+    );
+
+    setState(() {
+      _transitions.add(newTransition);
+      _isAddingTransition = false;
+      _transitionStart = null;
+      _transitionPreviewPosition = null;
+    });
     _notifyAutomatonChanged();
   }
 
@@ -167,6 +203,52 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
       setState(() {
         _transitionPreviewPosition = position;
       });
+    });
+  }
+
+  void _handleTransitionPreview(TransitionDragPreview? preview) {
+    if (preview == null) {
+      if (_transitionStart != null || _transitionPreviewPosition != null) {
+        setState(() {
+          _transitionStart = null;
+          _transitionPreviewPosition = null;
+        });
+      }
+      return;
+    }
+
+    if (_transitionStart != preview.fromState) {
+      setState(() {
+        _transitionStart = preview.fromState;
+        _transitionPreviewPosition = preview.currentPosition;
+      });
+      return;
+    }
+
+    if (_transitionPreviewPosition == preview.currentPosition) {
+      return;
+    }
+
+    _pointerThrottler.schedule(() {
+      if (!mounted) return;
+      setState(() {
+        _transitionPreviewPosition = preview.currentPosition;
+      });
+    });
+  }
+
+  void _handleInteractionModeHandled() {
+    if (!_isAddingState && !_isAddingTransition &&
+        _transitionStart == null &&
+        _transitionPreviewPosition == null) {
+      return;
+    }
+
+    setState(() {
+      _isAddingState = false;
+      _isAddingTransition = false;
+      _transitionStart = null;
+      _transitionPreviewPosition = null;
     });
   }
 
@@ -291,10 +373,7 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
               _addState(position);
             },
             onTransitionAdded: (transition) {
-              setState(() {
-                _transitions.add(transition);
-              });
-              _notifyAutomatonChanged();
+              _addTransitionFromHandler(transition);
             },
             onStateEdited: (state) {
               _editState(state);
@@ -320,6 +399,9 @@ class _AutomatonCanvasState extends State<AutomatonCanvas> {
             onTransitionEdited: (transition) {
               _editTransition(transition);
             },
+            interactionMode: _interactionMode,
+            onTransitionPreview: _handleTransitionPreview,
+            onInteractionModeHandled: _handleInteractionModeHandled,
             child: MouseRegion(
               onExit: (_) {
                 _updateTransitionPreview(null);


### PR DESCRIPTION
## Summary
- extend the shared touch gesture handler with explicit canvas interaction modes and transition drag previews
- update the automaton, PDA, and TM canvases to drive the handler, surface temporary previews, and reset add-mode flags when completed
- adjust PDA and TM painters to render live transition previews and adapt TM transition creation to gather full configuration

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd584207a8832ea3e70f7bf9349be2