### PR TITLE
Add petitparser import to grammar parser

### DIFF
--- a/lib/core/algorithms/grammar_parser_petit.dart
+++ b/lib/core/algorithms/grammar_parser_petit.dart
@@ -1,3 +1,5 @@
+import 'package:petitparser/petitparser.dart';
+
 import '../models/grammar.dart';
 import '../models/production.dart';
 import '../result.dart' as jflutter_result;


### PR DESCRIPTION
## Summary
- add the petitparser package import to the PetitParser-based grammar parser implementation so referenced parser symbols resolve

## Testing
- flutter analyze *(fails: flutter not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb306f804832ebc406b9fe06a5835