### PR TITLE
Add tests for fl_nodes mappers and controllers

### DIFF
--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
@@ -1,0 +1,322 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:fl_nodes/fl_nodes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/repositories/automaton_repository.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/data/services/automaton_service.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+
+class _FakeLayoutRepository implements LayoutRepository {
+  Future<AutomatonResult> _unsupported() async {
+    return ResultFactory.failure('unsupported');
+  }
+
+  @override
+  Future<AutomatonResult> applyAutoLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) =>
+      _unsupported();
+}
+
+class _RecordingAutomatonProvider extends AutomatonProvider {
+  _RecordingAutomatonProvider()
+      : super(
+          automatonService: AutomatonService(),
+          layoutRepository: _FakeLayoutRepository(),
+        );
+
+  final List<Map<String, Object?>> addStateCalls = [];
+  final List<Map<String, Object?>> updateLabelCalls = [];
+  final List<Map<String, Object?>> transitionCalls = [];
+
+  @override
+  void addState({
+    required String id,
+    required String label,
+    required double x,
+    required double y,
+    bool? isInitial,
+    bool? isAccepting,
+  }) {
+    addStateCalls.add({
+      'id': id,
+      'label': label,
+      'x': x,
+      'y': y,
+      'isInitial': isInitial,
+      'isAccepting': isAccepting,
+    });
+  }
+
+  @override
+  void removeState({required String id}) {
+    // Intentionally left blank for tests.
+  }
+
+  @override
+  void moveState({
+    required String id,
+    required double x,
+    required double y,
+  }) {
+    // Intentionally left blank for tests.
+  }
+
+  @override
+  void updateStateLabel({
+    required String id,
+    required String label,
+  }) {
+    updateLabelCalls.add({'id': id, 'label': label});
+  }
+
+  @override
+  void addOrUpdateTransition({
+    required String id,
+    required String fromStateId,
+    required String toStateId,
+    String? label,
+  }) {
+    transitionCalls.add({
+      'id': id,
+      'fromStateId': fromStateId,
+      'toStateId': toStateId,
+      'label': label,
+    });
+  }
+
+  @override
+  void removeTransition({required String id}) {
+    // Intentionally left blank for tests.
+  }
+}
+
+Future<void> _flushEvents() async {
+  await Future<void>.delayed(Duration.zero);
+}
+
+NodeInstance _buildNode(
+  FlNodesCanvasController controller, {
+  required String id,
+  required String label,
+  required Offset offset,
+}) {
+  final prototype = controller.controller.nodePrototypes['automaton_state']!;
+  final inputPort =
+      prototype.ports.firstWhere((port) => port.idName == 'incoming');
+  final outputPort =
+      prototype.ports.firstWhere((port) => port.idName == 'outgoing');
+  final labelField =
+      prototype.fields.firstWhere((field) => field.idName == 'label');
+
+  return NodeInstance(
+    id: id,
+    prototype: prototype,
+    ports: {
+      'incoming': PortInstance(prototype: inputPort, state: PortState()),
+      'outgoing': PortInstance(prototype: outputPort, state: PortState()),
+    },
+    fields: {
+      'label': FieldInstance(prototype: labelField, data: label),
+    },
+    state: NodeState(),
+    offset: offset,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FlNodesCanvasController', () {
+    late _RecordingAutomatonProvider provider;
+    late FlNodesCanvasController controller;
+
+    setUp(() {
+      provider = _RecordingAutomatonProvider();
+      controller = FlNodesCanvasController(
+        automatonProvider: provider,
+        editorController: FlNodeEditorController(),
+      );
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('synchronize populates nodes and edges from automaton', () {
+      final q0 = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final q1 = State(
+        id: 'q1',
+        label: 'q1',
+        position: Vector2(120, 80),
+        isAccepting: true,
+      );
+      final transition = FSATransition(
+        id: 't0',
+        fromState: q0,
+        toState: q1,
+        inputSymbols: {'a'},
+        label: 'a',
+      );
+      final automaton = FSA(
+        id: 'auto',
+        name: 'Automaton',
+        states: {q0, q1},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: q0,
+        acceptingStates: {q1},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+      );
+
+      controller.synchronize(automaton);
+
+      final encodedInitial = controller.nodeById('q0');
+      final encodedEdge = controller.edgeById('t0');
+
+      expect(encodedInitial, isNotNull);
+      expect(encodedInitial!.isInitial, isTrue);
+      expect(encodedInitial.x, closeTo(0, 0.0001));
+      expect(encodedInitial.y, closeTo(0, 0.0001));
+
+      expect(encodedEdge, isNotNull);
+      expect(encodedEdge!.fromStateId, equals('q0'));
+      expect(encodedEdge.toStateId, equals('q1'));
+      expect(encodedEdge.symbols, equals(['a']));
+    });
+
+    test('propagates AddNodeEvent payload to provider', () async {
+      final node = _buildNode(
+        controller,
+        id: 'q2',
+        label: 'S',
+        offset: const Offset(42, 24),
+      );
+
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'event-add-node'),
+      );
+
+      await _flushEvents();
+
+      expect(provider.addStateCalls, hasLength(1));
+      final call = provider.addStateCalls.single;
+      expect(call['id'], equals('q2'));
+      expect(call['label'], equals('S'));
+      expect(call['x'], equals(42.0));
+      expect(call['y'], equals(24.0));
+    });
+
+    test('updates labels on NodeFieldEvent submissions', () async {
+      final q0 = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final automaton = FSA(
+        id: 'auto',
+        name: 'Automaton',
+        states: {q0},
+        transitions: {},
+        alphabet: {'a'},
+        initialState: q0,
+        acceptingStates: {},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+      );
+
+      controller.synchronize(automaton);
+
+      controller.controller.eventBus.emit(
+        const NodeFieldEvent(
+          'q0',
+          '  renamed  ',
+          FieldEventType.submit,
+          id: 'event-field',
+        ),
+      );
+
+      await _flushEvents();
+
+      expect(provider.updateLabelCalls, hasLength(1));
+      final call = provider.updateLabelCalls.single;
+      expect(call['id'], equals('q0'));
+      expect(call['label'], equals('renamed'));
+      expect(controller.nodeById('q0')!.label, equals('renamed'));
+    });
+
+    test('delegates AddLinkEvent to provider', () async {
+      controller.synchronize(null);
+      final node = _buildNode(
+        controller,
+        id: 'q0',
+        label: 'q0',
+        offset: Offset.zero,
+      );
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'seed'),
+      );
+      await _flushEvents();
+
+      final link = Link(
+        id: 't0',
+        fromTo: (
+          from: 'q0',
+          to: 'outgoing',
+          fromPort: 'q1',
+          toPort: 'incoming',
+        ),
+        state: LinkState(),
+      );
+
+      controller.controller.eventBus.emit(
+        AddLinkEvent(link, id: 'event-link'),
+      );
+
+      await _flushEvents();
+
+      expect(provider.transitionCalls, hasLength(1));
+      final call = provider.transitionCalls.single;
+      expect(call['id'], equals('t0'));
+      expect(call['fromStateId'], equals('q0'));
+      expect(call['toStateId'], equals('q1'));
+    });
+  });
+}

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
@@ -1,0 +1,331 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:fl_nodes/fl_nodes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/pda.dart';
+import 'package:jflutter/core/models/pda_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+
+class _RecordingPdaEditorNotifier extends PDAEditorNotifier {
+  final List<Map<String, Object?>> stateCalls = [];
+  final List<Map<String, Object?>> transitionCalls = [];
+
+  @override
+  PDA? addOrUpdateState({
+    required String id,
+    required String label,
+    required double x,
+    required double y,
+  }) {
+    stateCalls.add({
+      'type': 'upsert',
+      'id': id,
+      'label': label,
+      'x': x,
+      'y': y,
+    });
+    return null;
+  }
+
+  @override
+  PDA? removeState({required String id}) {
+    return null;
+  }
+
+  @override
+  PDA? updateStateLabel({
+    required String id,
+    required String label,
+  }) {
+    stateCalls.add({
+      'type': 'label',
+      'id': id,
+      'label': label,
+    });
+    return null;
+  }
+
+  @override
+  PDA? moveState({
+    required String id,
+    required double x,
+    required double y,
+  }) {
+    stateCalls.add({
+      'type': 'move',
+      'id': id,
+      'x': x,
+      'y': y,
+    });
+    return null;
+  }
+
+  @override
+  PDA? upsertTransition({
+    required String id,
+    String? fromStateId,
+    String? toStateId,
+    String? label,
+    String? readSymbol,
+    String? popSymbol,
+    String? pushSymbol,
+    bool? isLambdaInput,
+    bool? isLambdaPop,
+    bool? isLambdaPush,
+  }) {
+    transitionCalls.add({
+      'id': id,
+      'fromStateId': fromStateId,
+      'toStateId': toStateId,
+      'label': label,
+      'readSymbol': readSymbol,
+      'popSymbol': popSymbol,
+      'pushSymbol': pushSymbol,
+      'isLambdaInput': isLambdaInput,
+      'isLambdaPop': isLambdaPop,
+      'isLambdaPush': isLambdaPush,
+    });
+    return null;
+  }
+
+  @override
+  PDA? removeTransition({required String id}) {
+    return null;
+  }
+}
+
+Future<void> _flushEvents() async {
+  await Future<void>.delayed(Duration.zero);
+}
+
+NodeInstance _buildNode(
+  FlNodesPdaCanvasController controller, {
+  required String id,
+  required String label,
+  required Offset offset,
+}) {
+  final prototype = controller.controller.nodePrototypes['pda_state']!;
+  final inputPort =
+      prototype.ports.firstWhere((port) => port.idName == 'incoming');
+  final outputPort =
+      prototype.ports.firstWhere((port) => port.idName == 'outgoing');
+  final labelField =
+      prototype.fields.firstWhere((field) => field.idName == 'label');
+
+  return NodeInstance(
+    id: id,
+    prototype: prototype,
+    ports: {
+      'incoming': PortInstance(prototype: inputPort, state: PortState()),
+      'outgoing': PortInstance(prototype: outputPort, state: PortState()),
+    },
+    fields: {
+      'label': FieldInstance(prototype: labelField, data: label),
+    },
+    state: NodeState(),
+    offset: offset,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FlNodesPdaCanvasController', () {
+    late _RecordingPdaEditorNotifier notifier;
+    late FlNodesPdaCanvasController controller;
+
+    setUp(() {
+      notifier = _RecordingPdaEditorNotifier();
+      controller = FlNodesPdaCanvasController(
+        editorNotifier: notifier,
+        editorController: FlNodeEditorController(),
+      );
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('synchronize mirrors PDA data into controller state', () {
+      final q0 = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final q1 = State(
+        id: 'q1',
+        label: 'accept',
+        position: Vector2(100, 80),
+        isAccepting: true,
+      );
+      final transition = PDATransition(
+        id: 't0',
+        fromState: q0,
+        toState: q1,
+        label: 'a,Z/AZ',
+        controlPoint: Vector2(24, 32),
+        type: TransitionType.deterministic,
+        inputSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'AZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+      final pda = PDA(
+        id: 'pda1',
+        name: 'Sample PDA',
+        states: {q0, q1},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: q0,
+        acceptingStates: {q1},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        stackAlphabet: {'Z', 'A'},
+        initialStackSymbol: 'Z',
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+
+      controller.synchronize(pda);
+
+      final encodedNode = controller.nodeById('q0');
+      final encodedEdge = controller.edgeById('t0');
+
+      expect(encodedNode, isNotNull);
+      expect(encodedNode!.isInitial, isTrue);
+      expect(encodedNode.x, closeTo(0, 0.0001));
+      expect(encodedNode.y, closeTo(0, 0.0001));
+
+      expect(encodedEdge, isNotNull);
+      expect(encodedEdge!.readSymbol, equals('a'));
+      expect(encodedEdge.popSymbol, equals('Z'));
+      expect(encodedEdge.pushSymbol, equals('AZ'));
+      expect(encodedEdge.isLambdaInput, isFalse);
+      expect(encodedEdge.isLambdaPop, isFalse);
+      expect(encodedEdge.isLambdaPush, isFalse);
+      expect(encodedEdge.controlPointX, closeTo(24, 0.0001));
+      expect(encodedEdge.controlPointY, closeTo(32, 0.0001));
+    });
+
+    test('captures AddNodeEvent data for PDA states', () async {
+      final node = _buildNode(
+        controller,
+        id: 'q2',
+        label: 'mid',
+        offset: const Offset(12, 18),
+      );
+
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'event-add'),
+      );
+
+      await _flushEvents();
+
+      expect(notifier.stateCalls, hasLength(1));
+      final call = notifier.stateCalls.single;
+      expect(call['type'], equals('upsert'));
+      expect(call['id'], equals('q2'));
+      expect(call['label'], equals('mid'));
+      expect(call['x'], equals(12.0));
+      expect(call['y'], equals(18.0));
+    });
+
+    test('updates labels via NodeFieldEvent submissions', () async {
+      final q0 = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final pda = PDA(
+        id: 'pda1',
+        name: 'Sample PDA',
+        states: {q0},
+        transitions: {},
+        alphabet: {'a'},
+        initialState: q0,
+        acceptingStates: {},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        stackAlphabet: {'Z'},
+        initialStackSymbol: 'Z',
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+
+      controller.synchronize(pda);
+
+      controller.controller.eventBus.emit(
+        const NodeFieldEvent(
+          'q0',
+          '  renamed  ',
+          FieldEventType.submit,
+          id: 'event-field',
+        ),
+      );
+
+      await _flushEvents();
+
+      expect(notifier.stateCalls.length, equals(1));
+      final call = notifier.stateCalls.single;
+      expect(call['type'], equals('label'));
+      expect(call['id'], equals('q0'));
+      expect(call['label'], equals('renamed'));
+      expect(controller.nodeById('q0')!.label, equals('renamed'));
+    });
+
+    test('creates lambda PDA transitions on AddLinkEvent', () async {
+      final node = _buildNode(
+        controller,
+        id: 'q0',
+        label: 'start',
+        offset: Offset.zero,
+      );
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'seed'),
+      );
+      await _flushEvents();
+
+      final link = Link(
+        id: 't0',
+        fromTo: (
+          from: 'q0',
+          to: 'outgoing',
+          fromPort: 'q1',
+          toPort: 'incoming',
+        ),
+        state: LinkState(),
+      );
+
+      controller.controller.eventBus.emit(
+        AddLinkEvent(link, id: 'event-link'),
+      );
+
+      await _flushEvents();
+
+      expect(notifier.transitionCalls, hasLength(1));
+      final call = notifier.transitionCalls.single;
+      expect(call['id'], equals('t0'));
+      expect(call['fromStateId'], equals('q0'));
+      expect(call['toStateId'], equals('q1'));
+      expect(call['readSymbol'], equals(''));
+      expect(call['popSymbol'], equals(''));
+      expect(call['pushSymbol'], equals(''));
+      expect(call['isLambdaInput'], isTrue);
+      expect(call['isLambdaPop'], isTrue);
+      expect(call['isLambdaPush'], isTrue);
+    });
+  });
+}

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_mapper_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_mapper_test.dart
@@ -1,0 +1,176 @@
+import 'dart:math' as math;
+
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/pda.dart';
+import 'package:jflutter/core/models/pda_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_canvas_models.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_pda_mapper.dart';
+
+void main() {
+  group('FlNodesPdaMapper', () {
+    late State initialState;
+    late State acceptingState;
+    late PDATransition transition;
+    late PDA basePda;
+
+    setUp(() {
+      initialState = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      acceptingState = State(
+        id: 'q1',
+        label: 'accept',
+        position: Vector2(160, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      transition = PDATransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        label: 'read a push Z',
+        controlPoint: Vector2(30, 40),
+        type: TransitionType.deterministic,
+        inputSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'AZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+      basePda = PDA(
+        id: 'pda1',
+        name: 'Sample PDA',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        stackAlphabet: {'Z', 'A'},
+        initialStackSymbol: 'Z',
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+    });
+
+    test('toSnapshot encodes states and transitions with PDA metadata', () {
+      final snapshot = FlNodesPdaMapper.toSnapshot(basePda);
+
+      expect(snapshot.metadata.id, equals('pda1'));
+      expect(snapshot.metadata.name, equals('Sample PDA'));
+      expect(snapshot.metadata.alphabet, contains('a'));
+
+      expect(snapshot.nodes, hasLength(2));
+      final nodeIds = snapshot.nodes.map((node) => node.id).toSet();
+      expect(nodeIds, containsAll({'q0', 'q1'}));
+
+      final encodedInitial =
+          snapshot.nodes.firstWhere((node) => node.id == 'q0');
+      expect(encodedInitial.isInitial, isTrue);
+      expect(encodedInitial.x, closeTo(0, 0.0001));
+      expect(encodedInitial.y, closeTo(0, 0.0001));
+
+      expect(snapshot.edges, hasLength(1));
+      final edge = snapshot.edges.single;
+      expect(edge.id, equals('t0'));
+      expect(edge.fromStateId, equals('q0'));
+      expect(edge.toStateId, equals('q1'));
+      expect(edge.readSymbol, equals('a'));
+      expect(edge.popSymbol, equals('Z'));
+      expect(edge.pushSymbol, equals('AZ'));
+      expect(edge.controlPointX, closeTo(30, 0.0001));
+      expect(edge.controlPointY, closeTo(40, 0.0001));
+      expect(edge.isLambdaInput, isFalse);
+      expect(edge.isLambdaPop, isFalse);
+      expect(edge.isLambdaPush, isFalse);
+    });
+
+    test('mergeIntoTemplate rebuilds PDA from snapshot', () {
+      final template = basePda.copyWith(
+        states: {initialState},
+        transitions: {},
+        alphabet: {'a'},
+        acceptingStates: {initialState},
+      );
+
+      final snapshot = FlNodesAutomatonSnapshot(
+        nodes: const [
+          FlNodesCanvasNode(
+            id: 'q0',
+            label: 'start',
+            x: 10,
+            y: 20,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          FlNodesCanvasNode(
+            id: 'q1',
+            label: 'accept',
+            x: 200,
+            y: 160,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          FlNodesCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: <String>[],
+            controlPointX: 18,
+            controlPointY: 24,
+            readSymbol: 'b',
+            popSymbol: 'Z',
+            pushSymbol: 'XZ',
+            isLambdaInput: false,
+            isLambdaPop: false,
+            isLambdaPush: false,
+          ),
+        ],
+        metadata: const FlNodesAutomatonMetadata(
+          id: 'pda1',
+          name: 'Sample PDA',
+          alphabet: ['a', 'b'],
+        ),
+      );
+
+      final rebuilt = FlNodesPdaMapper.mergeIntoTemplate(snapshot, template);
+
+      expect(rebuilt.states.length, equals(2));
+      final rebuiltInitial =
+          rebuilt.states.firstWhere((state) => state.id == 'q0');
+      final rebuiltAccepting =
+          rebuilt.states.firstWhere((state) => state.id == 'q1');
+      expect(rebuiltInitial.position.x, closeTo(10, 0.0001));
+      expect(rebuiltInitial.position.y, closeTo(20, 0.0001));
+      expect(rebuiltAccepting.isAccepting, isTrue);
+
+      final rebuiltTransition = rebuilt.pdaTransitions.single;
+      expect(rebuiltTransition.inputSymbol, equals('b'));
+      expect(rebuiltTransition.popSymbol, equals('Z'));
+      expect(rebuiltTransition.pushSymbol, equals('XZ'));
+      expect(rebuiltTransition.controlPoint.x, closeTo(18, 0.0001));
+      expect(rebuiltTransition.controlPoint.y, closeTo(24, 0.0001));
+      expect(rebuiltTransition.isLambdaInput, isFalse);
+      expect(rebuiltTransition.isLambdaPop, isFalse);
+      expect(rebuiltTransition.isLambdaPush, isFalse);
+
+      expect(rebuilt.alphabet, containsAll({'a', 'b'}));
+      expect(rebuilt.stackAlphabet, containsAll({'Z', 'A', 'XZ'}));
+      expect(rebuilt.initialState?.id, equals('q0'));
+      expect(rebuilt.acceptingStates.map((state) => state.id), contains('q1'));
+    });
+  });
+}

--- a/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
@@ -1,0 +1,303 @@
+import 'dart:async';
+import 'dart:math' as math;
+
+import 'package:fl_nodes/fl_nodes.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+
+class _RecordingTmEditorNotifier extends TMEditorNotifier {
+  final List<Map<String, Object?>> upsertStateCalls = [];
+  final List<Map<String, Object?>> updateStateLabelCalls = [];
+  final List<Map<String, Object?>> transitionCalls = [];
+
+  @override
+  TM? upsertState({
+    required String id,
+    required String label,
+    required double x,
+    required double y,
+    bool? isInitial,
+    bool? isAccepting,
+  }) {
+    upsertStateCalls.add({
+      'id': id,
+      'label': label,
+      'x': x,
+      'y': y,
+      'isInitial': isInitial,
+      'isAccepting': isAccepting,
+    });
+    return null;
+  }
+
+  @override
+  TM? moveState({
+    required String id,
+    required double x,
+    required double y,
+  }) {
+    return null;
+  }
+
+  @override
+  TM? updateStateLabel({
+    required String id,
+    required String label,
+  }) {
+    updateStateLabelCalls.add({'id': id, 'label': label});
+    return null;
+  }
+
+  @override
+  TM? addOrUpdateTransition({
+    required String id,
+    required String fromStateId,
+    required String toStateId,
+    String? readSymbol,
+    String? writeSymbol,
+    TapeDirection? direction,
+    Vector2? controlPoint,
+  }) {
+    transitionCalls.add({
+      'id': id,
+      'fromStateId': fromStateId,
+      'toStateId': toStateId,
+      'readSymbol': readSymbol,
+      'writeSymbol': writeSymbol,
+      'direction': direction,
+      'controlPoint': controlPoint,
+    });
+    return null;
+  }
+
+  @override
+  TM? removeTransition({required String id}) {
+    return null;
+  }
+}
+
+Future<void> _flushEvents() async {
+  await Future<void>.delayed(Duration.zero);
+}
+
+NodeInstance _buildNode(
+  FlNodesTmCanvasController controller, {
+  required String id,
+  required String label,
+  required Offset offset,
+}) {
+  final prototype = controller.controller.nodePrototypes['tm_state']!;
+  final inputPort =
+      prototype.ports.firstWhere((port) => port.idName == 'incoming');
+  final outputPort =
+      prototype.ports.firstWhere((port) => port.idName == 'outgoing');
+  final labelField =
+      prototype.fields.firstWhere((field) => field.idName == 'label');
+
+  return NodeInstance(
+    id: id,
+    prototype: prototype,
+    ports: {
+      'incoming': PortInstance(prototype: inputPort, state: PortState()),
+      'outgoing': PortInstance(prototype: outputPort, state: PortState()),
+    },
+    fields: {
+      'label': FieldInstance(prototype: labelField, data: label),
+    },
+    state: NodeState(),
+    offset: offset,
+  );
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('FlNodesTmCanvasController', () {
+    late _RecordingTmEditorNotifier notifier;
+    late FlNodesTmCanvasController controller;
+
+    setUp(() {
+      notifier = _RecordingTmEditorNotifier();
+      controller = FlNodesTmCanvasController(
+        editorNotifier: notifier,
+        editorController: FlNodeEditorController(),
+      );
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    test('synchronize rebuilds controller state from TM', () {
+      final q0 = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final q1 = State(
+        id: 'q1',
+        label: 'halt',
+        position: Vector2(120, 80),
+        isAccepting: true,
+      );
+      final transition = TMTransition(
+        id: 't0',
+        fromState: q0,
+        toState: q1,
+        label: '1/0,R',
+        controlPoint: Vector2(60, 20),
+        readSymbol: '1',
+        writeSymbol: '0',
+        direction: TapeDirection.right,
+      );
+      final tm = TM(
+        id: 'tm1',
+        name: 'Binary inverter',
+        states: {q0, q1},
+        transitions: {transition},
+        alphabet: {'0', '1'},
+        initialState: q0,
+        acceptingStates: {q1},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 2),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+        tapeAlphabet: {'0', '1', 'B'},
+        blankSymbol: 'B',
+        tapeCount: 1,
+      );
+
+      controller.synchronize(tm);
+
+      final encodedNode = controller.nodeById('q0');
+      final encodedEdge = controller.edgeById('t0');
+
+      expect(encodedNode, isNotNull);
+      expect(encodedNode!.isInitial, isTrue);
+      expect(encodedNode.x, closeTo(0, 0.0001));
+      expect(encodedNode.y, closeTo(0, 0.0001));
+
+      expect(encodedEdge, isNotNull);
+      expect(encodedEdge!.readSymbol, equals('1'));
+      expect(encodedEdge.writeSymbol, equals('0'));
+      expect(encodedEdge.direction, equals(TapeDirection.right));
+      expect(encodedEdge.controlPointX, closeTo(60, 0.0001));
+      expect(encodedEdge.controlPointY, closeTo(20, 0.0001));
+    });
+
+    test('records AddNodeEvent invocations', () async {
+      final node = _buildNode(
+        controller,
+        id: 'q2',
+        label: 'mid',
+        offset: const Offset(30, 18),
+      );
+
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'event-add'),
+      );
+
+      await _flushEvents();
+
+      expect(notifier.upsertStateCalls, hasLength(1));
+      final call = notifier.upsertStateCalls.single;
+      expect(call['id'], equals('q2'));
+      expect(call['label'], equals('mid'));
+      expect(call['x'], equals(30.0));
+      expect(call['y'], equals(18.0));
+    });
+
+    test('delegates label submissions through NodeFieldEvent', () async {
+      final q0 = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+      );
+      final tm = TM(
+        id: 'tm1',
+        name: 'Binary inverter',
+        states: {q0},
+        transitions: {},
+        alphabet: {'0', '1'},
+        initialState: q0,
+        acceptingStates: {},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+        tapeAlphabet: {'0', '1', 'B'},
+        blankSymbol: 'B',
+        tapeCount: 1,
+      );
+
+      controller.synchronize(tm);
+
+      controller.controller.eventBus.emit(
+        const NodeFieldEvent(
+          'q0',
+          '  renamed  ',
+          FieldEventType.submit,
+          id: 'event-field',
+        ),
+      );
+
+      await _flushEvents();
+
+      expect(notifier.updateStateLabelCalls, hasLength(1));
+      final call = notifier.updateStateLabelCalls.single;
+      expect(call['id'], equals('q0'));
+      expect(call['label'], equals('renamed'));
+      expect(controller.nodeById('q0')!.label, equals('renamed'));
+    });
+
+    test('creates TM transition stubs on AddLinkEvent', () async {
+      final node = _buildNode(
+        controller,
+        id: 'q0',
+        label: 'start',
+        offset: Offset.zero,
+      );
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'seed'),
+      );
+      await _flushEvents();
+
+      final link = Link(
+        id: 't0',
+        fromTo: (
+          from: 'q0',
+          to: 'outgoing',
+          fromPort: 'q1',
+          toPort: 'incoming',
+        ),
+        state: LinkState(),
+      );
+
+      controller.controller.eventBus.emit(
+        AddLinkEvent(link, id: 'event-link'),
+      );
+
+      await _flushEvents();
+
+      expect(notifier.transitionCalls, hasLength(1));
+      final call = notifier.transitionCalls.single;
+      expect(call['id'], equals('t0'));
+      expect(call['fromStateId'], equals('q0'));
+      expect(call['toStateId'], equals('q1'));
+      expect(call['readSymbol'], equals(''));
+      expect(call['writeSymbol'], equals(''));
+      expect(call['direction'], equals(TapeDirection.right));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a dedicated suite for `FlNodesPdaMapper` covering snapshot encoding and template merge behaviour
- introduce unit tests for the FSA, TM and PDA fl_nodes canvas controllers to ensure events are forwarded to their providers

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68dfbe868afc832eb97449c9fd757c26