### PR TITLE
Fix Draw2D runtime asset availability

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -127,6 +127,7 @@ flutter:
     - jflutter_js/examples/tm_binary_to_unary.json
     # Draw2D prototype assets
     - assets/draw2d/
+    - assets/draw2d/vendor/
 
 flutter_launcher_icons:
   image_path: "icon.PNG"


### PR DESCRIPTION
## Summary
- include the Draw2D vendor directory in the Flutter asset bundle so the runtime can be loaded by the canvases

## Testing
- not run (Flutter SDK is unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68de75adbd74832e8be5236801e1c9be