### PR TITLE
Maintain Draw2D controller stack for fallback highlights

### DIFF
--- a/lib/core/services/draw2d_bridge_platform_stub.dart
+++ b/lib/core/services/draw2d_bridge_platform_stub.dart
@@ -6,22 +6,31 @@ import 'package:webview_flutter/webview_flutter.dart';
 class Draw2DBridgePlatform {
   Draw2DBridgePlatform();
 
-  WebViewController? _controller;
+  final List<WebViewController> _controllerStack = <WebViewController>[];
+
+  WebViewController? get _activeController =>
+      _controllerStack.isEmpty ? null : _controllerStack.last;
 
   void registerWebViewController(WebViewController controller) {
-    _controller = controller;
+    final existingIndex = _controllerStack.indexOf(controller);
+    if (existingIndex != -1) {
+      _controllerStack.removeAt(existingIndex);
+    }
+    _controllerStack.add(controller);
   }
 
   void unregisterWebViewController(WebViewController controller) {
-    if (identical(_controller, controller)) {
-      _controller = null;
+    final index = _controllerStack.indexOf(controller);
+    if (index == -1) {
+      return;
     }
+    _controllerStack.removeAt(index);
   }
 
-  bool get hasRegisteredController => _controller != null;
+  bool get hasRegisteredController => _activeController != null;
 
   void runJavaScript(String script) {
-    final controller = _controller;
+    final controller = _activeController;
     if (controller == null) {
       return;
     }

--- a/lib/core/services/draw2d_bridge_service.dart
+++ b/lib/core/services/draw2d_bridge_service.dart
@@ -16,6 +16,8 @@ class Draw2DBridgeService {
 
   final Draw2DBridgePlatform _platform;
 
+  bool get hasRegisteredController => _platform.hasRegisteredController;
+
   /// Registers the [controller] currently rendering the Draw2D canvas.
   void registerWebViewController(WebViewController controller) {
     _platform.registerWebViewController(controller);
@@ -24,6 +26,13 @@ class Draw2DBridgeService {
   /// Removes the [controller] registration when it is no longer active.
   void unregisterWebViewController(WebViewController controller) {
     _platform.unregisterWebViewController(controller);
+  }
+
+  void runJavaScript(String script) {
+    if (!hasRegisteredController) {
+      return;
+    }
+    _platform.runJavaScript(script);
   }
 
   /// Dispatches a highlight event to the Draw2D runtime.
@@ -38,18 +47,14 @@ class Draw2DBridgeService {
 
     final encoded = jsonEncode(payload);
 
-    if (_platform.hasRegisteredController) {
-      _platform.runJavaScript('window.draw2dBridge?.highlight($encoded);');
-    }
+    runJavaScript('window.draw2dBridge?.highlight($encoded);');
 
     _platform.postMessage('highlight', payload);
   }
 
   /// Dispatches a request to clear all highlights.
   void clearHighlight() {
-    if (_platform.hasRegisteredController) {
-      _platform.runJavaScript('window.draw2dBridge?.clearHighlight();');
-    }
+    runJavaScript('window.draw2dBridge?.clearHighlight();');
     _platform.postMessage('clear_highlight', const {});
   }
 }


### PR DESCRIPTION
## Summary
- track WebView controllers in the Draw2D bridge stub so the most recent view stays active and automatically falls back when dismissed
- expose controller state helpers in the Draw2D bridge service so highlight and clear commands always target the active controller

## Testing
- not run (environment limitation)


------
https://chatgpt.com/codex/tasks/task_e_68dde5e675ac832e8e82de78c6227d1d