### PR TITLE
Add independent MPR window state for iOS viewer

### DIFF
--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+                D0A07D1D2B6F4C7A00A1B2C3 /* VolumetricSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A07D1C2B6F4C7A00A1B2C3 /* VolumetricSessionState.swift */; };
+                D0A07D1F2B6F4C7A00A1B2C3 /* ViewerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A07D1E2B6F4C7A00A1B2C3 /* ViewerViewModel.swift */; };
+                D0A07D212B6F4C7A00A1B2C3 /* ViewerPanZoomStabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0A07D202B6F4C7A00A1B2C3 /* ViewerPanZoomStabilityTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +68,9 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		D90347593A2EB9E0A336522E /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		FFF916834D2E518F8C457DD0 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
+		D0A07D1C2B6F4C7A00A1B2C3 /* VolumetricSessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentation/ViewModels/Viewer/VolumetricSessionState.swift; sourceTree = "<group>"; };
+		D0A07D1E2B6F4C7A00A1B2C3 /* ViewerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Presentation/ViewModels/Viewer/ViewerViewModel.swift; sourceTree = "<group>"; };
+		D0A07D202B6F4C7A00A1B2C3 /* ViewerPanZoomStabilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewerPanZoomStabilityTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -91,6 +97,7 @@
 			isa = PBXGroup;
 			children = (
 				331C807B294A618700263BE5 /* RunnerTests.swift */,
+				D0A07D202B6F4C7A00A1B2C3 /* ViewerPanZoomStabilityTests.swift */,
 			);
 			path = RunnerTests;
 			sourceTree = "<group>";
@@ -146,6 +153,7 @@
 				1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */,
 				1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */,
 				74858FAE1ED2DC5600515810 /* AppDelegate.swift */,
+				D0A07D222B6F4C7A00A1B2C3 /* Presentation */,
 				74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */,
 			);
 			path = Runner;
@@ -162,6 +170,31 @@
 				11018D468FB6C1B77CD20016 /* Pods-RunnerTests.profile.xcconfig */,
 			);
 			path = Pods;
+			sourceTree = "<group>";
+		};
+		D0A07D242B6F4C7A00A1B2C3 /* Viewer */ = {
+			isa = PBXGroup;
+			children = (
+				D0A07D1C2B6F4C7A00A1B2C3 /* VolumetricSessionState.swift */,
+				D0A07D1E2B6F4C7A00A1B2C3 /* ViewerViewModel.swift */,
+			);
+			path = Viewer;
+			sourceTree = "<group>";
+		};
+		D0A07D232B6F4C7A00A1B2C3 /* ViewModels */ = {
+			isa = PBXGroup;
+			children = (
+				D0A07D242B6F4C7A00A1B2C3 /* Viewer */,
+			);
+			path = ViewModels;
+			sourceTree = "<group>";
+		};
+		D0A07D222B6F4C7A00A1B2C3 /* Presentation */ = {
+			isa = PBXGroup;
+			children = (
+				D0A07D232B6F4C7A00A1B2C3 /* ViewModels */,
+			);
+			path = Presentation;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -369,6 +402,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				331C808B294A63AB00263BE5 /* RunnerTests.swift in Sources */,
+				D0A07D212B6F4C7A00A1B2C3 /* ViewerPanZoomStabilityTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -377,6 +411,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */,
+				D0A07D1D2B6F4C7A00A1B2C3 /* VolumetricSessionState.swift in Sources */,
+				D0A07D1F2B6F4C7A00A1B2C3 /* ViewerViewModel.swift in Sources */,
 				1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/ios/Runner/Presentation/ViewModels/Viewer/ViewerViewModel.swift
+++ b/ios/Runner/Presentation/ViewModels/Viewer/ViewerViewModel.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// View model that orchestrates window/level interactions for volumetric and MPR modes.
+public final class ViewerViewModel {
+  private let sessionState: VolumetricSessionState
+
+  /// Window/level persisted for volumetric rendering.
+  public private(set) var volumetricWWLState: HuWindow?
+
+  /// Dedicated window/level persisted for MPR rendering.
+  public private(set) var mprWWLState: HuWindow?
+
+  public init(sessionState: VolumetricSessionState) {
+    self.sessionState = sessionState
+    volumetricWWLState = sessionState.volumeHuWindow
+    mprWWLState = sessionState.currentMprHuWindow
+  }
+
+  /// Applies a volumetric window/level preserving the independent MPR state.
+  public func applyVolumetricWindowLevel(_ window: HuWindow?) {
+    volumetricWWLState = window
+    sessionState.setHuWindow(window)
+  }
+
+  /// Applies a dedicated MPR window/level without touching the volumetric configuration.
+  public func applyMprWindowLevel(_ window: HuWindow?) {
+    mprWWLState = window
+    sessionState.setMprHuWindow(window)
+  }
+
+  /// Returns the active MPR window/level, considering the cached state and the session defaults.
+  public var currentMprWindowLevelState: HuWindow? {
+    mprWWLState ?? sessionState.currentMprHuWindow
+  }
+}

--- a/ios/Runner/Presentation/ViewModels/Viewer/VolumetricSessionState.swift
+++ b/ios/Runner/Presentation/ViewModels/Viewer/VolumetricSessionState.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// Represents an HU (Hounsfield Units) window level configuration.
+public struct HuWindow: Equatable {
+  public var width: Double
+  public var level: Double
+
+  public init(width: Double, level: Double) {
+    self.width = width
+    self.level = level
+  }
+}
+
+/// Abstraction describing a component capable of reacting to HU window updates.
+public protocol HuWindowControlling: AnyObject {
+  var huWindow: HuWindow? { get set }
+}
+
+/// Holds the volumetric viewer session state, keeping independent window ranges for the
+/// volume rendering and the MPR controllers.
+public final class VolumetricSessionState {
+  public weak var volumetricController: (any HuWindowControlling)?
+  private(set) var mprControllers: [HuWindowControlling] = []
+
+  /// Persists the HU window applied on the volumetric controller so it can be reused when
+  /// rebuilding the pipeline.
+  public private(set) var volumeHuWindow: HuWindow?
+
+  /// Tracks the latest HU window that should be applied on MPR controllers without touching the
+  /// volumetric controller configuration.
+  public private(set) var currentMprHuWindow: HuWindow?
+
+  public init(volumetricController: (any HuWindowControlling)? = nil) {
+    self.volumetricController = volumetricController
+  }
+
+  /// Applies the HU window exclusively on volumetric rendering, preserving the HU range in memory
+  /// for future reconfiguration.
+  public func setHuWindow(_ window: HuWindow?) {
+    volumeHuWindow = window
+    volumetricController?.huWindow = window
+  }
+
+  /// Updates only the cached HU window for MPR controllers and pushes the change to them without
+  /// altering the volumetric HU state.
+  public func setMprHuWindow(_ window: HuWindow?) {
+    currentMprHuWindow = window
+    for controller in mprControllers {
+      controller.huWindow = window
+    }
+  }
+
+  /// Stores the supplied MPR controllers and applies the cached HU window, if any. When no
+  /// override is available we fall back to the dataset metadata.
+  public func prepareMprControllers(
+    _ controllers: [HuWindowControlling],
+    metadataWindow: HuWindow?
+  ) {
+    mprControllers = controllers
+
+    if let override = currentMprHuWindow {
+      controllers.forEach { $0.huWindow = override }
+    } else if let metadataWindow {
+      controllers.forEach { $0.huWindow = metadataWindow }
+    }
+  }
+}

--- a/ios/RunnerTests/ViewerPanZoomStabilityTests.swift
+++ b/ios/RunnerTests/ViewerPanZoomStabilityTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import Runner
+
+private final class MockHuWindowController: HuWindowControlling {
+  var huWindow: HuWindow?
+}
+
+final class ViewerPanZoomStabilityTests: XCTestCase {
+  func testSettingMprWindowDoesNotAlterVolumetricState() {
+    let volumetricController = MockHuWindowController()
+    let mprController = MockHuWindowController()
+    let state = VolumetricSessionState(volumetricController: volumetricController)
+    state.prepareMprControllers([mprController], metadataWindow: HuWindow(width: 1200, level: 40))
+
+    let volumetricWindow = HuWindow(width: 400, level: 50)
+    state.setHuWindow(volumetricWindow)
+    let mprWindow = HuWindow(width: 1600, level: 60)
+    state.setMprHuWindow(mprWindow)
+
+    XCTAssertEqual(state.volumeHuWindow, volumetricWindow)
+    XCTAssertEqual(state.currentMprHuWindow, mprWindow)
+    XCTAssertEqual(volumetricController.huWindow, volumetricWindow)
+    XCTAssertEqual(mprController.huWindow, mprWindow)
+  }
+
+  func testSettingVolumetricWindowDoesNotAlterMprState() {
+    let volumetricController = MockHuWindowController()
+    let mprController = MockHuWindowController()
+    let state = VolumetricSessionState(volumetricController: volumetricController)
+    let mprWindow = HuWindow(width: 1800, level: 70)
+    state.prepareMprControllers([mprController], metadataWindow: HuWindow(width: 900, level: 30))
+    state.setMprHuWindow(mprWindow)
+
+    let volumetricWindow = HuWindow(width: 500, level: 45)
+    state.setHuWindow(volumetricWindow)
+
+    XCTAssertEqual(state.currentMprHuWindow, mprWindow)
+    XCTAssertEqual(mprController.huWindow, mprWindow)
+  }
+
+  func testPrepareMprControllersUsesOverrideWhenPresent() {
+    let firstMprController = MockHuWindowController()
+    let secondMprController = MockHuWindowController()
+    let state = VolumetricSessionState()
+    let override = HuWindow(width: 2000, level: 80)
+    state.setMprHuWindow(override)
+
+    state.prepareMprControllers([firstMprController, secondMprController], metadataWindow: HuWindow(width: 400, level: 10))
+
+    XCTAssertEqual(firstMprController.huWindow, override)
+    XCTAssertEqual(secondMprController.huWindow, override)
+  }
+
+  func testPrepareMprControllersFallsBackToMetadata() {
+    let firstMprController = MockHuWindowController()
+    let secondMprController = MockHuWindowController()
+    let state = VolumetricSessionState()
+    let metadata = HuWindow(width: 350, level: -20)
+
+    state.prepareMprControllers([firstMprController, secondMprController], metadataWindow: metadata)
+
+    XCTAssertEqual(firstMprController.huWindow, metadata)
+    XCTAssertEqual(secondMprController.huWindow, metadata)
+  }
+
+  func testViewModelKeepsIndependentStates() {
+    let volumetricController = MockHuWindowController()
+    let mprController = MockHuWindowController()
+    let state = VolumetricSessionState(volumetricController: volumetricController)
+    state.prepareMprControllers([mprController], metadataWindow: nil)
+    let viewModel = ViewerViewModel(sessionState: state)
+
+    let volumetricWindow = HuWindow(width: 450, level: 20)
+    viewModel.applyVolumetricWindowLevel(volumetricWindow)
+    XCTAssertEqual(viewModel.volumetricWWLState, volumetricWindow)
+    XCTAssertNil(viewModel.mprWWLState)
+
+    let mprWindow = HuWindow(width: 1750, level: 30)
+    viewModel.applyMprWindowLevel(mprWindow)
+    XCTAssertEqual(viewModel.mprWWLState, mprWindow)
+    XCTAssertEqual(viewModel.currentMprWindowLevelState, mprWindow)
+    XCTAssertEqual(state.volumeHuWindow, volumetricWindow)
+    XCTAssertEqual(state.currentMprHuWindow, mprWindow)
+  }
+}


### PR DESCRIPTION
## Summary
- add volumetric session state and viewer view model infrastructure under `Presentation/ViewModels/Viewer`
- ensure volumetric and MPR HU window updates are isolated by maintaining separate cached state
- cover the separation with a new `ViewerPanZoomStabilityTests` suite and wire files into the Xcode project

## Testing
- not run (iOS tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68de80a1ac90832ebf9d89e0cb3b3759