### PR TITLE
draw2d: align fsa canvas bridge

### DIFF
--- a/docs/canvas_bridge.md
+++ b/docs/canvas_bridge.md
@@ -54,9 +54,8 @@ instance, ensuring the rest of the UI reacts immediately.
   instead of the legacy Flutter canvas.
 * Open the WebView's developer tools (when available) to inspect console logs.
   Every inbound/outbound message is printed with a `[Draw2D]` prefix.
-* The `Draw2DCanvasView` widget can be duplicated side-by-side with the native
-  canvas by toggling `_enableDraw2dDevPreview` in `fsa_page.dart`, which is
-  useful when validating layout parity.
+* The toolbar now shows "Canvas not connected" until the Draw2D bridge reports
+  readiness. If the message persists, inspect the console for bridge errors.
 
 ## Web Highlight Bridge
 

--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -22,7 +22,6 @@ class FSAPage extends ConsumerStatefulWidget {
 }
 
 class _FSAPageState extends ConsumerState<FSAPage> {
-  static const bool _enableDraw2dDevPreview = false;
   final GlobalKey _canvasKey = GlobalKey();
   void _showSnack(String message, {bool isError = false}) {
     final theme = Theme.of(context);
@@ -343,32 +342,15 @@ class _FSAPageState extends ConsumerState<FSAPage> {
         showTrace: state.simulationResult != null,
       );
 
-      if (!_enableDraw2dDevPreview) {
-        return Stack(
-          children: [
-            Positioned.fill(child: automatonCanvas),
-            Positioned(top: 12, right: 12, child: Draw2DCanvasToolbar(onClear: () => ref.read(automatonProvider.notifier).clearAutomaton())),
-          ],
-        );
-      }
-
-      final spacing = isMobile ? 8.0 : 12.0;
-
-      return Column(
+      return Stack(
         children: [
-          Expanded(
-            flex: 3,
-            child: Stack(
-              children: [
-                Positioned.fill(child: automatonCanvas),
-                Positioned(top: 12, right: 12, child: Draw2DCanvasToolbar(onClear: () => ref.read(automatonProvider.notifier).clearAutomaton())),
-              ],
+          Positioned.fill(child: automatonCanvas),
+          Positioned(
+            top: 12,
+            right: 12,
+            child: Draw2DCanvasToolbar(
+              onClear: () => ref.read(automatonProvider.notifier).clearAutomaton(),
             ),
-          ),
-          SizedBox(height: spacing),
-          const Expanded(
-            flex: 2,
-            child: Draw2DCanvasView(),
           ),
         ],
       );

--- a/lib/presentation/widgets/automaton_canvas_web.dart
+++ b/lib/presentation/widgets/automaton_canvas_web.dart
@@ -14,6 +14,7 @@ import '../../core/models/simulation_result.dart';
 import '../../core/models/simulation_step.dart';
 import '../../core/models/state.dart' as automaton_state;
 import '../../core/models/transition.dart';
+import '../../core/services/draw2d_bridge_service.dart';
 import '../../core/utils/automaton_patch.dart';
 
 /// Web implementation of the Automaton canvas that delegates rendering and
@@ -83,6 +84,7 @@ class _AutomatonCanvasWebState extends State<AutomatonCanvas> {
     _messageSubscription?.cancel();
     _messageSubscription = null;
     _iframe = null;
+    Draw2DBridgeService().markBridgeDisconnected();
     super.dispose();
   }
 
@@ -116,7 +118,19 @@ class _AutomatonCanvasWebState extends State<AutomatonCanvas> {
     final dynamic typeValue = data?['type'];
     final String? messageType = typeValue is String ? typeValue : null;
 
-    if (messageType == 'highlight' || messageType == 'clear_highlight') {
+    const forwardedTypes = <String>{
+      'highlight',
+      'clear_highlight',
+      'zoom_in',
+      'zoom_out',
+      'fit_content',
+      'reset_view',
+      'add_state_center',
+    };
+
+    if (messageType != null &&
+        forwardedTypes.contains(messageType) &&
+        event.source != _iframe?.contentWindow) {
       _postMessage(event.data);
       return;
     }
@@ -136,6 +150,7 @@ class _AutomatonCanvasWebState extends State<AutomatonCanvas> {
             _isReady = true;
           });
         }
+        Draw2DBridgeService().markBridgeReady();
         _postAutomaton(force: true);
         break;
       case 'patch':

--- a/lib/presentation/widgets/draw2d_canvas_toolbar.dart
+++ b/lib/presentation/widgets/draw2d_canvas_toolbar.dart
@@ -10,63 +10,89 @@ class Draw2DCanvasToolbar extends StatelessWidget {
   Widget build(BuildContext context) {
     final bridge = Draw2DBridgeService();
     final colorScheme = Theme.of(context).colorScheme;
+    final textTheme = Theme.of(context).textTheme;
 
-    return Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-      decoration: BoxDecoration(
-        color: colorScheme.surface,
-        borderRadius: BorderRadius.circular(8),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.08),
-            blurRadius: 8,
-            offset: const Offset(0, 2),
+    return AnimatedBuilder(
+      animation: bridge,
+      builder: (context, _) {
+        final hasBridge = bridge.hasActiveBridge;
+
+        final toolbar = Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+          decoration: BoxDecoration(
+            color: colorScheme.surface,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              BoxShadow(
+                color: Colors.black.withOpacity(0.08),
+                blurRadius: 8,
+                offset: const Offset(0, 2),
+              ),
+            ],
           ),
-        ],
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          IconButton(
-            tooltip: 'Add state (center)',
-            icon: const Icon(Icons.add_circle_outline),
-            onPressed: bridge.addStateAtCenter,
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              IconButton(
+                tooltip: 'Add state (center)',
+                icon: const Icon(Icons.add_circle_outline),
+                onPressed: hasBridge ? bridge.addStateAtCenter : null,
+              ),
+              const SizedBox(width: 4),
+              const VerticalDivider(width: 1),
+              const SizedBox(width: 4),
+              IconButton(
+                tooltip: 'Zoom out',
+                icon: const Icon(Icons.zoom_out),
+                onPressed: hasBridge ? bridge.zoomOut : null,
+              ),
+              IconButton(
+                tooltip: 'Reset view',
+                icon: const Icon(Icons.center_focus_strong),
+                onPressed: hasBridge ? bridge.resetView : null,
+              ),
+              IconButton(
+                tooltip: 'Zoom in',
+                icon: const Icon(Icons.zoom_in),
+                onPressed: hasBridge ? bridge.zoomIn : null,
+              ),
+              IconButton(
+                tooltip: 'Fit to content',
+                icon: const Icon(Icons.fit_screen),
+                onPressed: hasBridge ? bridge.fitToContent : null,
+              ),
+              if (onClear != null) ...[
+                const SizedBox(width: 4),
+                const VerticalDivider(width: 1),
+                const SizedBox(width: 4),
+                IconButton(
+                  tooltip: 'Clear',
+                  icon: const Icon(Icons.delete_outline),
+                  onPressed: onClear,
+                ),
+              ],
+            ],
           ),
-          const SizedBox(width: 4),
-          const VerticalDivider(width: 1),
-          const SizedBox(width: 4),
-          IconButton(
-            tooltip: 'Zoom out',
-            icon: const Icon(Icons.zoom_out),
-            onPressed: bridge.zoomOut,
-          ),
-          IconButton(
-            tooltip: 'Reset view',
-            icon: const Icon(Icons.center_focus_strong),
-            onPressed: bridge.resetView,
-          ),
-          IconButton(
-            tooltip: 'Zoom in',
-            icon: const Icon(Icons.zoom_in),
-            onPressed: bridge.zoomIn,
-          ),
-          IconButton(
-            tooltip: 'Fit to content',
-            icon: const Icon(Icons.fit_screen),
-            onPressed: bridge.fitToContent,
-          ),
-          if (onClear != null) ...[
-            const SizedBox(width: 4),
-            const VerticalDivider(width: 1),
-            const SizedBox(width: 4),
-            IconButton(
-              tooltip: 'Clear',
-              icon: const Icon(Icons.delete_outline),
-              onPressed: onClear,
-            ),
+        );
+
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            toolbar,
+            if (!hasBridge)
+              Padding(
+                padding: const EdgeInsets.only(top: 6),
+                child: Text(
+                  'Canvas not connected',
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                ),
+              ),
           ],
-        ],
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/presentation/widgets/draw2d_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_canvas_view.dart
@@ -61,7 +61,7 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
           return NavigationDecision.prevent;
         },
       ))
-        ..loadFlutterAsset('assets/draw2d/minimal_editor.html');
+        ..loadFlutterAsset('assets/draw2d/editor.html');
 
     _controller = controller;
 
@@ -128,6 +128,7 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
         setState(() {
           _isReady = true;
         });
+        _bridge.markBridgeReady();
         _pushModel(ref.read(automatonProvider));
         break;
       case 'state.add':

--- a/lib/presentation/widgets/draw2d_pda_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_pda_canvas_view.dart
@@ -114,6 +114,7 @@ class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
         setState(() {
           _isReady = true;
         });
+        _bridge.markBridgeReady();
         _pushModel(ref.read(pdaEditorProvider).pda);
         break;
       case 'state.add':

--- a/lib/presentation/widgets/draw2d_tm_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_tm_canvas_view.dart
@@ -111,6 +111,7 @@ class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
         setState(() {
           _isReady = true;
         });
+        _bridge.markBridgeReady();
         _pushModel(ref.read(tmEditorProvider));
         break;
       case 'state.add':


### PR DESCRIPTION
## Summary
- load the production Draw2D editor for the FSA WebView and mark the bridge ready once the handshake completes
- track Draw2D bridge readiness in the shared service and surface the connection status through the toolbar UI
- forward toolbar commands to the web iframe implementation and update the troubleshooting docs

## Testing
- Not run (Flutter tooling unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68de5ada4fec832eb9d3f4988beb081b