### PR TITLE
canvas: integrate fl_nodes automaton controller

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_automaton_mapper.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_automaton_mapper.dart
@@ -1,0 +1,124 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/fsa.dart';
+import '../../../core/models/fsa_transition.dart';
+import '../../../core/models/state.dart';
+import 'fl_nodes_canvas_models.dart';
+
+/// Utility helpers to convert between [FSA] instances and fl_nodes snapshots.
+class FlNodesAutomatonMapper {
+  const FlNodesAutomatonMapper._();
+
+  /// Converts the provided [automaton] into a snapshot consumed by the
+  /// [FlNodesCanvasController].
+  static FlNodesAutomatonSnapshot toSnapshot(FSA? automaton) {
+    if (automaton == null) {
+      return const FlNodesAutomatonSnapshot.empty();
+    }
+
+    final nodes = automaton.states.map((state) {
+      return FlNodesCanvasNode(
+        id: state.id,
+        label: state.label,
+        x: state.position.x,
+        y: state.position.y,
+        isInitial: automaton.initialState?.id == state.id,
+        isAccepting: automaton.acceptingStates.any(
+          (candidate) => candidate.id == state.id,
+        ),
+      );
+    }).toList();
+
+    final edges = automaton.fsaTransitions.map((transition) {
+      return FlNodesCanvasEdge(
+        id: transition.id,
+        fromStateId: transition.fromState.id,
+        toStateId: transition.toState.id,
+        symbols: transition.inputSymbols.toList(),
+        lambdaSymbol: transition.lambdaSymbol,
+        controlPointX: transition.controlPoint.x,
+        controlPointY: transition.controlPoint.y,
+      );
+    }).toList();
+
+    final metadata = FlNodesAutomatonMetadata(
+      id: automaton.id,
+      name: automaton.name,
+      alphabet: automaton.alphabet.toList(),
+    );
+
+    return FlNodesAutomatonSnapshot(
+      nodes: nodes,
+      edges: edges,
+      metadata: metadata,
+    );
+  }
+
+  /// Rebuilds an [FSA] template with the snapshot produced by the canvas.
+  static FSA mergeIntoTemplate(
+    FlNodesAutomatonSnapshot snapshot,
+    FSA template,
+  ) {
+    final states = snapshot.nodes
+        .map(
+          (node) => State(
+            id: node.id,
+            label: node.label,
+            position: Vector2(node.x, node.y),
+            isInitial: node.isInitial,
+            isAccepting: node.isAccepting,
+          ),
+        )
+        .toSet();
+
+    final stateMap = {for (final state in states) state.id: state};
+
+    final transitions = snapshot.edges.map((edge) {
+      final fromState = stateMap[edge.fromStateId];
+      final toState = stateMap[edge.toStateId];
+      if (fromState == null || toState == null) {
+        throw StateError('Edge references missing state: ${edge.toJson()}');
+      }
+      return FSATransition(
+        id: edge.id,
+        fromState: fromState,
+        toState: toState,
+        inputSymbols: edge.symbols.toSet(),
+        lambdaSymbol: edge.lambdaSymbol,
+        label: edge.label,
+        controlPoint: edge.controlPointX != null && edge.controlPointY != null
+            ? Vector2(edge.controlPointX!, edge.controlPointY!)
+            : null,
+      );
+    }).toSet();
+
+    final acceptingStates = {
+      for (final node in snapshot.nodes.where((node) => node.isAccepting))
+        stateMap[node.id]!,
+    };
+
+    FlNodesCanvasNode? initialNode;
+    for (final node in snapshot.nodes) {
+      if (node.isInitial) {
+        initialNode = node;
+        break;
+      }
+    }
+
+    final alphabet = <String>{
+      ...template.alphabet,
+      for (final edge in snapshot.edges) ...edge.symbols,
+    }..removeWhere((symbol) => symbol.isEmpty);
+
+    final initialState =
+        initialNode != null ? stateMap[initialNode.id] : template.initialState;
+
+    return template.copyWith(
+      states: states,
+      transitions: transitions,
+      acceptingStates: acceptingStates,
+      initialState: initialState,
+      alphabet: alphabet,
+    );
+  }
+}

--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_models.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_models.dart
@@ -1,0 +1,272 @@
+import 'package:collection/collection.dart';
+
+/// Metadata describing the current automaton rendered in the canvas.
+class FlNodesAutomatonMetadata {
+  const FlNodesAutomatonMetadata({
+    required this.id,
+    required this.name,
+    required this.alphabet,
+  });
+
+  const FlNodesAutomatonMetadata.empty()
+      : id = null,
+        name = null,
+        alphabet = const <String>[];
+
+  final String? id;
+  final String? name;
+  final List<String> alphabet;
+
+  FlNodesAutomatonMetadata copyWith({
+    String? id,
+    String? name,
+    List<String>? alphabet,
+  }) {
+    return FlNodesAutomatonMetadata(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      alphabet: alphabet ?? this.alphabet,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'alphabet': alphabet,
+    };
+  }
+
+  factory FlNodesAutomatonMetadata.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return const FlNodesAutomatonMetadata.empty();
+    }
+    final rawAlphabet = json['alphabet'];
+    final alphabet = rawAlphabet is List
+        ? rawAlphabet.cast<String>()
+        : const <String>[];
+    return FlNodesAutomatonMetadata(
+      id: json['id'] as String?,
+      name: json['name'] as String?,
+      alphabet: alphabet,
+    );
+  }
+}
+
+/// Node rendered inside the fl_nodes editor.
+class FlNodesCanvasNode {
+  const FlNodesCanvasNode({
+    required this.id,
+    required this.label,
+    required this.x,
+    required this.y,
+    required this.isInitial,
+    required this.isAccepting,
+  });
+
+  final String id;
+  final String label;
+  final double x;
+  final double y;
+  final bool isInitial;
+  final bool isAccepting;
+
+  FlNodesCanvasNode copyWith({
+    String? id,
+    String? label,
+    double? x,
+    double? y,
+    bool? isInitial,
+    bool? isAccepting,
+  }) {
+    return FlNodesCanvasNode(
+      id: id ?? this.id,
+      label: label ?? this.label,
+      x: x ?? this.x,
+      y: y ?? this.y,
+      isInitial: isInitial ?? this.isInitial,
+      isAccepting: isAccepting ?? this.isAccepting,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'label': label,
+      'x': x,
+      'y': y,
+      'isInitial': isInitial,
+      'isAccepting': isAccepting,
+    };
+  }
+
+  factory FlNodesCanvasNode.fromJson(Map<String, dynamic> json) {
+    return FlNodesCanvasNode(
+      id: json['id'] as String,
+      label: (json['label'] as String?) ?? json['id'] as String,
+      x: (json['x'] as num?)?.toDouble() ?? 0,
+      y: (json['y'] as num?)?.toDouble() ?? 0,
+      isInitial: json['isInitial'] as bool? ?? false,
+      isAccepting: json['isAccepting'] as bool? ?? false,
+    );
+  }
+}
+
+/// Directed edge rendered inside the fl_nodes editor.
+class FlNodesCanvasEdge {
+  const FlNodesCanvasEdge({
+    required this.id,
+    required this.fromStateId,
+    required this.toStateId,
+    required this.symbols,
+    this.lambdaSymbol,
+    this.controlPointX,
+    this.controlPointY,
+  });
+
+  final String id;
+  final String fromStateId;
+  final String toStateId;
+  final List<String> symbols;
+  final String? lambdaSymbol;
+  final double? controlPointX;
+  final double? controlPointY;
+
+  String get label {
+    if (lambdaSymbol != null && lambdaSymbol!.isNotEmpty) {
+      return lambdaSymbol!;
+    }
+    final filtered = symbols.where((symbol) => symbol.isNotEmpty).toList();
+    return filtered.join(',');
+  }
+
+  FlNodesCanvasEdge copyWith({
+    String? id,
+    String? fromStateId,
+    String? toStateId,
+    List<String>? symbols,
+    String? lambdaSymbol,
+    double? controlPointX,
+    double? controlPointY,
+  }) {
+    return FlNodesCanvasEdge(
+      id: id ?? this.id,
+      fromStateId: fromStateId ?? this.fromStateId,
+      toStateId: toStateId ?? this.toStateId,
+      symbols: symbols ?? this.symbols,
+      lambdaSymbol: lambdaSymbol ?? this.lambdaSymbol,
+      controlPointX: controlPointX ?? this.controlPointX,
+      controlPointY: controlPointY ?? this.controlPointY,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'from': fromStateId,
+      'to': toStateId,
+      'symbols': symbols,
+      if (lambdaSymbol != null) 'lambdaSymbol': lambdaSymbol,
+      if (controlPointX != null) 'controlPointX': controlPointX,
+      if (controlPointY != null) 'controlPointY': controlPointY,
+    };
+  }
+
+  factory FlNodesCanvasEdge.fromJson(Map<String, dynamic> json) {
+    final rawSymbols = json['symbols'];
+    final symbols = rawSymbols is List
+        ? rawSymbols.cast<String>()
+        : rawSymbols is String && rawSymbols.isNotEmpty
+            ? rawSymbols.split(',')
+            : const <String>[];
+    return FlNodesCanvasEdge(
+      id: json['id'] as String,
+      fromStateId: json['from'] as String,
+      toStateId: json['to'] as String,
+      symbols: symbols,
+      lambdaSymbol: json['lambdaSymbol'] as String?,
+      controlPointX: (json['controlPointX'] as num?)?.toDouble(),
+      controlPointY: (json['controlPointY'] as num?)?.toDouble(),
+    );
+  }
+}
+
+/// Snapshot of nodes, edges and metadata rendered in the canvas.
+class FlNodesAutomatonSnapshot {
+  const FlNodesAutomatonSnapshot({
+    required this.nodes,
+    required this.edges,
+    required this.metadata,
+  });
+
+  const FlNodesAutomatonSnapshot.empty()
+      : nodes = const <FlNodesCanvasNode>[],
+        edges = const <FlNodesCanvasEdge>[],
+        metadata = const FlNodesAutomatonMetadata.empty();
+
+  final List<FlNodesCanvasNode> nodes;
+  final List<FlNodesCanvasEdge> edges;
+  final FlNodesAutomatonMetadata metadata;
+
+  FlNodesAutomatonSnapshot copyWith({
+    List<FlNodesCanvasNode>? nodes,
+    List<FlNodesCanvasEdge>? edges,
+    FlNodesAutomatonMetadata? metadata,
+  }) {
+    return FlNodesAutomatonSnapshot(
+      nodes: nodes ?? this.nodes,
+      edges: edges ?? this.edges,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'nodes': nodes.map((node) => node.toJson()).toList(),
+      'edges': edges.map((edge) => edge.toJson()).toList(),
+      'metadata': metadata.toJson(),
+    };
+  }
+
+  factory FlNodesAutomatonSnapshot.fromJson(Map<String, dynamic> json) {
+    final rawNodes = (json['nodes'] as List?)?.cast<Map>() ?? const [];
+    final rawEdges = (json['edges'] as List?)?.cast<Map>() ?? const [];
+    return FlNodesAutomatonSnapshot(
+      nodes: rawNodes
+          .map((node) => FlNodesCanvasNode.fromJson(
+                node.cast<String, dynamic>(),
+              ))
+          .toList(),
+      edges: rawEdges
+          .map((edge) => FlNodesCanvasEdge.fromJson(
+                edge.cast<String, dynamic>(),
+              ))
+          .toList(),
+      metadata: FlNodesAutomatonMetadata.fromJson(
+        (json['metadata'] as Map?)?.cast<String, dynamic>(),
+      ),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is FlNodesAutomatonSnapshot &&
+        const ListEquality<FlNodesCanvasNode>().equals(nodes, other.nodes) &&
+        const ListEquality<FlNodesCanvasEdge>().equals(edges, other.edges) &&
+        metadata.id == other.metadata.id &&
+        metadata.name == other.metadata.name &&
+        const ListEquality<String>().equals(
+          metadata.alphabet,
+          other.metadata.alphabet,
+        );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        const ListEquality<FlNodesCanvasNode>().hash(nodes),
+        const ListEquality<FlNodesCanvasEdge>().hash(edges),
+        metadata.id,
+        metadata.name,
+        const ListEquality<String>().hash(metadata.alphabet),
+      );
+}

--- a/test/features/canvas/fl_nodes/fl_nodes_automaton_mapper_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_automaton_mapper_test.dart
@@ -1,0 +1,152 @@
+import 'dart:math' as math;
+
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_automaton_mapper.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_canvas_models.dart';
+
+void main() {
+  group('FlNodesAutomatonMapper', () {
+    late FSA baseAutomaton;
+    late State initialState;
+    late State acceptingState;
+    late FSATransition transition;
+
+    setUp(() {
+      initialState = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      acceptingState = State(
+        id: 'q1',
+        label: 'q1',
+        position: Vector2(160, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      transition = FSATransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        inputSymbols: {'a'},
+        label: 'a',
+        controlPoint: Vector2(12, 18),
+      );
+
+      baseAutomaton = FSA(
+        id: 'auto',
+        name: 'Automaton',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+      );
+    });
+
+    test('toSnapshot captures nodes, edges and metadata', () {
+      final snapshot = FlNodesAutomatonMapper.toSnapshot(baseAutomaton);
+
+      expect(snapshot.metadata.id, equals('auto'));
+      expect(snapshot.metadata.name, equals('Automaton'));
+      expect(snapshot.metadata.alphabet, containsAll(['a']));
+
+      expect(snapshot.nodes, hasLength(2));
+      final nodeIds = snapshot.nodes.map((node) => node.id).toSet();
+      expect(nodeIds, containsAll({'q0', 'q1'}));
+
+      final acceptingNode =
+          snapshot.nodes.firstWhere((node) => node.id == 'q1');
+      expect(acceptingNode.isAccepting, isTrue);
+      expect(acceptingNode.x, closeTo(160, 0.0001));
+      expect(acceptingNode.y, closeTo(120, 0.0001));
+
+      expect(snapshot.edges, hasLength(1));
+      final edge = snapshot.edges.single;
+      expect(edge.id, equals('t0'));
+      expect(edge.fromStateId, equals('q0'));
+      expect(edge.toStateId, equals('q1'));
+      expect(edge.symbols, equals(['a']));
+      expect(edge.controlPointX, closeTo(12, 0.0001));
+      expect(edge.controlPointY, closeTo(18, 0.0001));
+    });
+
+    test('mergeIntoTemplate rebuilds automaton from snapshot', () {
+      final snapshot = FlNodesAutomatonSnapshot(
+        nodes: const [
+          FlNodesCanvasNode(
+            id: 'q0',
+            label: 'Start',
+            x: 40,
+            y: 60,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          FlNodesCanvasNode(
+            id: 'q1',
+            label: 'End',
+            x: 220,
+            y: 240,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          FlNodesCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: ['b'],
+            lambdaSymbol: null,
+            controlPointX: 8,
+            controlPointY: 12,
+          ),
+        ],
+        metadata: const FlNodesAutomatonMetadata(
+          id: 'auto',
+          name: 'Automaton',
+          alphabet: ['b'],
+        ),
+      );
+
+      final rebuilt = FlNodesAutomatonMapper.mergeIntoTemplate(
+        snapshot,
+        baseAutomaton,
+      );
+
+      expect(rebuilt.states, hasLength(2));
+      final rebuiltInitial =
+          rebuilt.states.firstWhere((state) => state.id == 'q0');
+      final rebuiltAccepting =
+          rebuilt.states.firstWhere((state) => state.id == 'q1');
+
+      expect(rebuiltInitial.label, equals('Start'));
+      expect(rebuiltInitial.position.x, closeTo(40, 0.0001));
+      expect(rebuiltInitial.position.y, closeTo(60, 0.0001));
+      expect(rebuiltInitial.isInitial, isTrue);
+
+      expect(rebuiltAccepting.label, equals('End'));
+      expect(rebuiltAccepting.isAccepting, isTrue);
+
+      final rebuiltTransition = rebuilt.fsaTransitions.single;
+      expect(rebuiltTransition.label, equals('b'));
+      expect(rebuiltTransition.inputSymbols, equals({'b'}));
+      expect(rebuiltTransition.controlPoint.x, closeTo(8, 0.0001));
+      expect(rebuiltTransition.controlPoint.y, closeTo(12, 0.0001));
+
+      expect(rebuilt.alphabet, containsAll({'a', 'b'}));
+      expect(rebuilt.initialState?.id, equals('q0'));
+      expect(rebuilt.acceptingStates.map((state) => state.id), contains('q1'));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add fl_nodes canvas models, mapper, and controller that forward user callbacks to AutomatonProvider
- migrate Draw2D bridge/mapper logic to reuse the shared fl_nodes snapshot structures
- cover the new mapper behaviour with unit tests

## Testing
- not run (flutter tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68df493a8578832eb81b217a52a8acda