### PR TITLE
Migrate automaton canvas to shared fl_nodes widget

### DIFF
--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/entities/automaton_entity.dart';
 import '../../core/models/fsa.dart';
@@ -334,9 +333,6 @@ class _FSAPageState extends ConsumerState<FSAPage> {
       return AutomatonCanvas(
         automaton: state.currentAutomaton,
         canvasKey: _canvasKey,
-        onAutomatonChanged: (automaton) {
-          ref.read(automatonProvider.notifier).updateAutomaton(automaton);
-        },
         simulationResult: state.simulationResult,
         showTrace: state.simulationResult != null,
       );
@@ -355,10 +351,6 @@ class _FSAPageState extends ConsumerState<FSAPage> {
           ),
         ],
       );
-    }
-
-    if (kIsWeb) {
-      return buildCanvasWithToolbar(buildAutomatonCanvas());
     }
 
     return buildCanvasWithToolbar(buildAutomatonCanvas());

--- a/lib/presentation/widgets/automaton_canvas_web.dart
+++ b/lib/presentation/widgets/automaton_canvas_web.dart
@@ -1,0 +1,2 @@
+/// Web now shares the Flutter-based automaton canvas implementation.
+export 'automaton_canvas_native.dart';


### PR DESCRIPTION
## Summary
- replace the legacy CustomPaint automaton canvas with the fl_nodes-backed editor that stays in sync with AutomatonProvider
- reuse the same Flutter implementation for web builds by exporting the shared canvas
- simplify the FSA page canvas wiring to rely on the new widget across platforms

## Testing
- not run (Flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68df4cd37b60832eae156115ce5daa4a