### PR TITLE
feat: integrate draw2d pda canvas

### DIFF
--- a/lib/presentation/pages/pda_page.dart
+++ b/lib/presentation/pages/pda_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/pda.dart';
 import '../providers/pda_editor_provider.dart';
+import '../providers/settings_provider.dart';
+import '../widgets/draw2d_pda_canvas_view.dart';
 import '../widgets/pda_canvas.dart';
 import '../widgets/pda_simulation_panel.dart';
 import '../widgets/pda_algorithm_panel.dart';
@@ -38,12 +40,16 @@ class _PDAPageState extends ConsumerState<PDAPage> {
     final screenSize = MediaQuery.of(context).size;
     final isMobile = screenSize.width < 1024;
 
+    final useDraw2dCanvas = ref.watch(settingsProvider).useDraw2dCanvas;
+
     return Scaffold(
-      body: isMobile ? _buildMobileLayout() : _buildDesktopLayout(),
+      body: isMobile
+          ? _buildMobileLayout(useDraw2dCanvas)
+          : _buildDesktopLayout(useDraw2dCanvas),
     );
   }
 
-  Widget _buildMobileLayout() {
+  Widget _buildMobileLayout(bool useDraw2dCanvas) {
     return SafeArea(
       child: Stack(
         children: [
@@ -52,10 +58,14 @@ class _PDAPageState extends ConsumerState<PDAPage> {
               Expanded(
                 child: Container(
                   margin: const EdgeInsets.all(8),
-                  child: PDACanvas(
-                    canvasKey: _canvasKey,
-                    onPDAModified: _handlePdaModified,
-                  ),
+                  child: useDraw2dCanvas
+                      ? Draw2DPdaCanvasView(
+                          onPdaModified: _handlePdaModified,
+                        )
+                      : PDACanvas(
+                          canvasKey: _canvasKey,
+                          onPDAModified: _handlePdaModified,
+                        ),
                 ),
               ),
               _buildMobileInfoPanel(context),
@@ -235,7 +245,7 @@ class _PDAPageState extends ConsumerState<PDAPage> {
     );
   }
 
-  Widget _buildDesktopLayout() {
+  Widget _buildDesktopLayout(bool useDraw2dCanvas) {
     return Row(
       children: [
         // Left panel - PDA Canvas
@@ -243,10 +253,14 @@ class _PDAPageState extends ConsumerState<PDAPage> {
           flex: 2,
           child: Container(
             margin: const EdgeInsets.all(8),
-            child: PDACanvas(
-              canvasKey: _canvasKey,
-              onPDAModified: _handlePdaModified,
-            ),
+            child: useDraw2dCanvas
+                ? Draw2DPdaCanvasView(
+                    onPdaModified: _handlePdaModified,
+                  )
+                : PDACanvas(
+                    canvasKey: _canvasKey,
+                    onPDAModified: _handlePdaModified,
+                  ),
           ),
         ),
         const SizedBox(width: 16),

--- a/lib/presentation/providers/pda_editor_provider.dart
+++ b/lib/presentation/providers/pda_editor_provider.dart
@@ -45,6 +45,219 @@ class PDAEditorState {
 class PDAEditorNotifier extends StateNotifier<PDAEditorState> {
   PDAEditorNotifier() : super(const PDAEditorState());
 
+  PDA _createEmptyPda() {
+    final now = DateTime.now();
+    return PDA(
+      id: 'editor-pda',
+      name: 'Canvas PDA',
+      states: {},
+      transitions: {},
+      alphabet: {},
+      initialState: null,
+      acceptingStates: {},
+      created: now,
+      modified: now,
+      bounds: const math.Rectangle(0, 0, 800, 600),
+      stackAlphabet: const {'Z'},
+      initialStackSymbol: 'Z',
+      zoomLevel: 1,
+      panOffset: Vector2.zero(),
+    );
+  }
+
+  PDA? _mutatePda(PDA Function(PDA current) transform) {
+    final current = state.pda ?? _createEmptyPda();
+    final updated = transform(current);
+    if (identical(updated, current)) {
+      return state.pda;
+    }
+    _updateStateWithPda(updated);
+    return updated;
+  }
+
+  PDA? addOrUpdateState({
+    required String id,
+    required String label,
+    required double x,
+    required double y,
+  }) {
+    return _mutatePda((current) {
+      final states = current.states.toList();
+      final index = states.indexWhere((state) => state.id == id);
+      final position = Vector2(x, y);
+
+      if (index >= 0) {
+        states[index] = states[index].copyWith(
+          label: label,
+          position: position,
+        );
+      } else {
+        states.add(
+          State(
+            id: id,
+            label: label,
+            position: position,
+            isInitial: states.isEmpty,
+            isAccepting: false,
+          ),
+        );
+      }
+
+      final statesById = {
+        for (final state in states) state.id: state,
+      };
+
+      final updated = _finalisePda(
+        base: current,
+        statesById: statesById,
+        transitions: current.pdaTransitions,
+      );
+
+      return updated;
+    });
+  }
+
+  PDA? moveState({
+    required String id,
+    required double x,
+    required double y,
+  }) {
+    return _mutatePda((current) {
+      final states = current.states
+          .map(
+            (state) => state.id == id
+                ? state.copyWith(position: Vector2(x, y))
+                : state,
+          )
+          .toList();
+
+      final statesById = {
+        for (final state in states) state.id: state,
+      };
+
+      return _finalisePda(
+        base: current,
+        statesById: statesById,
+        transitions: current.pdaTransitions,
+      );
+    });
+  }
+
+  PDA? updateStateLabel({
+    required String id,
+    required String label,
+  }) {
+    return _mutatePda((current) {
+      final states = current.states
+          .map(
+            (state) => state.id == id ? state.copyWith(label: label) : state,
+          )
+          .toList();
+
+      final statesById = {
+        for (final state in states) state.id: state,
+      };
+
+      return _finalisePda(
+        base: current,
+        statesById: statesById,
+        transitions: current.pdaTransitions,
+      );
+    });
+  }
+
+  PDA? upsertTransition({
+    required String id,
+    String? fromStateId,
+    String? toStateId,
+    String? label,
+    String? readSymbol,
+    String? popSymbol,
+    String? pushSymbol,
+    bool? isLambdaInput,
+    bool? isLambdaPop,
+    bool? isLambdaPush,
+  }) {
+    return _mutatePda((current) {
+      final statesById = {
+        for (final state in current.states) state.id: state,
+      };
+      final transitions = current.pdaTransitions.toList();
+      final index = transitions.indexWhere((transition) => transition.id == id);
+
+      PDATransition base;
+      if (index >= 0) {
+        base = transitions[index];
+      } else {
+        if (fromStateId == null || toStateId == null) {
+          return current;
+        }
+        final fromState = statesById[fromStateId];
+        final toState = statesById[toStateId];
+        if (fromState == null || toState == null) {
+          return current;
+        }
+        base = PDATransition(
+          id: id,
+          fromState: fromState,
+          toState: toState,
+          label: '',
+          controlPoint: Vector2.zero(),
+          type: TransitionType.deterministic,
+          inputSymbol: '',
+          popSymbol: '',
+          pushSymbol: '',
+          isLambdaInput: true,
+          isLambdaPop: true,
+          isLambdaPush: true,
+        );
+        transitions.add(base);
+      }
+
+      final effectiveFrom = fromStateId != null && statesById.containsKey(fromStateId)
+          ? statesById[fromStateId]!
+          : base.fromState;
+      final effectiveTo = toStateId != null && statesById.containsKey(toStateId)
+          ? statesById[toStateId]!
+          : base.toState;
+
+      final lambdaInput = isLambdaInput ?? base.isLambdaInput;
+      final lambdaPop = isLambdaPop ?? base.isLambdaPop;
+      final lambdaPush = isLambdaPush ?? base.isLambdaPush;
+
+      final updatedTransition = base.copyWith(
+        fromState: effectiveFrom,
+        toState: effectiveTo,
+        inputSymbol: lambdaInput
+            ? ''
+            : (readSymbol ?? base.inputSymbol),
+        popSymbol:
+            lambdaPop ? '' : (popSymbol ?? base.popSymbol),
+        pushSymbol:
+            lambdaPush ? '' : (pushSymbol ?? base.pushSymbol),
+        isLambdaInput: lambdaInput,
+        isLambdaPop: lambdaPop,
+        isLambdaPush: lambdaPush,
+      );
+
+      final resolvedLabel = label ?? _formatTransitionLabel(updatedTransition);
+      final finalTransition =
+          updatedTransition.copyWith(label: resolvedLabel.trim());
+
+      if (index >= 0) {
+        transitions[index] = finalTransition;
+      } else {
+        transitions[transitions.length - 1] = finalTransition;
+      }
+
+      return _finalisePda(
+        base: current,
+        statesById: statesById,
+        transitions: transitions,
+      );
+    });
+  }
+
   /// Updates the notifier using the raw state and transition collections
   /// maintained by the canvas.
   void updateFromCanvas({
@@ -150,6 +363,73 @@ class PDAEditorNotifier extends StateNotifier<PDAEditorState> {
       nondeterministicTransitionIds: nondeterministicTransitionIds,
       lambdaTransitionIds: lambdaTransitionIds,
     );
+  }
+
+  PDA _finalisePda({
+    required PDA base,
+    required Map<String, State> statesById,
+    required Iterable<PDATransition> transitions,
+  }) {
+    final reboundTransitions = transitions
+        .map(
+          (transition) => transition.copyWith(
+            fromState:
+                statesById[transition.fromState.id] ?? transition.fromState,
+            toState: statesById[transition.toState.id] ?? transition.toState,
+          ),
+        )
+        .toSet();
+
+    final initialState = _ensureInitialState(statesById);
+    final acceptingStates =
+        statesById.values.where((state) => state.isAccepting).toSet();
+
+    final alphabet = <String>{...base.alphabet};
+    final stackAlphabet = <String>{base.initialStackSymbol, ...base.stackAlphabet};
+
+    for (final transition in reboundTransitions) {
+      if (!transition.isLambdaInput && transition.inputSymbol.isNotEmpty) {
+        alphabet.add(transition.inputSymbol);
+      }
+      if (!transition.isLambdaPop && transition.popSymbol.isNotEmpty) {
+        stackAlphabet.add(transition.popSymbol);
+      }
+      if (!transition.isLambdaPush && transition.pushSymbol.isNotEmpty) {
+        stackAlphabet.add(transition.pushSymbol);
+      }
+    }
+
+    return base.copyWith(
+      states: statesById.values.toSet(),
+      transitions: reboundTransitions.map<Transition>((t) => t).toSet(),
+      initialState: initialState,
+      acceptingStates: acceptingStates,
+      alphabet: alphabet,
+      stackAlphabet: stackAlphabet,
+      modified: DateTime.now(),
+    );
+  }
+
+  State? _ensureInitialState(Map<String, State> statesById) {
+    for (final entry in statesById.values) {
+      if (entry.isInitial) {
+        return entry;
+      }
+    }
+    if (statesById.isEmpty) {
+      return null;
+    }
+    final firstKey = statesById.keys.first;
+    final updated = statesById[firstKey]!.copyWith(isInitial: true);
+    statesById[firstKey] = updated;
+    return updated;
+  }
+
+  String _formatTransitionLabel(PDATransition transition) {
+    final input = transition.isLambdaInput ? 'λ' : transition.inputSymbol;
+    final pop = transition.isLambdaPop ? 'λ' : transition.popSymbol;
+    final push = transition.isLambdaPush ? 'λ' : transition.pushSymbol;
+    return '$input, $pop/$push';
   }
 }
 

--- a/lib/presentation/widgets/draw2d_pda_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_pda_canvas_view.dart
@@ -1,0 +1,319 @@
+import 'dart:async';
+import 'dart:convert';
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+import '../../core/models/pda.dart';
+import '../../core/services/draw2d_bridge_service.dart';
+import '../mappers/draw2d_pda_mapper.dart';
+import '../providers/pda_editor_provider.dart';
+
+/// Draw2D canvas for editing pushdown automata.
+class Draw2DPdaCanvasView extends ConsumerStatefulWidget {
+  const Draw2DPdaCanvasView({
+    super.key,
+    required this.onPdaModified,
+  });
+
+  final ValueChanged<PDA> onPdaModified;
+
+  @override
+  ConsumerState<Draw2DPdaCanvasView> createState() => _Draw2DPdaCanvasViewState();
+}
+
+class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
+  late final WebViewController _controller;
+  final Draw2DBridgeService _bridge = Draw2DBridgeService();
+  ProviderSubscription<PDAEditorState>? _subscription;
+  bool _isReady = false;
+  Timer? _moveDebounce;
+  final Map<String, _PendingMove> _pendingMoves = {};
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = WebViewController()
+      ..setJavaScriptMode(JavaScriptMode.unrestricted)
+      ..setBackgroundColor(Colors.transparent)
+      ..addJavaScriptChannel('JFlutterBridge', onMessageReceived: _handleMessage)
+      ..setNavigationDelegate(
+        NavigationDelegate(
+          onPageFinished: (_) {
+            setState(() {
+              _isReady = true;
+            });
+            _pushModel(ref.read(pdaEditorProvider).pda);
+          },
+        ),
+      )
+      ..loadFlutterAsset('assets/draw2d/editor.html');
+
+    _bridge.registerWebViewController(_controller);
+
+    _subscription = ref.listenManual<PDAEditorState>(
+      pdaEditorProvider,
+      (previous, next) {
+        if (!_isReady) {
+          return;
+        }
+        if (identical(previous?.pda, next.pda)) {
+          return;
+        }
+        _pushModel(next.pda);
+      },
+    );
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    _moveDebounce?.cancel();
+    _bridge.unregisterWebViewController(_controller);
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return DecoratedBox(
+      decoration: const BoxDecoration(color: Colors.transparent),
+      child: WebViewWidget(controller: _controller),
+    );
+  }
+
+  void _handleMessage(JavaScriptMessage message) {
+    Map<String, dynamic> decoded;
+    try {
+      decoded = jsonDecode(message.message) as Map<String, dynamic>;
+    } catch (error, stackTrace) {
+      debugPrint('Failed to decode PDA bridge message: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(exception: error, stack: stackTrace),
+      );
+      return;
+    }
+
+    final type = decoded['type'] as String? ?? '';
+    final payload =
+        (decoded['payload'] as Map?)?.cast<String, dynamic>() ?? const {};
+
+    switch (type) {
+      case 'state.add':
+        _handleStateAdd(payload);
+        break;
+      case 'state.move':
+        _handleStateMove(payload);
+        break;
+      case 'state.label':
+        _handleStateLabel(payload);
+        break;
+      case 'transition.add':
+        _handleTransitionUpsert(payload, requireEndpoints: true);
+        break;
+      case 'transition.label':
+        _handleTransitionUpsert(payload, requireEndpoints: false);
+        break;
+      default:
+        debugPrint('Unhandled Draw2D PDA event: $type');
+        break;
+    }
+  }
+
+  void _handleStateAdd(Map<String, dynamic> payload) {
+    final notifier = ref.read(pdaEditorProvider.notifier);
+    final id = payload['id'] as String? ?? _nextStateId();
+    final label = payload['label'] as String? ?? id;
+    final x = (payload['x'] as num?)?.toDouble();
+    final y = (payload['y'] as num?)?.toDouble();
+    if (x == null || y == null) {
+      return;
+    }
+
+    final updated = notifier.addOrUpdateState(
+      id: id,
+      label: label,
+      x: x,
+      y: y,
+    );
+    if (updated != null) {
+      widget.onPdaModified(updated);
+    }
+  }
+
+  void _handleStateMove(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    final x = (payload['x'] as num?)?.toDouble();
+    final y = (payload['y'] as num?)?.toDouble();
+    if (id == null || x == null || y == null) {
+      return;
+    }
+
+    _pendingMoves[id] = _PendingMove(id: id, x: x, y: y);
+    _moveDebounce ??= Timer(const Duration(milliseconds: 60), _flushMoves);
+  }
+
+  void _handleStateLabel(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    final label = payload['label'] as String?;
+    if (id == null || label == null) {
+      return;
+    }
+
+    final updated =
+        ref.read(pdaEditorProvider.notifier).updateStateLabel(id: id, label: label);
+    if (updated != null) {
+      widget.onPdaModified(updated);
+    }
+  }
+
+  void _handleTransitionUpsert(
+    Map<String, dynamic> payload, {
+    required bool requireEndpoints,
+  }) {
+    final id = payload['id'] as String? ?? _nextTransitionId();
+    final from = payload['fromStateId'] as String?;
+    final to = payload['toStateId'] as String?;
+    final label = payload['label'] as String?;
+
+    if (requireEndpoints && (from == null || to == null)) {
+      return;
+    }
+
+    final stackPayload = _parseStackPayload(payload);
+    if (stackPayload == null && requireEndpoints) {
+      return;
+    }
+
+    final updated = ref.read(pdaEditorProvider.notifier).upsertTransition(
+          id: id,
+          fromStateId: from,
+          toStateId: to,
+          label: label,
+          readSymbol: stackPayload?.readSymbol,
+          popSymbol: stackPayload?.popSymbol,
+          pushSymbol: stackPayload?.pushSymbol,
+          isLambdaInput: stackPayload?.isLambdaInput,
+          isLambdaPop: stackPayload?.isLambdaPop,
+          isLambdaPush: stackPayload?.isLambdaPush,
+        );
+    if (updated != null) {
+      widget.onPdaModified(updated);
+    }
+  }
+
+  void _flushMoves() {
+    final notifier = ref.read(pdaEditorProvider.notifier);
+    for (final move in _pendingMoves.values) {
+      notifier.moveState(id: move.id, x: move.x, y: move.y);
+    }
+    _pendingMoves.clear();
+    _moveDebounce?.cancel();
+    _moveDebounce = null;
+    final pda = ref.read(pdaEditorProvider).pda;
+    if (pda != null) {
+      widget.onPdaModified(pda);
+    }
+  }
+
+  Future<void> _pushModel(PDA? pda) async {
+    final payload = Draw2DPdaMapper.toJson(pda);
+    final json = jsonEncode(payload);
+    try {
+      await _controller.runJavaScript('window.draw2dBridge?.loadModel($json);');
+    } catch (error, stackTrace) {
+      debugPrint('Failed to push PDA model to Draw2D: $error');
+      FlutterError.reportError(
+        FlutterErrorDetails(exception: error, stack: stackTrace),
+      );
+    }
+  }
+
+  _TransitionStackPayload? _parseStackPayload(Map<String, dynamic> payload) {
+    final readSymbol = payload['readSymbol'] as String?;
+    final popSymbol = payload['popSymbol'] as String?;
+    final pushSymbol = payload['pushSymbol'] as String?;
+    final isLambdaInput = payload['isLambdaInput'] as bool?;
+    final isLambdaPop = payload['isLambdaPop'] as bool?;
+    final isLambdaPush = payload['isLambdaPush'] as bool?;
+
+    if (readSymbol == null &&
+        popSymbol == null &&
+        pushSymbol == null &&
+        isLambdaInput == null &&
+        isLambdaPop == null &&
+        isLambdaPush == null) {
+      return null;
+    }
+
+    return _TransitionStackPayload(
+      readSymbol: readSymbol ?? '',
+      popSymbol: popSymbol ?? '',
+      pushSymbol: pushSymbol ?? '',
+      isLambdaInput: isLambdaInput ?? false,
+      isLambdaPop: isLambdaPop ?? false,
+      isLambdaPush: isLambdaPush ?? false,
+    );
+  }
+
+  String _nextStateId() {
+    final pda = ref.read(pdaEditorProvider).pda;
+    if (pda == null) {
+      return 'q0';
+    }
+    final existing = pda.states.map((state) => state.id).toSet();
+    var index = existing.length;
+    var candidate = 'q$index';
+    while (existing.contains(candidate)) {
+      index++;
+      candidate = 'q$index';
+    }
+    return candidate;
+  }
+
+  String _nextTransitionId() {
+    final pda = ref.read(pdaEditorProvider).pda;
+    if (pda == null) {
+      return 't0';
+    }
+    final existing = pda.pdaTransitions.map((transition) => transition.id).toSet();
+    var index = existing.length;
+    var candidate = 't$index';
+    while (existing.contains(candidate)) {
+      index++;
+      candidate = 't$index';
+    }
+    return candidate;
+  }
+}
+
+class _PendingMove {
+  const _PendingMove({
+    required this.id,
+    required this.x,
+    required this.y,
+  });
+
+  final String id;
+  final double x;
+  final double y;
+}
+
+class _TransitionStackPayload {
+  const _TransitionStackPayload({
+    required this.readSymbol,
+    required this.popSymbol,
+    required this.pushSymbol,
+    required this.isLambdaInput,
+    required this.isLambdaPop,
+    required this.isLambdaPush,
+  });
+
+  final String readSymbol;
+  final String popSymbol;
+  final String pushSymbol;
+  final bool isLambdaInput;
+  final bool isLambdaPop;
+  final bool isLambdaPush;
+}


### PR DESCRIPTION
## Summary
- add a WebView-backed PDA canvas that syncs Riverpod state with the Draw2D bridge
- serialize PDA stack metadata for Draw2D and extend the JS editor to edit push/pop data
- toggle the PDA page between native and Draw2D canvases via the existing setting

## Testing
- not run (Flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68ddab5f7c00832e8aad79dc8b8dd55e