### PR TITLE
Fix home navigation skipping to intermediate tabs

### DIFF
--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -98,12 +98,24 @@ class _HomePageState extends ConsumerState<HomePage> {
     // Handle navigation changes
     if (_lastNavigationIndex != currentIndex) {
       WidgetsBinding.instance.addPostFrameCallback((_) {
-        if (mounted && _pageController.hasClients) {
+        if (!mounted || !_pageController.hasClients) {
+          return;
+        }
+
+        final currentPage = _pageController.page?.round() ?? _pageController.initialPage;
+        if (currentPage == currentIndex) {
+          return;
+        }
+
+        final pageDistance = (currentIndex - currentPage).abs();
+        if (pageDistance <= 1) {
           _pageController.animateToPage(
             currentIndex,
             duration: const Duration(milliseconds: 300),
             curve: Curves.easeInOut,
           );
+        } else {
+          _pageController.jumpToPage(currentIndex);
         }
       });
       _lastNavigationIndex = currentIndex;


### PR DESCRIPTION
## Summary
- prevent the home page from scrolling through intermediate workspaces when selecting distant tabs
- animate adjacent transitions while jumping directly to far destinations to keep navigation responsive

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd5946a2a8832eb5eb4822b41f862d