### PR TITLE
docs: document draw2d bridge protocol

### DIFF
--- a/USER_GUIDE
+++ b/USER_GUIDE
@@ -7,28 +7,56 @@ Draw2D Canvas Toggle
 * Navigate to **Settings → Canvas**.
 * Enable **Use Draw2D Canvas** to switch the FSA editor to the WebView-powered renderer.
 * Tap **Save Settings**. The preference is persisted via `SharedPreferences` and propagated through Riverpod (`settingsProvider`).
-* Return to the automaton workspace. Supported platforms will render the Draw2D canvas; unsupported targets display a warning placeholder.
+* Return to the automaton workspace. Supported platforms render the Draw2D canvas; unsupported targets display a warning placeholder.
+* The canvas toolbar shows “Canvas not connected” until the Draw2D bridge confirms the `editor_ready` handshake.
 
 Bridge Message Reference
 ------------------------
 
-* **loadAutomaton** (Flutter → WebView): complete snapshot of states, transitions, and alphabet.
-* **node:add** (WebView → Flutter): create or replace a state using `{ id, label, x, y, isInitial, isAccepting }`.
-* **node:move** (WebView → Flutter): update a state's position.
-* **edge:link** (WebView → Flutter): connect two states with `symbols` (array or comma-delimited string).
+### Flutter → Draw2D
+
+| Command                | Payload summary                                                  | Notes |
+| ---------------------- | ---------------------------------------------------------------- | ----- |
+| `loadModel`            | Full automaton snapshot from `Draw2DAutomatonMapper.toJson`.      | Injected via `window.draw2dBridge.loadModel(...)` on mobile platforms. |
+| `load_automaton`       | Automaton snapshot + viewport + optional simulation trace.       | Posted to the iframe on Flutter web builds. |
+| `clear_automaton`      | `{}`                                                             | Clears the web canvas when no automaton is active. |
+| `highlight`            | `{ states: string[], transitions: string[] }`                    | Keeps simulator highlights in sync (also echoed through `postMessage`). |
+| `clear_highlight`      | `{}`                                                             | Removes simulator highlights. |
+| `zoom_in` / `zoom_out` | `{}`                                                             | Updates the viewport zoom. |
+| `reset_view`           | `{}`                                                             | Restores pan/zoom defaults. |
+| `fit_content`          | `{}`                                                             | Frames the full automaton. |
+| `add_state_center`     | `{}`                                                             | Adds a new state at the viewport centre. |
+
+### Draw2D → Flutter
+
+| Event `type`           | Payload highlights                                               | Flutter behaviour |
+| ---------------------- | ---------------------------------------------------------------- | ----------------- |
+| `editor_ready`         | `{}`                                                             | Marks the bridge as ready and triggers an immediate automaton sync. |
+| `log`                  | `level`, `message`, optional `details`                           | Forwards diagnostics to Flutter logs. |
+| `state.add`            | `id?`, `label?`, `x`, `y`, `isInitial?`, `isAccepting?`          | Adds or replaces a state via the automaton provider. |
+| `state.move`           | `id`, `x`, `y`                                                   | Debounced to 60 ms batches before updating state positions. |
+| `state.label`          | `id`, `label`                                                    | Renames the state. |
+| `state.updateFlags`    | `id`, `isInitial?`, `isAccepting?`                               | Updates initial/accepting markers. |
+| `state.remove`         | `id`                                                             | Removes the state. |
+| `transition.add`       | `id?`, `fromStateId`, `toStateId`, `label?`                      | Creates or updates a transition. |
+| `transition.label`     | `id`, `label`                                                    | Updates transition symbols. |
+| `transition.remove`    | `id`                                                             | Removes the transition. |
+| `patch`                | Partial automaton diff (web only).                               | Applied to the current FSA via `applyAutomatonPatchToFsa`. |
+| `viewport_patch`       | `{ pan: {x, y}, zoom }` (web only).                               | Updates viewport metadata in Flutter state. |
+| `request_automaton`    | `{}` (web only).                                                  | Forces a fresh automaton snapshot to be posted back. |
 
 Manual Verification Checklist
 -----------------------------
 
 1. Enable the Draw2D toggle and save.
-2. Inject `node:add`, `node:move`, and `edge:link` events from the browser console or the integration test harness.
-3. Confirm the automaton updates in Flutter (state list, positions, transitions, alphabet).
-4. Disable the toggle to restore the legacy Flutter canvas.
-5. Run `flutter analyze` and `flutter test` to validate CI parity.
+2. Wait for the toolbar to drop the “Canvas not connected” label (verifies `editor_ready`).
+3. Inject `state.add`, `state.move`, and `transition.add` events from the browser console or integration harness and confirm the automaton list updates.
+4. Trigger toolbar commands (`zoom_in`, `fit_content`, `add_state_center`) and confirm they map to the expected Draw2D behaviour.
+5. Run `flutter analyze` (and `flutter test` once suites exist) before requesting review.
 
 Troubleshooting
 ---------------
 
 * **WebView unavailable**: The widget falls back to an instructional placeholder when the platform lacks WebView support.
 * **Bridge not responding**: Check the console for malformed JSON. The bridge ignores invalid payloads by design.
-* **Settings not persisting**: Ensure the settings dialog `Save` action completes; the provider mirrors the persisted value after success.
+* **Settings not persisting**: Ensure the settings dialog **Save** action completes; the provider mirrors the persisted value after success.

--- a/docs/fl_nodes_migration.md
+++ b/docs/fl_nodes_migration.md
@@ -1,0 +1,35 @@
+# FL Nodes Canvas Migration
+
+Summary of Draw2D-specific behaviours and dependencies that the upcoming Flutter canvas must replicate to preserve feature parity.
+
+## Behavioural Parity Requirements
+
+### `lib/presentation/widgets/draw2d_canvas_view.dart`
+
+* WebView setup injects two JavaScript channels (`JFlutterBridge`, `Alert`) and waits for the `editor_ready` message before syncing automata, using `Draw2DBridgeService` to toggle the toolbar status. The replacement canvas must surface an equivalent readiness signal so the UI can hide the “Canvas not connected” warning. 【F:lib/presentation/widgets/draw2d_canvas_view.dart†L52-L133】【F:lib/presentation/widgets/draw2d_canvas_toolbar.dart†L15-L95】
+* Automaton updates are streamed through Riverpod and debounced move events (`state.move`) to avoid flooding state updates. The new implementation should preserve debouncing for drag gestures. 【F:lib/presentation/widgets/draw2d_canvas_view.dart†L84-L197】【F:lib/presentation/widgets/draw2d_canvas_view.dart†L279-L287】
+* Incoming events must support adding/removing states and transitions, renaming, and flag toggles (`state.updateFlags`, `transition.remove`) as Draw2D currently normalises them into the shared `automatonProvider`. 【F:lib/presentation/widgets/draw2d_canvas_view.dart†L137-L277】
+* ID generation for newly created entities mirrors Draw2D’s incremental scheme (`qN`, `tN`). The Flutter canvas should keep compatible heuristics to avoid collisions with persisted data. 【F:lib/presentation/widgets/draw2d_canvas_view.dart†L308-L338】
+
+### `lib/presentation/widgets/automaton_canvas_web.dart`
+
+* Flutter web uses an `<iframe>` bridge that mirrors the handshake (`editor_ready`) and posts `load_automaton` / `clear_automaton` messages with viewport and simulation trace metadata. The new canvas must continue exposing viewport pan/zoom and trace highlights through the same payload structure. 【F:lib/presentation/widgets/automaton_canvas_web.dart†L91-L235】【F:lib/presentation/widgets/automaton_canvas_web.dart†L251-L299】
+* Web builds forward toolbar commands and simulator highlights via `postMessage` (`highlight`, `zoom_in`, `add_state_center`, etc.). Any replacement must keep accepting those message types to avoid breaking existing services (`Draw2DBridgeService`, `SimulationHighlightService`). 【F:lib/presentation/widgets/automaton_canvas_web.dart†L116-L180】【F:lib/core/services/draw2d_bridge_service.dart†L76-L123】
+* Diff-based updates (`patch`, `viewport_patch`) are applied to the current automaton and can skip the next full sync to prevent feedback loops. The incoming canvas must either keep patch semantics or provide an alternative that preserves performance. 【F:lib/presentation/widgets/automaton_canvas_web.dart†L146-L235】
+
+### `lib/presentation/widgets/draw2d_canvas_toolbar.dart`
+
+* Toolbar buttons trigger `Draw2DBridgeService` helpers (zoom, fit, reset, add state) and expose a clear callback hook for bulk deletion. The new canvas should reuse the same command surface or provide backward-compatible callbacks. 【F:lib/presentation/widgets/draw2d_canvas_toolbar.dart†L20-L74】
+* The toolbar reflects bridge readiness through an AnimatedBuilder. Maintain the notifier contract so the status label still reflects connectivity. 【F:lib/presentation/widgets/draw2d_canvas_toolbar.dart†L15-L95】【F:lib/core/services/draw2d_bridge_service.dart†L26-L131】
+
+## Dependencies & Assets
+
+* `Draw2DBridgeService` orchestrates JavaScript invocations and `postMessage` fallbacks; any migration must supply equivalent hooks for highlight control and viewport actions. 【F:lib/core/services/draw2d_bridge_service.dart†L66-L123】
+* `Draw2dHtmlBuilder` inlines vendor assets (`jquery`, `draw2d.js`, `editor.js`) to work inside platform WebViews. If Draw2D is removed, ensure replacement assets (or compiled Flutter canvas code) are referenced through the same asset bundle plumbing. 【F:lib/presentation/widgets/draw2d_html_builder.dart†L1-L131】
+* Embedded HTML currently loads `assets/draw2d/editor.html` / `editor.js`. Removing these without updating `pubspec.yaml` and the HTML builder will break the WebView bootstrap path. 【F:lib/presentation/widgets/draw2d_canvas_view.dart†L52-L104】【F:lib/presentation/widgets/automaton_canvas_web.dart†L91-L111】
+
+## Risks & Open Questions
+
+* WebView-only features such as the readiness handshake rely on JavaScript messaging; replacing Draw2D with a Flutter canvas must re-implement the handshake or adjust toolbar UX to avoid persistent “not connected” states. 【F:lib/presentation/widgets/draw2d_canvas_view.dart†L126-L133】【F:lib/presentation/widgets/draw2d_canvas_toolbar.dart†L15-L95】
+* Highlight controls and viewport commands are broadcast to both WebView and web iframe targets; diverging message names would break simulator playback and toolbar actions. 【F:lib/core/services/draw2d_bridge_service.dart†L76-L123】【F:lib/presentation/widgets/automaton_canvas_web.dart†L116-L180】
+* Current implementation lacks automated coverage for the WebView bridge, so regression risk is high without integration tests or golden scenarios for the new canvas. Plan manual verification scripts or new widget tests during migration.


### PR DESCRIPTION
## Summary
- update the canvas bridge reference with the current message inventory and toolbar commands
- align the user guide with the latest handshake expectations and simulator events
- record Draw2D parity requirements, dependencies, and risks for the FL Nodes canvas migration

## Testing
- not run (docs only)


------
https://chatgpt.com/codex/tasks/task_e_68df43778574832ea5be876a6780cd4d