### PR TITLE
Route simulation highlights to fl_nodes controllers

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -8,11 +8,12 @@ import '../../../core/models/simulation_highlight.dart';
 import '../../../presentation/providers/automaton_provider.dart';
 import 'fl_nodes_automaton_mapper.dart';
 import 'fl_nodes_canvas_models.dart';
+import 'fl_nodes_highlight_controller.dart';
 import 'fl_nodes_label_field_editor.dart';
 
 /// Controller that keeps the [FlNodeEditorController] in sync with the
 /// [AutomatonProvider].
-class FlNodesCanvasController {
+class FlNodesCanvasController implements FlNodesHighlightController {
   FlNodesCanvasController({
     required AutomatonProvider automatonProvider,
     FlNodeEditorController? editorController,
@@ -166,10 +167,12 @@ class FlNodesCanvasController {
     controller.addNode(_statePrototypeId, offset: center);
   }
 
+  @override
   void applyHighlight(SimulationHighlight highlight) {
     highlightNotifier.value = highlight;
   }
 
+  @override
   void clearHighlight() {
     highlightNotifier.value = SimulationHighlight.empty;
   }

--- a/lib/features/canvas/fl_nodes/fl_nodes_highlight_channel.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_highlight_channel.dart
@@ -1,0 +1,21 @@
+import '../../../core/models/simulation_highlight.dart';
+import '../../../core/services/simulation_highlight_service.dart';
+import 'fl_nodes_highlight_controller.dart';
+
+/// Highlight channel that bridges [SimulationHighlightService] payloads to a
+/// fl_nodes canvas controller.
+class FlNodesSimulationHighlightChannel implements SimulationHighlightChannel {
+  FlNodesSimulationHighlightChannel(this._controller);
+
+  final FlNodesHighlightController _controller;
+
+  @override
+  void clear() {
+    _controller.clearHighlight();
+  }
+
+  @override
+  void send(SimulationHighlight highlight) {
+    _controller.applyHighlight(highlight);
+  }
+}

--- a/lib/features/canvas/fl_nodes/fl_nodes_highlight_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_highlight_controller.dart
@@ -1,0 +1,11 @@
+import '../../../core/models/simulation_highlight.dart';
+
+/// Common contract exposed by fl_nodes canvas controllers that support
+/// simulation highlights.
+abstract class FlNodesHighlightController {
+  /// Applies the provided [highlight] to the canvas.
+  void applyHighlight(SimulationHighlight highlight);
+
+  /// Clears any active highlight from the canvas.
+  void clearHighlight();
+}

--- a/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
@@ -7,12 +7,13 @@ import '../../../core/models/pda.dart';
 import '../../../core/models/simulation_highlight.dart';
 import '../../../presentation/providers/pda_editor_provider.dart';
 import 'fl_nodes_canvas_models.dart';
+import 'fl_nodes_highlight_controller.dart';
 import 'fl_nodes_label_field_editor.dart';
 import 'fl_nodes_pda_mapper.dart';
 
 /// Controller responsible for synchronising the fl_nodes editor with the
 /// [PDAEditorNotifier].
-class FlNodesPdaCanvasController {
+class FlNodesPdaCanvasController implements FlNodesHighlightController {
   FlNodesPdaCanvasController({
     required PDAEditorNotifier editorNotifier,
     FlNodeEditorController? editorController,
@@ -171,10 +172,12 @@ class FlNodesPdaCanvasController {
     controller.addNode(_statePrototypeId, offset: center);
   }
 
+  @override
   void applyHighlight(SimulationHighlight highlight) {
     highlightNotifier.value = highlight;
   }
 
+  @override
   void clearHighlight() {
     highlightNotifier.value = SimulationHighlight.empty;
   }

--- a/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
@@ -8,12 +8,13 @@ import '../../../core/models/tm_transition.dart';
 import '../../../core/models/simulation_highlight.dart';
 import '../../../presentation/providers/tm_editor_provider.dart';
 import 'fl_nodes_canvas_models.dart';
+import 'fl_nodes_highlight_controller.dart';
 import 'fl_nodes_label_field_editor.dart';
 import 'fl_nodes_tm_mapper.dart';
 
 /// Controller responsible for synchronising the fl_nodes editor with the
 /// [TMEditorNotifier].
-class FlNodesTmCanvasController {
+class FlNodesTmCanvasController implements FlNodesHighlightController {
   FlNodesTmCanvasController({
     required TMEditorNotifier editorNotifier,
     FlNodeEditorController? editorController,
@@ -172,10 +173,12 @@ class FlNodesTmCanvasController {
     controller.addNode(_statePrototypeId, offset: center);
   }
 
+  @override
   void applyHighlight(SimulationHighlight highlight) {
     highlightNotifier.value = highlight;
   }
 
+  @override
   void clearHighlight() {
     highlightNotifier.value = SimulationHighlight.empty;
   }

--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -12,6 +12,7 @@ import 'grammar_page.dart';
 import 'regex_page.dart';
 import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_canvas_controller.dart';
+import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 
 /// Page for working with Finite State Automata
 class FSAPage extends ConsumerStatefulWidget {
@@ -24,6 +25,7 @@ class FSAPage extends ConsumerStatefulWidget {
 class _FSAPageState extends ConsumerState<FSAPage> {
   final GlobalKey _canvasKey = GlobalKey();
   late final FlNodesCanvasController _canvasController;
+  late final FlNodesSimulationHighlightChannel _highlightChannel;
   late final SimulationHighlightService _highlightService;
 
   @override
@@ -35,18 +37,15 @@ class _FSAPageState extends ConsumerState<FSAPage> {
     _canvasController.synchronize(
       ref.read(automatonProvider).currentAutomaton,
     );
-    _highlightService = SimulationHighlightService(
-      dispatcher: _canvasController.applyHighlight,
-    );
-    SimulationHighlightService.registerGlobalDispatcher(
-      _canvasController.applyHighlight,
-    );
+    _highlightChannel = FlNodesSimulationHighlightChannel(_canvasController);
+    _highlightService = SimulationHighlightService(channel: _highlightChannel);
+    SimulationHighlightService.registerGlobalChannel(_highlightChannel);
   }
 
   @override
   void dispose() {
     _highlightService.clear();
-    SimulationHighlightService.registerGlobalDispatcher(null);
+    SimulationHighlightService.registerGlobalChannel(null);
     _canvasController.dispose();
     super.dispose();
   }

--- a/lib/presentation/widgets/simulation_panel.dart
+++ b/lib/presentation/widgets/simulation_panel.dart
@@ -374,7 +374,7 @@ class _SimulationPanelState extends State<SimulationPanel> {
                       _currentStepIndex = 0;
                       _isPlaying = false;
                       _simulationSteps.clear();
-                      _highlightService.clear();
+                      widget.highlightService.clear();
                     }
                   });
                   if (value) {
@@ -666,12 +666,12 @@ class _SimulationPanelState extends State<SimulationPanel> {
       _currentStepIndex = 0;
       _isPlaying = false;
     });
-    _highlightService.clear();
+    widget.highlightService.clear();
   }
 
   void _emitHighlightForCurrentStep() {
     if (!_isStepByStep || _simulationSteps.isEmpty) {
-      _highlightService.clear();
+      widget.highlightService.clear();
       return;
     }
 

--- a/test/core/services/simulation_highlight_service_test.dart
+++ b/test/core/services/simulation_highlight_service_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/simulation_highlight.dart';
+import 'package:jflutter/core/models/simulation_step.dart';
+import 'package:jflutter/core/services/simulation_highlight_service.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_highlight_controller.dart';
+
+class _FakeHighlightController implements FlNodesHighlightController {
+  SimulationHighlight? lastHighlight;
+  int clearCount = 0;
+
+  @override
+  void applyHighlight(SimulationHighlight highlight) {
+    lastHighlight = highlight;
+  }
+
+  @override
+  void clearHighlight() {
+    clearCount++;
+  }
+}
+
+void main() {
+  group('SimulationHighlightService', () {
+    test('emits highlight payload to fl_nodes controller', () {
+      final controller = _FakeHighlightController();
+      final channel = FlNodesSimulationHighlightChannel(controller);
+      final service = SimulationHighlightService(channel: channel);
+
+      final steps = [
+        const SimulationStep(
+          currentState: 'q0',
+          remainingInput: 'ab',
+          usedTransition: 't0',
+          stepNumber: 0,
+          nextState: 'q1',
+        ),
+        const SimulationStep(
+          currentState: 'q1',
+          remainingInput: 'b',
+          usedTransition: 't1',
+          stepNumber: 1,
+          nextState: 'q2',
+        ),
+      ];
+
+      final highlight = service.emitFromSteps(steps, 0);
+
+      expect(controller.lastHighlight, equals(highlight));
+      expect(highlight.stateIds, equals({'q0', 'q1'}));
+      expect(highlight.transitionIds, equals({'t0'}));
+    });
+
+    test('falls back to subsequent step when nextState is missing', () {
+      final controller = _FakeHighlightController();
+      final channel = FlNodesSimulationHighlightChannel(controller);
+      final service = SimulationHighlightService(channel: channel);
+
+      final steps = [
+        const SimulationStep(
+          currentState: 'q0',
+          remainingInput: 'a',
+          usedTransition: 't0',
+          stepNumber: 0,
+          nextState: '',
+        ),
+        const SimulationStep(
+          currentState: 'q1',
+          remainingInput: '',
+          usedTransition: null,
+          stepNumber: 1,
+        ),
+      ];
+
+      final highlight = service.emitFromSteps(steps, 0);
+
+      expect(controller.lastHighlight, equals(highlight));
+      expect(highlight.stateIds, equals({'q0', 'q1'}));
+      expect(highlight.transitionIds, equals({'t0'}));
+    });
+
+    test('clear delegates to the channel controller', () {
+      final controller = _FakeHighlightController();
+      final channel = FlNodesSimulationHighlightChannel(controller);
+      final service = SimulationHighlightService(channel: channel);
+
+      service.clear();
+
+      expect(controller.clearCount, equals(1));
+      expect(controller.lastHighlight, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- replace SimulationHighlightService's dispatcher with an injectable channel abstraction
- bridge the service to fl_nodes canvas controllers and keep simulation panels dispatching highlights on step changes
- add unit coverage asserting the payload sent to fl_nodes highlight controllers

## Testing
- Unable to run `flutter test test/core/services/simulation_highlight_service_test.dart` (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfb4c4b108832e983457d76c6e35bd