### PR TITLE
Fix fl_nodes link semantics

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -252,8 +252,8 @@ class FlNodesCanvasController implements FlNodesHighlightController {
       id: edge.id,
       fromTo: (
         from: edge.fromStateId,
-        to: _outPortId,
-        fromPort: edge.toStateId,
+        to: edge.toStateId,
+        fromPort: _outPortId,
         toPort: _inPortId,
       ),
       state: LinkState(),
@@ -343,7 +343,14 @@ class FlNodesCanvasController implements FlNodesHighlightController {
 
   void _handleLinkAdded(Link link) {
     final fromStateId = link.fromTo.from;
-    final toStateId = link.fromTo.fromPort;
+    final toStateId = link.fromTo.to;
+    final fromPortId = link.fromTo.fromPort;
+    final toPortId = link.fromTo.toPort;
+
+    if (fromPortId != _outPortId || toPortId != _inPortId) {
+      return;
+    }
+
     final edge = FlNodesCanvasEdge(
       id: link.id,
       fromStateId: fromStateId,
@@ -354,6 +361,9 @@ class FlNodesCanvasController implements FlNodesHighlightController {
       controlPointY: null,
     );
     _edges[edge.id] = edge;
+    if (_highlightedTransitionIds.contains(edge.id)) {
+      _updateLinkHighlights(_highlightedTransitionIds);
+    }
     _provider.addOrUpdateTransition(
       id: edge.id,
       fromStateId: edge.fromStateId,

--- a/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
@@ -256,8 +256,8 @@ class FlNodesPdaCanvasController implements FlNodesHighlightController {
       id: edge.id,
       fromTo: (
         from: edge.fromStateId,
-        to: _outPortId,
-        fromPort: edge.toStateId,
+        to: edge.toStateId,
+        fromPort: _outPortId,
         toPort: _inPortId,
       ),
       state: LinkState(),
@@ -354,7 +354,14 @@ class FlNodesPdaCanvasController implements FlNodesHighlightController {
 
   void _handleLinkAdded(Link link) {
     final fromStateId = link.fromTo.from;
-    final toStateId = link.fromTo.fromPort;
+    final toStateId = link.fromTo.to;
+    final fromPortId = link.fromTo.fromPort;
+    final toPortId = link.fromTo.toPort;
+
+    if (fromPortId != _outPortId || toPortId != _inPortId) {
+      return;
+    }
+
     final edge = FlNodesCanvasEdge(
       id: link.id,
       fromStateId: fromStateId,
@@ -368,6 +375,9 @@ class FlNodesPdaCanvasController implements FlNodesHighlightController {
       isLambdaPush: true,
     );
     _edges[edge.id] = edge;
+    if (_highlightedTransitionIds.contains(edge.id)) {
+      _updateLinkHighlights(_highlightedTransitionIds);
+    }
     _notifier.upsertTransition(
       id: edge.id,
       fromStateId: edge.fromStateId,

--- a/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
@@ -257,8 +257,8 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
       id: edge.id,
       fromTo: (
         from: edge.fromStateId,
-        to: _outPortId,
-        fromPort: edge.toStateId,
+        to: edge.toStateId,
+        fromPort: _outPortId,
         toPort: _inPortId,
       ),
       state: LinkState(),
@@ -346,7 +346,14 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
 
   void _handleLinkAdded(Link link) {
     final fromStateId = link.fromTo.from;
-    final toStateId = link.fromTo.fromPort;
+    final toStateId = link.fromTo.to;
+    final fromPortId = link.fromTo.fromPort;
+    final toPortId = link.fromTo.toPort;
+
+    if (fromPortId != _outPortId || toPortId != _inPortId) {
+      return;
+    }
+
     final edge = FlNodesCanvasEdge(
       id: link.id,
       fromStateId: fromStateId,
@@ -358,6 +365,9 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
       tapeNumber: 0,
     );
     _edges[edge.id] = edge;
+    if (_highlightedTransitionIds.contains(edge.id)) {
+      _updateLinkHighlights(_highlightedTransitionIds);
+    }
     _notifier.addOrUpdateTransition(
       id: edge.id,
       fromStateId: edge.fromStateId,

--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
@@ -300,8 +300,8 @@ void main() {
         id: 't0',
         fromTo: (
           from: 'q0',
-          to: 'outgoing',
-          fromPort: 'q1',
+          to: 'q1',
+          fromPort: 'outgoing',
           toPort: 'incoming',
         ),
         state: LinkState(),
@@ -318,6 +318,10 @@ void main() {
       expect(call['id'], equals('t0'));
       expect(call['fromStateId'], equals('q0'));
       expect(call['toStateId'], equals('q1'));
+      final storedEdge = controller.edgeById('t0');
+      expect(storedEdge, isNotNull);
+      expect(storedEdge!.fromStateId, equals('q0'));
+      expect(storedEdge.toStateId, equals('q1'));
     });
 
     test('applyHighlight toggles link selection state without altering manual selection', () {

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
@@ -303,8 +303,8 @@ void main() {
         id: 't0',
         fromTo: (
           from: 'q0',
-          to: 'outgoing',
-          fromPort: 'q1',
+          to: 'q1',
+          fromPort: 'outgoing',
           toPort: 'incoming',
         ),
         state: LinkState(),
@@ -327,6 +327,10 @@ void main() {
       expect(call['isLambdaInput'], isTrue);
       expect(call['isLambdaPop'], isTrue);
       expect(call['isLambdaPush'], isTrue);
+      final storedEdge = controller.edgeById('t0');
+      expect(storedEdge, isNotNull);
+      expect(storedEdge!.fromStateId, equals('q0'));
+      expect(storedEdge.toStateId, equals('q1'));
     });
 
     test('applyHighlight marks PDA transitions without mutating selection', () {

--- a/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
@@ -278,8 +278,8 @@ void main() {
         id: 't0',
         fromTo: (
           from: 'q0',
-          to: 'outgoing',
-          fromPort: 'q1',
+          to: 'q1',
+          fromPort: 'outgoing',
           toPort: 'incoming',
         ),
         state: LinkState(),
@@ -299,6 +299,10 @@ void main() {
       expect(call['readSymbol'], equals(''));
       expect(call['writeSymbol'], equals(''));
       expect(call['direction'], equals(TapeDirection.right));
+      final storedEdge = controller.edgeById('t0');
+      expect(storedEdge, isNotNull);
+      expect(storedEdge!.fromStateId, equals('q0'));
+      expect(storedEdge.toStateId, equals('q1'));
     });
 
     test('applyHighlight toggles TM transitions without changing selection', () {


### PR DESCRIPTION
## Summary
- align FSA/TM/PDA fl_nodes link construction with actual state IDs and canonical port IDs
- persist transitions only for outgoing→incoming connections and refresh highlights when links already highlighted
- update controller tests to use real FromTo semantics and verify stored edges

## Testing
- flutter analyze *(fails: Flutter SDK not installed in container)*
- flutter test test/features/canvas/fl_nodes *(fails: Flutter SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e007eaf56c832e95a193b29e11f274