### PR TITLE
Add TM type flag to Draw2D mapper payload

### DIFF
--- a/lib/presentation/mappers/draw2d_tm_mapper.dart
+++ b/lib/presentation/mappers/draw2d_tm_mapper.dart
@@ -15,6 +15,7 @@ class Draw2DTMMapper {
       return {
         'id': null,
         'name': null,
+        'type': 'tm',
         'states': const <Map<String, dynamic>>[],
         'transitions': const <Map<String, dynamic>>[],
         'initialStateId': null,
@@ -48,6 +49,7 @@ class Draw2DTMMapper {
     return {
       'id': machine.id,
       'name': machine.name,
+      'type': 'tm',
       'states': statesJson,
       'transitions': transitionsJson,
       'initialStateId': initialId,

--- a/test/unit/presentation/mappers/draw2d_tm_mapper_test.dart
+++ b/test/unit/presentation/mappers/draw2d_tm_mapper_test.dart
@@ -1,0 +1,60 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/presentation/mappers/draw2d_tm_mapper.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+void main() {
+  group('Draw2DTMMapper', () {
+    test('includes tm type in serialised payloads', () {
+      final initialState = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final nextState = State(
+        id: 'q1',
+        label: 'q1',
+        position: Vector2(100, 0),
+        isAccepting: true,
+      );
+      final transition = TMTransition(
+        id: 't0',
+        fromState: initialState,
+        toState: nextState,
+        label: 'a/b,R',
+        controlPoint: Vector2.zero(),
+        readSymbol: 'a',
+        writeSymbol: 'b',
+        direction: TapeDirection.right,
+      );
+      final machine = TM(
+        id: 'tm1',
+        name: 'Example TM',
+        states: {initialState, nextState},
+        transitions: {transition},
+        alphabet: {'a', 'b'},
+        initialState: initialState,
+        acceptingStates: {nextState},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 2),
+        bounds: const math.Rectangle<double>(0, 0, 200, 100),
+        zoomLevel: 1.0,
+        panOffset: Vector2.zero(),
+        tapeAlphabet: {'a', 'b', 'B'},
+        blankSymbol: 'B',
+        tapeCount: 1,
+      );
+
+      final serializedMachine = Draw2DTMMapper.toJson(machine);
+      final serializedNull = Draw2DTMMapper.toJson(null);
+
+      expect(serializedMachine['type'], 'tm');
+      expect(serializedNull['type'], 'tm');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- ensure Draw2DTMMapper always emits the tm type flag in its payloads
- add a unit test covering the mapper serialization to assert the type field is tm

## Testing
- flutter test test/unit/presentation/mappers/draw2d_tm_mapper_test.dart *(fails: flutter command unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dde5e6ab94832eba23e84a52e6f19b