### PR TITLE
Add Draw2D TM canvas integration

### DIFF
--- a/lib/presentation/mappers/draw2d_tm_mapper.dart
+++ b/lib/presentation/mappers/draw2d_tm_mapper.dart
@@ -1,0 +1,133 @@
+import '../../core/models/state.dart';
+import '../../core/models/tm.dart';
+import '../../core/models/tm_transition.dart';
+
+/// Utility that converts [TM] models into the structure expected by the
+/// Draw2D canvas bridge.
+class Draw2DTMMapper {
+  const Draw2DTMMapper._();
+
+  static const double _stateDiameter = 60.0;
+  static const double _stateRadius = _stateDiameter / 2;
+
+  static Map<String, dynamic> toJson(TM? machine) {
+    if (machine == null) {
+      return {
+        'id': null,
+        'name': null,
+        'states': const <Map<String, dynamic>>[],
+        'transitions': const <Map<String, dynamic>>[],
+        'initialStateId': null,
+      };
+    }
+
+    final sortedStates = machine.states.toList()
+      ..sort((a, b) => a.id.compareTo(b.id));
+    final sortedTransitions =
+        machine.transitions.whereType<TMTransition>().toList()
+          ..sort((a, b) => a.id.compareTo(b.id));
+
+    final Map<String, String> stateIdMap = {};
+    final statesJson = sortedStates.map((state) {
+      final draw2dId = _stableStateId(machine.id, state.id);
+      stateIdMap[state.id] = draw2dId;
+      return _stateToJson(draw2dId, state);
+    }).toList(growable: false);
+
+    final transitionsJson = sortedTransitions.map((transition) {
+      final draw2dId = _stableTransitionId(machine.id, transition.id);
+      final fromId = stateIdMap[transition.fromState.id];
+      final toId = stateIdMap[transition.toState.id];
+      return _transitionToJson(draw2dId, fromId, toId, transition);
+    }).whereType<Map<String, dynamic>>().toList(growable: false);
+
+    final initialId = machine.initialState != null
+        ? stateIdMap[machine.initialState!.id]
+        : null;
+
+    return {
+      'id': machine.id,
+      'name': machine.name,
+      'states': statesJson,
+      'transitions': transitionsJson,
+      'initialStateId': initialId,
+    };
+  }
+
+  static Map<String, dynamic> _stateToJson(String id, State state) {
+    final position = state.position;
+    final x = position.x.isFinite ? position.x : 0.0;
+    final y = position.y.isFinite ? position.y : 0.0;
+
+    return {
+      'id': id,
+      'sourceId': state.id,
+      'label': state.label,
+      'isInitial': state.isInitial,
+      'isAccepting': state.isAccepting,
+      'position': {
+        'x': x - _stateRadius,
+        'y': y - _stateRadius,
+      },
+    };
+  }
+
+  static Map<String, dynamic>? _transitionToJson(
+    String draw2dId,
+    String? fromId,
+    String? toId,
+    TMTransition transition,
+  ) {
+    if (fromId == null || toId == null) {
+      return null;
+    }
+
+    final control = transition.controlPoint;
+    final label = _formatTransitionLabel(transition);
+
+    return {
+      'id': draw2dId,
+      'sourceId': transition.id,
+      'from': fromId,
+      'to': toId,
+      'label': label,
+      'readSymbol': transition.readSymbol,
+      'writeSymbol': transition.writeSymbol,
+      'direction': _directionSymbol(transition.direction),
+      'tapeNumber': transition.tapeNumber,
+      'controlPoint': {
+        'x': control.x.isFinite ? control.x : 0.0,
+        'y': control.y.isFinite ? control.y : 0.0,
+      },
+    };
+  }
+
+  static String _formatTransitionLabel(TMTransition transition) {
+    return '${transition.readSymbol.isEmpty ? '∅' : transition.readSymbol}'
+        '/${transition.writeSymbol.isEmpty ? '∅' : transition.writeSymbol},'
+        '${_directionSymbol(transition.direction)}';
+  }
+
+  static String _directionSymbol(TapeDirection direction) {
+    switch (direction) {
+      case TapeDirection.left:
+        return 'L';
+      case TapeDirection.right:
+        return 'R';
+      case TapeDirection.stay:
+        return 'S';
+    }
+  }
+
+  static String _stableStateId(String automatonId, String stateId) {
+    return 'state_${_hashFor(automatonId)}_${_hashFor(stateId)}';
+  }
+
+  static String _stableTransitionId(String automatonId, String transitionId) {
+    return 'transition_${_hashFor(automatonId)}_${_hashFor(transitionId)}';
+  }
+
+  static int _hashFor(String value) {
+    return value.codeUnits.fold<int>(17, (hash, code) => hash * 31 + code);
+  }
+}

--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -3,7 +3,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/tm.dart';
 import '../../core/models/tm_transition.dart';
+import '../providers/settings_provider.dart';
 import '../providers/tm_editor_provider.dart';
+import '../widgets/draw2d_tm_canvas_view.dart';
 import '../widgets/tm_algorithm_panel.dart';
 import '../widgets/tm_canvas.dart';
 import '../widgets/tm_simulation_panel.dart';
@@ -57,13 +59,16 @@ class _TMPageState extends ConsumerState<TMPage> {
   Widget build(BuildContext context) {
     final screenSize = MediaQuery.of(context).size;
     final isMobile = screenSize.width < 1024;
+    final useDraw2dCanvas = ref.watch(settingsProvider).useDraw2dCanvas;
 
     return Scaffold(
-      body: isMobile ? _buildMobileLayout() : _buildDesktopLayout(),
+      body: isMobile
+          ? _buildMobileLayout(useDraw2dCanvas)
+          : _buildDesktopLayout(useDraw2dCanvas),
     );
   }
 
-  Widget _buildMobileLayout() {
+  Widget _buildMobileLayout(bool useDraw2dCanvas) {
     return SafeArea(
       child: Column(
         children: [
@@ -105,10 +110,12 @@ class _TMPageState extends ConsumerState<TMPage> {
           Expanded(
             child: Padding(
               padding: const EdgeInsets.all(8),
-              child: TMCanvas(
-                canvasKey: _canvasKey,
-                onTMModified: _handleTMUpdate,
-              ),
+              child: useDraw2dCanvas
+                  ? Draw2DTMCanvasView(onTMModified: _handleTMUpdate)
+                  : TMCanvas(
+                      canvasKey: _canvasKey,
+                      onTMModified: _handleTMUpdate,
+                    ),
             ),
           ),
         ],
@@ -116,7 +123,7 @@ class _TMPageState extends ConsumerState<TMPage> {
     );
   }
 
-  Widget _buildDesktopLayout() {
+  Widget _buildDesktopLayout(bool useDraw2dCanvas) {
     return Row(
       children: [
         // Left panel - TM Canvas
@@ -124,10 +131,12 @@ class _TMPageState extends ConsumerState<TMPage> {
           flex: 2,
           child: Container(
             margin: const EdgeInsets.all(8),
-            child: TMCanvas(
-              canvasKey: _canvasKey,
-              onTMModified: _handleTMUpdate,
-            ),
+            child: useDraw2dCanvas
+                ? Draw2DTMCanvasView(onTMModified: _handleTMUpdate)
+                : TMCanvas(
+                    canvasKey: _canvasKey,
+                    onTMModified: _handleTMUpdate,
+                  ),
           ),
         ),
         const SizedBox(width: 16),

--- a/lib/presentation/providers/tm_editor_provider.dart
+++ b/lib/presentation/providers/tm_editor_provider.dart
@@ -24,11 +24,19 @@ class TMEditorState {
   /// Identifiers of transitions that participate in nondeterministic choices.
   final Set<String> nondeterministicTransitionIds;
 
+  /// States currently rendered on the canvas.
+  final List<State> states;
+
+  /// TM transitions currently rendered on the canvas.
+  final List<TMTransition> transitions;
+
   const TMEditorState({
     this.tm,
     this.tapeSymbols = const {},
     this.moveDirections = const {},
     this.nondeterministicTransitionIds = const {},
+    this.states = const [],
+    this.transitions = const [],
   });
 
   TMEditorState copyWith({
@@ -36,6 +44,8 @@ class TMEditorState {
     Set<String>? tapeSymbols,
     Set<String>? moveDirections,
     Set<String>? nondeterministicTransitionIds,
+    List<State>? states,
+    List<TMTransition>? transitions,
   }) {
     return TMEditorState(
       tm: tm ?? this.tm,
@@ -43,6 +53,8 @@ class TMEditorState {
       moveDirections: moveDirections ?? this.moveDirections,
       nondeterministicTransitionIds:
           nondeterministicTransitionIds ?? this.nondeterministicTransitionIds,
+      states: states ?? this.states,
+      transitions: transitions ?? this.transitions,
     );
   }
 }
@@ -51,82 +63,199 @@ class TMEditorState {
 class TMEditorNotifier extends StateNotifier<TMEditorState> {
   TMEditorNotifier() : super(const TMEditorState());
 
+  final List<State> _states = [];
+  final List<TMTransition> _transitions = [];
+
   /// Updates the notifier using the raw state and transition collections
   /// maintained by the canvas and returns the resulting TM.
   TM? updateFromCanvas({
     required List<State> states,
     required List<TMTransition> transitions,
   }) {
-    if (states.isEmpty) {
-      state = const TMEditorState(tm: null);
-      return null;
+    _states
+      ..clear()
+      ..addAll(states.map((state) => state.copyWith()));
+    _transitions
+      ..clear()
+      ..addAll(transitions.map((transition) => transition.copyWith()));
+
+    return _rebuildState();
+  }
+
+  /// Adds a new state or updates an existing one using the provided data.
+  TM? upsertState({
+    required String id,
+    required String label,
+    required double x,
+    required double y,
+    bool? isInitial,
+    bool? isAccepting,
+  }) {
+    final index = _states.indexWhere((state) => state.id == id);
+    final existing = index != -1 ? _states[index] : null;
+
+    final hasInitial = _states.any((state) => state.isInitial);
+    final resolvedInitial =
+        isInitial ?? existing?.isInitial ?? (!hasInitial && index == -1);
+    final resolvedAccepting = isAccepting ?? existing?.isAccepting ?? false;
+
+    final updated = (existing ??
+            State(
+              id: id,
+              label: label,
+              position: Vector2(x, y),
+              isInitial: resolvedInitial || _states.isEmpty,
+              isAccepting: resolvedAccepting,
+            ))
+        .copyWith(
+      label: label,
+      position: Vector2(x, y),
+      isInitial: resolvedInitial,
+      isAccepting: resolvedAccepting,
+    );
+
+    if (index == -1) {
+      _states.add(updated);
+    } else {
+      _states[index] = updated;
     }
 
-    final stateSet = states.toSet();
-    final transitionSet = transitions.toSet();
-
-    final initialState = states.firstWhere(
-      (s) => s.isInitial,
-      orElse: () => states.first,
-    );
-
-    final acceptingStates = states.where((s) => s.isAccepting).toSet();
-
-    final alphabet = <String>{};
-    final tapeAlphabet = <String>{'B'};
-    final moveDirections = <String>{};
-
-    for (final transition in transitionSet) {
-      if (transition.readSymbol.isNotEmpty) {
-        alphabet.add(transition.readSymbol);
-        tapeAlphabet.add(transition.readSymbol);
+    if (updated.isInitial) {
+      for (var i = 0; i < _states.length; i++) {
+        if (_states[i].id != updated.id && _states[i].isInitial) {
+          _states[i] = _states[i].copyWith(isInitial: false);
+        }
       }
-
-      if (transition.writeSymbol.isNotEmpty) {
-        tapeAlphabet.add(transition.writeSymbol);
-      }
-
-      moveDirections.add(transition.direction.name);
+    } else if (!_states.any((state) => state.isInitial) && _states.isNotEmpty) {
+      final normalisedInitial = _states[0].copyWith(isInitial: true);
+      _states[0] = normalisedInitial;
+      _rebindTransitionsForState(normalisedInitial);
     }
 
-    // Ensure at least the blank symbol is present in the tape alphabet.
-    const blankSymbol = 'B';
-    tapeAlphabet.add(blankSymbol);
+    final storedState = index == -1 ? _states.last : _states[index];
+    _rebindTransitionsForState(storedState);
 
-    final now = DateTime.now();
+    return _rebuildState();
+  }
 
-    final tm = TM(
-      id: 'editor-tm',
-      name: 'Canvas TM',
-      states: stateSet,
-      transitions: transitionSet.map<Transition>((t) => t).toSet(),
-      alphabet: alphabet,
-      initialState: initialState,
-      acceptingStates: acceptingStates.isEmpty
-          ? {states.last}
-          : acceptingStates,
-      created: now,
-      modified: now,
-      bounds: const math.Rectangle(0, 0, 800, 600),
-      tapeAlphabet: tapeAlphabet,
-      blankSymbol: blankSymbol,
-      tapeCount: 1,
-      zoomLevel: 1,
-      panOffset: Vector2.zero(),
+  /// Moves a state to a new position on the canvas.
+  TM? moveState({
+    required String id,
+    required double x,
+    required double y,
+  }) {
+    final index = _states.indexWhere((state) => state.id == id);
+    if (index == -1) {
+      return state.tm;
+    }
+
+    final updated = _states[index].copyWith(position: Vector2(x, y));
+    _states[index] = updated;
+    _rebindTransitionsForState(updated);
+
+    return _rebuildState();
+  }
+
+  /// Updates the label of the state matching [id].
+  TM? updateStateLabel({
+    required String id,
+    required String label,
+  }) {
+    final index = _states.indexWhere((state) => state.id == id);
+    if (index == -1) {
+      return state.tm;
+    }
+
+    final updated = _states[index].copyWith(label: label);
+    _states[index] = updated;
+    _rebindTransitionsForState(updated);
+
+    return _rebuildState();
+  }
+
+  /// Adds or updates a TM transition using the supplied values.
+  TM? addOrUpdateTransition({
+    required String id,
+    required String fromStateId,
+    required String toStateId,
+    String? readSymbol,
+    String? writeSymbol,
+    TapeDirection? direction,
+    Vector2? controlPoint,
+  }) {
+    final fromIndex = _states.indexWhere((state) => state.id == fromStateId);
+    final toIndex = _states.indexWhere((state) => state.id == toStateId);
+    if (fromIndex == -1 || toIndex == -1) {
+      return state.tm;
+    }
+
+    final existingIndex =
+        _transitions.indexWhere((transition) => transition.id == id);
+    final existing = existingIndex != -1 ? _transitions[existingIndex] : null;
+
+    final resolvedRead = readSymbol ?? existing?.readSymbol ?? '';
+    final resolvedWrite = writeSymbol ?? existing?.writeSymbol ?? '';
+    final resolvedDirection = direction ?? existing?.direction ?? TapeDirection.right;
+    final resolvedControlPoint =
+        controlPoint ?? existing?.controlPoint ?? Vector2.zero();
+
+    final base = existing ??
+        TMTransition(
+          id: id,
+          fromState: _states[fromIndex],
+          toState: _states[toIndex],
+          label: '',
+          controlPoint: resolvedControlPoint,
+          readSymbol: resolvedRead,
+          writeSymbol: resolvedWrite,
+          direction: resolvedDirection,
+        );
+
+    final updated = base.copyWith(
+      fromState: _states[fromIndex],
+      toState: _states[toIndex],
+      controlPoint: resolvedControlPoint,
+      readSymbol: resolvedRead,
+      writeSymbol: resolvedWrite,
+      direction: resolvedDirection,
+      label: _formatTransitionLabel(
+        resolvedRead,
+        resolvedWrite,
+        resolvedDirection,
+      ),
     );
 
-    final nondeterministicTransitionIds = _findNondeterministicTransitions(
-      transitionSet,
-    );
+    if (existingIndex == -1) {
+      _transitions.add(updated);
+    } else {
+      _transitions[existingIndex] = updated;
+    }
 
-    state = state.copyWith(
-      tm: tm,
-      tapeSymbols: tapeAlphabet,
-      moveDirections: moveDirections,
-      nondeterministicTransitionIds: nondeterministicTransitionIds,
-    );
+    return _rebuildState();
+  }
 
-    return tm;
+  /// Updates the tape operations for an existing transition.
+  TM? updateTransitionOperations({
+    required String id,
+    String? readSymbol,
+    String? writeSymbol,
+    TapeDirection? direction,
+  }) {
+    final index = _transitions.indexWhere((transition) => transition.id == id);
+    if (index == -1) {
+      return state.tm;
+    }
+
+    final transition = _transitions[index];
+    return addOrUpdateTransition(
+      id: id,
+      fromStateId: transition.fromState.id,
+      toStateId: transition.toState.id,
+      readSymbol: readSymbol ?? transition.readSymbol,
+      writeSymbol: writeSymbol ?? transition.writeSymbol,
+      direction: direction ?? transition.direction,
+      controlPoint: transition.controlPoint,
+    );
   }
 
   Set<String> _findNondeterministicTransitions(Set<TMTransition> transitions) {
@@ -147,9 +276,116 @@ class TMEditorNotifier extends StateNotifier<TMEditorState> {
         .expand((list) => list.map((transition) => transition.id))
         .toSet();
   }
+
+  TM? _rebuildState() {
+    if (_states.isEmpty) {
+      state = const TMEditorState(tm: null);
+      return null;
+    }
+
+    final stateSet = _states.toSet();
+    final transitionSet = _transitions.toSet();
+
+    final initialState = _states.firstWhere(
+      (state) => state.isInitial,
+      orElse: () => _states.first,
+    );
+
+    final acceptingStates = _states.where((state) => state.isAccepting).toSet();
+
+    final alphabet = <String>{};
+    final tapeAlphabet = <String>{'B'};
+    final moveDirections = <String>{};
+
+    for (final transition in transitionSet) {
+      if (transition.readSymbol.isNotEmpty) {
+        alphabet.add(transition.readSymbol);
+        tapeAlphabet.add(transition.readSymbol);
+      }
+
+      if (transition.writeSymbol.isNotEmpty) {
+        tapeAlphabet.add(transition.writeSymbol);
+      }
+
+      moveDirections.add(transition.direction.name);
+    }
+
+    const blankSymbol = 'B';
+    tapeAlphabet.add(blankSymbol);
+
+    final now = DateTime.now();
+
+    final tm = TM(
+      id: 'editor-tm',
+      name: 'Canvas TM',
+      states: stateSet,
+      transitions: transitionSet.map<Transition>((t) => t).toSet(),
+      alphabet: alphabet,
+      initialState: initialState,
+      acceptingStates:
+          acceptingStates.isEmpty ? {_states.last} : acceptingStates,
+      created: now,
+      modified: now,
+      bounds: const math.Rectangle(0, 0, 800, 600),
+      tapeAlphabet: tapeAlphabet,
+      blankSymbol: blankSymbol,
+      tapeCount: 1,
+      zoomLevel: 1,
+      panOffset: Vector2.zero(),
+    );
+
+    final nondeterministicTransitionIds = _findNondeterministicTransitions(
+      transitionSet,
+    );
+
+    state = state.copyWith(
+      tm: tm,
+      tapeSymbols: tapeAlphabet,
+      moveDirections: moveDirections,
+      nondeterministicTransitionIds: nondeterministicTransitionIds,
+      states: List<State>.unmodifiable(_states),
+      transitions: List<TMTransition>.unmodifiable(_transitions),
+    );
+
+    return tm;
+  }
+
+  void _rebindTransitionsForState(State updatedState) {
+    for (var i = 0; i < _transitions.length; i++) {
+      final transition = _transitions[i];
+      if (transition.fromState.id == updatedState.id ||
+          transition.toState.id == updatedState.id) {
+        _transitions[i] = transition.copyWith(
+          fromState: transition.fromState.id == updatedState.id
+              ? updatedState
+              : transition.fromState,
+          toState: transition.toState.id == updatedState.id
+              ? updatedState
+              : transition.toState,
+        );
+      }
+    }
+  }
+
+  String _formatTransitionLabel(
+    String read,
+    String write,
+    TapeDirection direction,
+  ) {
+    final directionSymbol = switch (direction) {
+      TapeDirection.left => 'L',
+      TapeDirection.right => 'R',
+      TapeDirection.stay => 'S',
+    };
+
+    final safeRead = read.isEmpty ? '∅' : read;
+    final safeWrite = write.isEmpty ? '∅' : write;
+    return '$safeRead/$safeWrite,$directionSymbol';
+  }
 }
 
 /// Provider exposing the current TM editor state.
-final tmEditorProvider = StateNotifierProvider<TMEditorNotifier, TMEditorState>(
+final tmEditorProvider =
+    StateNotifierProvider<TMEditorNotifier, TMEditorState>(
   (ref) => TMEditorNotifier(),
 );

--- a/lib/presentation/widgets/draw2d_tm_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_tm_canvas_view.dart
@@ -1,0 +1,245 @@
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../core/models/tm.dart';
+import '../../core/models/tm_transition.dart';
+import '../../core/services/draw2d_bridge_service.dart';
+import '../mappers/draw2d_tm_mapper.dart';
+import '../providers/tm_editor_provider.dart';
+
+/// Draw2D-powered canvas for editing Turing Machines using the shared
+/// JavaScript editor.
+class Draw2DTMCanvasView extends ConsumerStatefulWidget {
+  const Draw2DTMCanvasView({
+    super.key,
+    required this.onTMModified,
+  });
+
+  final ValueChanged<TM> onTMModified;
+
+  @override
+  ConsumerState<Draw2DTMCanvasView> createState() => _Draw2DTMCanvasViewState();
+}
+
+class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
+  late final WebViewController _controller;
+  final Draw2DBridgeService _bridge = Draw2DBridgeService();
+  ProviderSubscription<TMEditorState>? _subscription;
+  bool _isReady = false;
+  TM? _lastEmittedTM;
+
+  @override
+  void initState() {
+    super.initState();
+
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..addJavaScriptChannel('JFlutterBridge', onMessageReceived: _handleMessage)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) {
+            setState(() {
+              _isReady = true;
+            });
+            _pushModel(ref.read(tmEditorProvider));
+          },
+        ),
+      )
+      ..loadFlutterAsset('assets/draw2d/editor.html');
+
+    _bridge.registerWebViewController(_controller);
+
+    _subscription = ref.listenManual<TMEditorState>(
+      tmEditorProvider,
+      (previous, next) {
+        if (_isReady) {
+          _pushModel(next);
+        }
+        _maybeEmitTM(next.tm);
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    _bridge.unregisterWebViewController(_controller);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: Colors.transparent),
+      child: WebViewWidget(controller: _controller),
+    );
+  }
+
+  void _handleMessage(JavaScriptMessage message) {
+    Map<String, dynamic> decoded;
+    try {
+      decoded = jsonDecode(message.message) as Map<String, dynamic>;
+    } catch (error, stackTrace) {
+      debugPrint('Failed to decode Draw2D TM bridge message: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(exception: error, stack: stackTrace),
+      );
+      return;
+    }
+
+    final type = decoded['type'] as String? ?? '';
+    final payload =
+        (decoded['payload'] as Map?)?.cast<String, dynamic>() ?? const {};
+
+    switch (type) {
+      case 'state.add':
+        _handleStateAdd(payload);
+        break;
+      case 'state.move':
+        _handleStateMove(payload);
+        break;
+      case 'state.label':
+        _handleStateLabel(payload);
+        break;
+      case 'transition.add':
+        _handleTransitionAdd(payload);
+        break;
+      case 'transition.label':
+        _handleTransitionUpdate(payload);
+        break;
+      default:
+        debugPrint('Unhandled Draw2D TM event: $type');
+        break;
+    }
+  }
+
+  void _handleStateAdd(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    final label = payload['label'] as String?;
+    final x = (payload['x'] as num?)?.toDouble();
+    final y = (payload['y'] as num?)?.toDouble();
+    if (id == null || label == null || x == null || y == null) {
+      return;
+    }
+
+    final tm = notifier.upsertState(id: id, label: label, x: x, y: y);
+    _maybeEmitTM(tm);
+  }
+
+  void _handleStateMove(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    final x = (payload['x'] as num?)?.toDouble();
+    final y = (payload['y'] as num?)?.toDouble();
+    if (id == null || x == null || y == null) {
+      return;
+    }
+
+    final tm = notifier.moveState(id: id, x: x, y: y);
+    _maybeEmitTM(tm);
+  }
+
+  void _handleStateLabel(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    final label = payload['label'] as String?;
+    if (id == null || label == null) {
+      return;
+    }
+
+    final tm = notifier.updateStateLabel(id: id, label: label);
+    _maybeEmitTM(tm);
+  }
+
+  void _handleTransitionAdd(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    final from = payload['fromStateId'] as String?;
+    final to = payload['toStateId'] as String?;
+    if (id == null || from == null || to == null) {
+      return;
+    }
+
+    final read = (payload['readSymbol'] as String?) ?? '';
+    final write = (payload['writeSymbol'] as String?) ?? '';
+    final direction = _parseDirection(payload['direction'] as String?);
+
+    final tm = notifier.addOrUpdateTransition(
+      id: id,
+      fromStateId: from,
+      toStateId: to,
+      readSymbol: read,
+      writeSymbol: write,
+      direction: direction,
+    );
+    _maybeEmitTM(tm);
+  }
+
+  void _handleTransitionUpdate(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final read = payload['readSymbol'] as String?;
+    final write = payload['writeSymbol'] as String?;
+    final direction = _parseDirection(payload['direction'] as String?);
+
+    final tm = notifier.updateTransitionOperations(
+      id: id,
+      readSymbol: read,
+      writeSymbol: write,
+      direction: direction,
+    );
+    _maybeEmitTM(tm);
+  }
+
+  void _pushModel(TMEditorState state) {
+    final payload = Draw2DTMMapper.toJson(state.tm);
+    final json = jsonEncode(payload);
+    _controller
+        .runJavaScript('window.draw2dBridge?.loadModel($json);')
+        .catchError((error, stackTrace) {
+      debugPrint('Failed to push Draw2D TM model: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(exception: error, stack: stackTrace),
+      );
+    });
+  }
+
+  void _maybeEmitTM(TM? tm) {
+    if (tm == null) {
+      _lastEmittedTM = null;
+      return;
+    }
+
+    if (!identical(_lastEmittedTM, tm)) {
+      _lastEmittedTM = tm;
+      widget.onTMModified(tm);
+    }
+  }
+
+  TapeDirection _parseDirection(String? value) {
+    final normalised = value?.trim().toUpperCase();
+    switch (normalised) {
+      case 'L':
+      case 'LEFT':
+        return TapeDirection.left;
+      case 'S':
+      case 'STAY':
+      case 'N':
+        return TapeDirection.stay;
+      case 'R':
+      case 'RIGHT':
+      default:
+        return TapeDirection.right;
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a Draw2D-backed TM canvas widget that syncs with the TM editor provider and emits TM updates
- extend the TM editor provider with state/transition mutation APIs and a Draw2D mapper that includes tape operations
- update the Draw2D bridge script and TM page to support TM read/write/direction editing and the settings toggle

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ddab609fdc832eadf8b8125e148eb3