### PR TITLE
Fix UX error handling test imports

### DIFF
--- a/test/widget/presentation/ux_error_handling_test.dart
+++ b/test/widget/presentation/ux_error_handling_test.dart
@@ -1,8 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:jflutter/presentation/widgets/error_banner.dart';
-import 'package:jflutter/presentation/widgets/import_error_dialog.dart';
-import 'package:jflutter/presentation/widgets/retry_button.dart';
 
 /// UX Error Handling Tests for Invalid Imports
 ///


### PR DESCRIPTION
## Summary
- remove broken widget imports from the UX error handling test so it relies on the local mock implementations

## Testing
- flutter analyze *(fails: Flutter SDK not available in container)*
- flutter test test/widget/presentation/ux_error_handling_test.dart *(fails: Flutter SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ddb30effbc832eb236a1adb3f7d1fc