### PR TITLE
Add Draw2D WebView preview scaffolding

### DIFF
--- a/assets/draw2d/editor.js
+++ b/assets/draw2d/editor.js
@@ -1,0 +1,25 @@
+const READY_MESSAGE = 'Draw2D placeholder booted';
+
+function emitReadySignal(message) {
+  if (window.Draw2dReadyChannel &&
+      typeof window.Draw2dReadyChannel.postMessage === 'function') {
+    window.Draw2dReadyChannel.postMessage(message);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  console.log(READY_MESSAGE);
+  emitReadySignal(READY_MESSAGE);
+});
+
+// Simulate Draw2D boot sequence placeholder
+setTimeout(() => {
+  const placeholder = document.getElementById('draw2d-placeholder');
+  if (!placeholder) {
+    return;
+  }
+
+  placeholder.querySelector('p').textContent =
+    'Draw2D placeholder is ready.';
+  placeholder.classList.add('ready');
+}, 300);

--- a/assets/draw2d/index.html
+++ b/assets/draw2d/index.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Draw2D Placeholder</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        height: 100%;
+        width: 100%;
+        overflow: hidden;
+        background-color: #f4f5f7;
+        font-family: system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+          sans-serif;
+        color: #1d1d1f;
+      }
+
+      #draw2d-root {
+        position: relative;
+        width: 100%;
+        height: 100%;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        background: repeating-linear-gradient(
+          45deg,
+          rgba(0, 0, 0, 0.025),
+          rgba(0, 0, 0, 0.025) 10px,
+          rgba(255, 255, 255, 0.025) 10px,
+          rgba(255, 255, 255, 0.025) 20px
+        );
+      }
+
+      #draw2d-placeholder {
+        padding: 24px 32px;
+        border-radius: 12px;
+        border: 1px dashed rgba(0, 0, 0, 0.25);
+        background-color: rgba(255, 255, 255, 0.85);
+        box-shadow: 0 12px 32px rgba(31, 41, 55, 0.1);
+        text-align: center;
+      }
+
+      #draw2d-placeholder h1 {
+        margin: 0 0 12px 0;
+        font-size: 20px;
+      }
+
+      #draw2d-placeholder p {
+        margin: 0;
+        font-size: 14px;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="draw2d-root">
+      <div id="draw2d-placeholder">
+        <h1>Draw2D Canvas Preview</h1>
+        <p>The embedded Draw2D editor is loading…</p>
+      </div>
+    </div>
+    <script type="module" src="editor.js"></script>
+  </body>
+</html>

--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -6,6 +6,7 @@ import '../providers/algorithm_provider.dart';
 import '../providers/automaton_provider.dart';
 import '../widgets/algorithm_panel.dart';
 import '../widgets/automaton_canvas.dart';
+import '../widgets/draw2d_canvas_view.dart';
 import '../widgets/simulation_panel.dart';
 import 'grammar_page.dart';
 import 'regex_page.dart';
@@ -19,6 +20,7 @@ class FSAPage extends ConsumerStatefulWidget {
 }
 
 class _FSAPageState extends ConsumerState<FSAPage> {
+  static const bool _enableDraw2dDevPreview = false;
   final GlobalKey _canvasKey = GlobalKey();
 
   void _showSnack(String message, {bool isError = false}) {
@@ -323,6 +325,38 @@ class _FSAPageState extends ConsumerState<FSAPage> {
     }
   }
 
+  Widget _buildCanvasArea({
+    required AutomatonState state,
+    required bool isMobile,
+  }) {
+    final automatonCanvas = AutomatonCanvas(
+      automaton: state.currentAutomaton,
+      canvasKey: _canvasKey,
+      onAutomatonChanged: (automaton) {
+        ref.read(automatonProvider.notifier).updateAutomaton(automaton);
+      },
+      simulationResult: state.simulationResult,
+      showTrace: state.simulationResult != null,
+    );
+
+    if (!_enableDraw2dDevPreview) {
+      return automatonCanvas;
+    }
+
+    final spacing = isMobile ? 8.0 : 12.0;
+
+    return Column(
+      children: [
+        Expanded(flex: 3, child: automatonCanvas),
+        SizedBox(height: spacing),
+        const Expanded(
+          flex: 2,
+          child: Draw2DCanvasView(),
+        ),
+      ],
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     final state = ref.watch(automatonProvider);
@@ -361,14 +395,9 @@ class _FSAPageState extends ConsumerState<FSAPage> {
         Expanded(
           child: Container(
             margin: const EdgeInsets.all(8),
-            child: AutomatonCanvas(
-              automaton: state.currentAutomaton,
-              canvasKey: _canvasKey,
-              onAutomatonChanged: (automaton) {
-                ref.read(automatonProvider.notifier).updateAutomaton(automaton);
-              },
-              simulationResult: state.simulationResult,
-              showTrace: state.simulationResult != null,
+            child: _buildCanvasArea(
+              state: state,
+              isMobile: true,
             ),
           ),
         ),
@@ -457,14 +486,9 @@ class _FSAPageState extends ConsumerState<FSAPage> {
         // Center panel - Canvas
         Expanded(
           flex: 3,
-          child: AutomatonCanvas(
-            automaton: state.currentAutomaton,
-            canvasKey: _canvasKey,
-            onAutomatonChanged: (automaton) {
-              ref.read(automatonProvider.notifier).updateAutomaton(automaton);
-            },
-            simulationResult: state.simulationResult,
-            showTrace: state.simulationResult != null,
+          child: _buildCanvasArea(
+            state: state,
+            isMobile: false,
           ),
         ),
         const SizedBox(width: 16),

--- a/lib/presentation/widgets/draw2d_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_canvas_view.dart
@@ -1,0 +1,101 @@
+import 'dart:async';
+import 'dart:developer' as developer;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+/// Temporary Draw2D prototype embedded through a WebView.
+class Draw2DCanvasView extends ConsumerStatefulWidget {
+  const Draw2DCanvasView({super.key});
+
+  @override
+  ConsumerState<Draw2DCanvasView> createState() => _Draw2DCanvasViewState();
+}
+
+class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
+  late final WebViewController _controller;
+  bool _isReady = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (url) {
+            developer.log(
+              'Draw2D asset finished loading: $url',
+              name: 'Draw2DCanvasView',
+            );
+          },
+          onWebResourceError: (error) {
+            developer.log(
+              'Draw2D asset failed to load',
+              name: 'Draw2DCanvasView',
+              error: error,
+            );
+          },
+        ),
+      )
+      ..addJavaScriptChannel(
+        'Draw2dReadyChannel',
+        onMessageReceived: (message) {
+          developer.log(
+            'Draw2D ready message: ${message.message}',
+            name: 'Draw2DCanvasView',
+          );
+          if (!mounted) {
+            return;
+          }
+          setState(() {
+            _isReady = true;
+          });
+        },
+      )
+      ..loadFlutterAsset('assets/draw2d/index.html');
+  }
+
+  @override
+  void dispose() {
+    if (!kIsWeb) {
+      unawaited(_controller.clearCache());
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final outlineColor = theme.colorScheme.outlineVariant;
+
+    return DecoratedBox(
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: outlineColor.withOpacity(0.6)),
+        color: theme.colorScheme.surface,
+      ),
+      child: ClipRRect(
+        borderRadius: BorderRadius.circular(12),
+        child: Stack(
+          children: [
+            WebViewWidget(controller: _controller),
+            AnimatedOpacity(
+              duration: const Duration(milliseconds: 250),
+              opacity: _isReady ? 0 : 1,
+              child: Container(
+                color: theme.colorScheme.surface,
+                child: const Center(
+                  child: CircularProgressIndicator(),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,9 @@ dependencies:
 
   # Clipboard support (built into Flutter)
 
+  # Embedded Draw2D workspace
+  webview_flutter: ^4.7.0
+
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
@@ -118,6 +121,8 @@ flutter:
     - jflutter_js/examples/apda_palindrome.json
     # Turing machine example
     - jflutter_js/examples/tm_binary_to_unary.json
+    # Draw2D prototype assets
+    - assets/draw2d/
 
 flutter_launcher_icons:
   image_path: "icon.PNG"


### PR DESCRIPTION
## Summary
- add the webview_flutter dependency and register the new draw2d asset bundle
- scaffold placeholder Draw2D HTML/JS assets that emit a readiness signal
- embed the assets in a ConsumerStatefulWidget and gate it behind a temporary dev flag on the FSA page

## Testing
- Not run (Flutter SDK unavailable in the container)


------
https://chatgpt.com/codex/tasks/task_e_68dd64063aac832ea83f39468527c950