### PR TITLE
Default first canvas node to initial state

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -282,12 +282,13 @@ class FlNodesCanvasController implements FlNodesHighlightController {
 
   void _handleNodeAdded(NodeInstance node) {
     final label = _resolveLabel(node);
+    final isFirstState = _nodes.isEmpty;
     final canvasNode = FlNodesCanvasNode(
       id: node.id,
       label: label,
       x: node.offset.dx,
       y: node.offset.dy,
-      isInitial: false,
+      isInitial: isFirstState,
       isAccepting: false,
     );
     _nodes[node.id] = canvasNode;
@@ -296,7 +297,7 @@ class FlNodesCanvasController implements FlNodesHighlightController {
       label: canvasNode.label,
       x: canvasNode.x,
       y: canvasNode.y,
-      isInitial: canvasNode.isInitial,
+      isInitial: isFirstState ? true : null,
       isAccepting: canvasNode.isAccepting,
     );
   }

--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
@@ -75,6 +75,14 @@ class _RecordingAutomatonProvider extends AutomatonProvider {
       'isInitial': isInitial,
       'isAccepting': isAccepting,
     });
+    super.addState(
+      id: id,
+      label: label,
+      x: x,
+      y: y,
+      isInitial: isInitial,
+      isAccepting: isAccepting,
+    );
   }
 
   @override
@@ -241,6 +249,12 @@ void main() {
       expect(call['label'], equals('S'));
       expect(call['x'], equals(42.0));
       expect(call['y'], equals(24.0));
+      expect(call['isInitial'], isTrue);
+
+      final automaton = provider.state.currentAutomaton;
+      expect(automaton, isNotNull);
+      expect(automaton!.initialState, isNotNull);
+      expect(automaton.initialState!.id, equals('q2'));
     });
 
     test('updates labels on NodeFieldEvent submissions', () async {


### PR DESCRIPTION
## Summary
- ensure the first node added through FlNodesCanvasController is flagged as the initial state
- avoid overwriting existing initial selections when adding subsequent nodes
- extend the controller test harness to exercise initial state propagation when emitting AddNodeEvent

## Testing
- flutter analyze *(fails: `flutter` command not found in container)*
- flutter test test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e00a95e658832e934da019732427f7