### PR TITLE
Forward highlight events to Draw2D iframe on web

### DIFF
--- a/test/widget/presentation/automaton_canvas_web_highlight_test.dart
+++ b/test/widget/presentation/automaton_canvas_web_highlight_test.dart
@@ -1,0 +1,52 @@
+@TestOn('browser')
+import 'dart:async';
+import 'dart:html' as html;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/presentation/widgets/automaton_canvas.dart';
+
+void main() {
+  testWidgets('forwards highlight events to the embedded iframe', (tester) async {
+    final canvasKey = GlobalKey();
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: AutomatonCanvas(
+            automaton: null,
+            canvasKey: canvasKey,
+            onAutomatonChanged: (_) {},
+          ),
+        ),
+      ),
+    );
+
+    final state = tester.state<State<AutomatonCanvas>>(
+      find.byType(AutomatonCanvas),
+    );
+
+    final completer = Completer<Object?>();
+    (state as dynamic).debugInterceptPostMessage((Object? message) {
+      if (!completer.isCompleted) {
+        completer.complete(message);
+      }
+    });
+
+    final message = {
+      'type': 'highlight',
+      'payload': {
+        'states': ['q0'],
+        'transitions': ['t0'],
+      },
+    };
+
+    html.window.postMessage(message, '*');
+
+    final forwarded = await completer.future
+        .timeout(const Duration(seconds: 1), onTimeout: () => null);
+
+    expect(forwarded, equals(message));
+
+    (state as dynamic).debugInterceptPostMessage(null);
+  });
+}


### PR DESCRIPTION
## Summary
- forward highlight and clear_highlight window messages to the embedded Draw2D iframe regardless of origin
- expose a testing hook so message payloads can be observed without altering runtime behaviour
- add a browser widget test that posts a highlight message and verifies the iframe forwarder receives it

## Testing
- flutter test --platform chrome test/widget/presentation/automaton_canvas_web_highlight_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd886c0cf4832ea776b1fb91acd834