### PR TITLE
Add Draw2D context controls for state flags and deletions

### DIFF
--- a/lib/presentation/widgets/draw2d_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_canvas_view.dart
@@ -104,11 +104,20 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
       case 'state.label':
         _handleStateLabel(payload);
         break;
+      case 'state.updateFlags':
+        _handleStateFlags(payload);
+        break;
+      case 'state.remove':
+        _handleStateRemove(payload);
+        break;
       case 'transition.add':
         _handleTransitionAdd(payload);
         break;
       case 'transition.label':
         _handleTransitionLabel(payload);
+        break;
+      case 'transition.remove':
+        _handleTransitionRemove(payload);
         break;
       default:
         debugPrint('Unhandled Draw2D event: $type');
@@ -149,6 +158,37 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
     ref.read(automatonProvider.notifier).updateStateLabel(id: id, label: label);
   }
 
+  void _handleStateFlags(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final bool? isInitial =
+        payload.containsKey('isInitial') ? payload['isInitial'] as bool? : null;
+    final bool? isAccepting = payload.containsKey('isAccepting')
+        ? payload['isAccepting'] as bool?
+        : null;
+
+    if (isInitial == null && isAccepting == null) {
+      return;
+    }
+
+    ref.read(automatonProvider.notifier).updateStateFlags(
+          id: id,
+          isInitial: isInitial,
+          isAccepting: isAccepting,
+        );
+  }
+
+  void _handleStateRemove(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+    ref.read(automatonProvider.notifier).removeState(id: id);
+  }
+
   void _handleTransitionAdd(Map<String, dynamic> payload) {
     final id = payload['id'] as String? ?? _nextTransitionId();
     final from = payload['fromStateId'] as String?;
@@ -174,6 +214,14 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
     ref
         .read(automatonProvider.notifier)
         .updateTransitionLabel(id: id, label: label);
+  }
+
+  void _handleTransitionRemove(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+    ref.read(automatonProvider.notifier).removeTransition(id: id);
   }
 
   void _flushMoves() {

--- a/lib/presentation/widgets/draw2d_pda_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_pda_canvas_view.dart
@@ -109,11 +109,20 @@ class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
       case 'state.label':
         _handleStateLabel(payload);
         break;
+      case 'state.updateFlags':
+        _handleStateFlags(payload);
+        break;
+      case 'state.remove':
+        _handleStateRemove(payload);
+        break;
       case 'transition.add':
         _handleTransitionUpsert(payload, requireEndpoints: true);
         break;
       case 'transition.label':
         _handleTransitionUpsert(payload, requireEndpoints: false);
+        break;
+      case 'transition.remove':
+        _handleTransitionRemove(payload);
         break;
       default:
         debugPrint('Unhandled Draw2D PDA event: $type');
@@ -168,6 +177,44 @@ class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
     }
   }
 
+  void _handleStateFlags(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final bool? isInitial =
+        payload.containsKey('isInitial') ? payload['isInitial'] as bool? : null;
+    final bool? isAccepting = payload.containsKey('isAccepting')
+        ? payload['isAccepting'] as bool?
+        : null;
+
+    if (isInitial == null && isAccepting == null) {
+      return;
+    }
+
+    final updated = ref.read(pdaEditorProvider.notifier).updateStateFlags(
+          id: id,
+          isInitial: isInitial,
+          isAccepting: isAccepting,
+        );
+    if (updated != null) {
+      widget.onPdaModified(updated);
+    }
+  }
+
+  void _handleStateRemove(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final updated = ref.read(pdaEditorProvider.notifier).removeState(id: id);
+    if (updated != null) {
+      widget.onPdaModified(updated);
+    }
+  }
+
   void _handleTransitionUpsert(
     Map<String, dynamic> payload, {
     required bool requireEndpoints,
@@ -198,6 +245,18 @@ class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
           isLambdaPop: stackPayload?.isLambdaPop,
           isLambdaPush: stackPayload?.isLambdaPush,
         );
+    if (updated != null) {
+      widget.onPdaModified(updated);
+    }
+  }
+
+  void _handleTransitionRemove(Map<String, dynamic> payload) {
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final updated = ref.read(pdaEditorProvider.notifier).removeTransition(id: id);
     if (updated != null) {
       widget.onPdaModified(updated);
     }

--- a/lib/presentation/widgets/draw2d_tm_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_tm_canvas_view.dart
@@ -106,11 +106,20 @@ class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
       case 'state.label':
         _handleStateLabel(payload);
         break;
+      case 'state.updateFlags':
+        _handleStateFlags(payload);
+        break;
+      case 'state.remove':
+        _handleStateRemove(payload);
+        break;
       case 'transition.add':
         _handleTransitionAdd(payload);
         break;
       case 'transition.label':
         _handleTransitionUpdate(payload);
+        break;
+      case 'transition.remove':
+        _handleTransitionRemove(payload);
         break;
       default:
         debugPrint('Unhandled Draw2D TM event: $type');
@@ -157,6 +166,42 @@ class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
     _maybeEmitTM(tm);
   }
 
+  void _handleStateFlags(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final bool? isInitial =
+        payload.containsKey('isInitial') ? payload['isInitial'] as bool? : null;
+    final bool? isAccepting = payload.containsKey('isAccepting')
+        ? payload['isAccepting'] as bool?
+        : null;
+
+    if (isInitial == null && isAccepting == null) {
+      return;
+    }
+
+    final tm = notifier.updateStateFlags(
+      id: id,
+      isInitial: isInitial,
+      isAccepting: isAccepting,
+    );
+    _maybeEmitTM(tm);
+  }
+
+  void _handleStateRemove(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final tm = notifier.removeState(id: id);
+    _maybeEmitTM(tm);
+  }
+
   void _handleTransitionAdd(Map<String, dynamic> payload) {
     final notifier = ref.read(tmEditorProvider.notifier);
     final id = payload['id'] as String?;
@@ -198,6 +243,17 @@ class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
       writeSymbol: write,
       direction: direction,
     );
+    _maybeEmitTM(tm);
+  }
+
+  void _handleTransitionRemove(Map<String, dynamic> payload) {
+    final notifier = ref.read(tmEditorProvider.notifier);
+    final id = payload['id'] as String?;
+    if (id == null) {
+      return;
+    }
+
+    final tm = notifier.removeTransition(id: id);
     _maybeEmitTM(tm);
   }
 


### PR DESCRIPTION
## Summary
- add Draw2D context menu actions to toggle initial/accepting flags and delete states or transitions, emitting the new bridge messages
- teach the Flutter Draw2D canvas views to consume the new events and forward them to their providers
- extend the automaton, PDA, and TM providers with helpers to update state flags and remove states or transitions so the bridge can keep models in sync

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68ddb34aaa3c832eb4a578137296efdc