### PR TITLE
Guard automaton canvas web registration on non-web builds

### DIFF
--- a/lib/presentation/widgets/automaton_canvas_web.dart
+++ b/lib/presentation/widgets/automaton_canvas_web.dart
@@ -86,6 +86,12 @@ class _AutomatonCanvasWebState extends State<AutomatonCanvas> {
   }
 
   void _registerViewFactory() {
+    if (!kIsWeb) {
+      throw UnsupportedError(
+        'AutomatonCanvas is only available on web builds.',
+      );
+    }
+
     if (_registeredFactories.contains(_viewType)) {
       return;
     }


### PR DESCRIPTION
## Summary
- add a runtime guard to `_registerViewFactory` so the web-only API is only accessed when running on web
- throw an `UnsupportedError` on non-web builds to avoid referencing `ui.platformViewRegistry`

## Testing
- flutter analyze *(fails: Flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb30c6838832e8243fc08c5e7210a