### PR TITLE
Remove legacy Draw2D setting persistence

### DIFF
--- a/lib/data/repositories/settings_repository_impl.dart
+++ b/lib/data/repositories/settings_repository_impl.dart
@@ -20,13 +20,15 @@ class SharedPreferencesSettingsRepository implements SettingsRepository {
   static const String _gridSizeKey = 'settings_grid_size';
   static const String _nodeSizeKey = 'settings_node_size';
   static const String _fontSizeKey = 'settings_font_size';
+  static const String _legacyUseDraw2dCanvasKey =
+      'settings_use_draw2d_canvas';
   final SettingsStorage _storage;
 
   @override
   Future<SettingsModel> loadSettings() async {
     const defaults = SettingsModel();
 
-    return SettingsModel(
+    final settings = SettingsModel(
       emptyStringSymbol:
           await _storage.readString(_emptyStringSymbolKey) ??
           defaults.emptyStringSymbol,
@@ -45,6 +47,8 @@ class SharedPreferencesSettingsRepository implements SettingsRepository {
       nodeSize: await _storage.readDouble(_nodeSizeKey) ?? defaults.nodeSize,
       fontSize: await _storage.readDouble(_fontSizeKey) ?? defaults.fontSize,
     );
+    await _removeLegacyCanvasPreference();
+    return settings;
   }
 
   @override
@@ -64,6 +68,15 @@ class SharedPreferencesSettingsRepository implements SettingsRepository {
 
     if (results.any((success) => !success)) {
       throw Exception('Failed to save settings');
+    }
+    await _removeLegacyCanvasPreference();
+  }
+
+  Future<void> _removeLegacyCanvasPreference() async {
+    try {
+      await _storage.remove(_legacyUseDraw2dCanvasKey);
+    } catch (_) {
+      // Ignore cleanup failures – they should not block settings operations.
     }
   }
 }

--- a/lib/data/storage/settings_storage.dart
+++ b/lib/data/storage/settings_storage.dart
@@ -9,6 +9,7 @@ abstract class SettingsStorage {
   Future<bool> writeString(String key, String value);
   Future<bool> writeBool(String key, bool value);
   Future<bool> writeDouble(String key, double value);
+  Future<bool> remove(String key);
 }
 
 /// [SettingsStorage] backed by [SharedPreferences].
@@ -62,6 +63,12 @@ class SharedPreferencesSettingsStorage implements SettingsStorage {
     final prefs = await _getPreferences();
     return prefs.setDouble(key, value);
   }
+
+  @override
+  Future<bool> remove(String key) async {
+    final prefs = await _getPreferences();
+    return prefs.remove(key);
+  }
 }
 
 /// In-memory implementation of [SettingsStorage] used in tests.
@@ -97,5 +104,10 @@ class InMemorySettingsStorage implements SettingsStorage {
   Future<bool> writeDouble(String key, double value) async {
     _values[key] = value;
     return true;
+  }
+
+  @override
+  Future<bool> remove(String key) async {
+    return _values.remove(key) != null;
   }
 }

--- a/test/unit/data/settings_repository_impl_test.dart
+++ b/test/unit/data/settings_repository_impl_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/core/models/settings_model.dart';
+import 'package:jflutter/data/repositories/settings_repository_impl.dart';
+import 'package:jflutter/data/storage/settings_storage.dart';
+
+void main() {
+  group('SharedPreferencesSettingsRepository legacy cleanup', () {
+    late InMemorySettingsStorage storage;
+    late SharedPreferencesSettingsRepository repository;
+
+    setUp(() {
+      storage = InMemorySettingsStorage({
+        'settings_use_draw2d_canvas': true,
+      });
+      repository = SharedPreferencesSettingsRepository(storage: storage);
+    });
+
+    test('loadSettings removes legacy Draw2D flag', () async {
+      final settings = await repository.loadSettings();
+
+      expect(settings, isA<SettingsModel>());
+      final legacyValue = await storage.readBool('settings_use_draw2d_canvas');
+      expect(legacyValue, isNull);
+    });
+
+    test('saveSettings removes legacy Draw2D flag', () async {
+      await repository.saveSettings(const SettingsModel());
+
+      final legacyValue = await storage.readBool('settings_use_draw2d_canvas');
+      expect(legacyValue, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- extend the settings storage interface with a remove helper so repositories can clean up legacy values
- purge the deprecated Draw2D canvas preference while loading and saving persisted settings
- cover the cleanup logic with a repository test using the in-memory storage

## Testing
- flutter test test/unit/data/settings_repository_impl_test.dart *(fails: Flutter SDK is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dfbbf9521c832e8bbd497949ec6931