### PR TITLE
Escape Draw2D model payloads for WebView scripts

### DIFF
--- a/lib/presentation/widgets/draw2d_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_canvas_view.dart
@@ -288,7 +288,7 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
 
   Future<void> _pushModel(AutomatonState state) async {
     final payload = Draw2DAutomatonMapper.toJson(state.currentAutomaton);
-    final json = jsonEncode(payload);
+    final json = _escapeForJsLiteral(jsonEncode(payload));
     final controller = _controller;
     if (controller == null) {
       return;
@@ -303,6 +303,10 @@ class _Draw2DCanvasViewState extends ConsumerState<Draw2DCanvasView> {
         FlutterErrorDetails(exception: error, stack: stackTrace),
       );
     }
+  }
+
+  String _escapeForJsLiteral(String value) {
+    return value.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
   }
 
   String _nextStateId() {

--- a/lib/presentation/widgets/draw2d_pda_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_pda_canvas_view.dart
@@ -295,7 +295,7 @@ class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
 
   Future<void> _pushModel(PDA? pda) async {
     final payload = Draw2DPdaMapper.toJson(pda);
-    final json = jsonEncode(payload);
+    final json = _escapeForJsLiteral(jsonEncode(payload));
     final controller = _controller;
     if (controller == null) {
       return;
@@ -308,6 +308,10 @@ class _Draw2DPdaCanvasViewState extends ConsumerState<Draw2DPdaCanvasView> {
         FlutterErrorDetails(exception: error, stack: stackTrace),
       );
     }
+  }
+
+  String _escapeForJsLiteral(String value) {
+    return value.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
   }
 
   _TransitionStackPayload? _parseStackPayload(Map<String, dynamic> payload) {

--- a/lib/presentation/widgets/draw2d_tm_canvas_view.dart
+++ b/lib/presentation/widgets/draw2d_tm_canvas_view.dart
@@ -276,7 +276,7 @@ class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
 
   void _pushModel(TMEditorState state) {
     final payload = Draw2DTMMapper.toJson(state.tm);
-    final json = jsonEncode(payload);
+    final json = _escapeForJsLiteral(jsonEncode(payload));
     final controller = _controller;
     if (controller == null) {
       return;
@@ -289,6 +289,10 @@ class _Draw2DTMCanvasViewState extends ConsumerState<Draw2DTMCanvasView> {
         FlutterErrorDetails(exception: error, stack: stackTrace),
       );
     });
+  }
+
+  String _escapeForJsLiteral(String value) {
+    return value.replaceAll(r'\', r'\\').replaceAll("'", r"\'");
   }
 
   void _maybeEmitTM(TM? tm) {


### PR DESCRIPTION
## Summary
- escape Draw2D automaton, PDA, and TM payload JSON before injecting into JavaScript
- add shared helper in each canvas view to protect against apostrophes and backslashes breaking the script

## Testing
- flutter analyze *(fails: `flutter` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68de6fa7784c832e96cf1a5696f8af41