### PR TITLE
Fix ParseResult import for simple grammar parser

### DIFF
--- a/lib/core/algorithms/grammar_parser_simple.dart
+++ b/lib/core/algorithms/grammar_parser_simple.dart
@@ -2,6 +2,7 @@ import '../models/grammar.dart';
 import '../models/production.dart';
 import '../models/parse_table.dart';
 import '../result.dart';
+import 'grammar_parser.dart';
 
 /// Simple grammar parser that can handle basic CFG parsing
 class SimpleGrammarParser {


### PR DESCRIPTION
## Summary
- import the main grammar parser module so SimpleGrammarParser can resolve ParseResult

## Testing
- flutter analyze *(fails: command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb30cd208832e904dd8e73c70fde2