### PR TITLE
Add state flag toggles to native canvases

### DIFF
--- a/USER_GUIDE
+++ b/USER_GUIDE
@@ -30,6 +30,11 @@ fl_nodes primitives:
   area. The controller receives either `addStateAtCenter()` or an
   `AddNodeEvent`, then forwards the mutation to `AutomatonProvider` so the new
   state appears across the app.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L236-L302】【F:lib/presentation/providers/automaton_provider.dart†L83-L166】
+* **Toggle initial/accepting flags** – tap the play/check icons in a state's
+  header to mark it as initial or accepting. The canvases call the respective
+  Riverpod notifiers (`AutomatonProvider`, `TMEditorNotifier`,
+  `PDAEditorNotifier`), so the change is reflected instantly across the
+  workspace.【F:lib/presentation/widgets/automaton_canvas_native.dart†L212-L308】【F:lib/presentation/widgets/tm_canvas_native.dart†L170-L306】【F:lib/presentation/widgets/pda_canvas_native.dart†L240-L360】
 * **Highlight Playback** – running a simulation pushes highlight payloads into
   the controller via the `FlNodesHighlightController` interface. The canvas
   updates instantly and clears highlights when the simulator stops.【F:lib/core/services/simulation_highlight_service.dart†L6-L74】【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L36-L45】

--- a/lib/presentation/widgets/pda_canvas_native.dart
+++ b/lib/presentation/widgets/pda_canvas_native.dart
@@ -237,6 +237,7 @@ class _PDACanvasNativeState extends ConsumerState<PDACanvasNative> {
                 isNondeterministic: isNondeterministic,
               );
 
+              final notifier = ref.read(pdaEditorProvider.notifier);
               return _PDANodeHeader(
                 label: label,
                 isInitial: isInitial,
@@ -245,6 +246,20 @@ class _PDACanvasNativeState extends ConsumerState<PDACanvasNative> {
                 isCollapsed: node.state.isCollapsed,
                 colors: colors,
                 onToggleCollapse: onToggleCollapse,
+                onToggleInitial: () {
+                  notifier.updateStateFlags(
+                    id: node.id,
+                    isInitial: !isInitial,
+                  );
+                },
+                onToggleAccepting: () {
+                  notifier.updateStateFlags(
+                    id: node.id,
+                    isAccepting: !isAccepting,
+                  );
+                },
+                initialToggleKey: Key('pda-node-${node.id}-initial-toggle'),
+                acceptingToggleKey: Key('pda-node-${node.id}-accepting-toggle'),
               );
             },
           ),
@@ -296,6 +311,10 @@ class _PDANodeHeader extends StatelessWidget {
     required this.isCollapsed,
     required this.colors,
     required this.onToggleCollapse,
+    required this.onToggleInitial,
+    required this.onToggleAccepting,
+    required this.initialToggleKey,
+    required this.acceptingToggleKey,
   });
 
   final String label;
@@ -305,6 +324,10 @@ class _PDANodeHeader extends StatelessWidget {
   final bool isCollapsed;
   final _HeaderColors colors;
   final VoidCallback onToggleCollapse;
+  final VoidCallback onToggleInitial;
+  final VoidCallback onToggleAccepting;
+  final Key initialToggleKey;
+  final Key acceptingToggleKey;
 
   @override
   Widget build(BuildContext context) {
@@ -326,15 +349,6 @@ class _PDANodeHeader extends StatelessWidget {
       padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
       child: Row(
         children: [
-          if (isInitial)
-            Padding(
-              padding: const EdgeInsets.only(right: 6),
-              child: Icon(
-                Icons.play_arrow_rounded,
-                size: 16,
-                color: colors.foreground,
-              ),
-            ),
           Expanded(
             child: Text(
               label,
@@ -343,34 +357,95 @@ class _PDANodeHeader extends StatelessWidget {
               style: textStyle,
             ),
           ),
-          if (isAccepting)
-            Padding(
-              padding: const EdgeInsets.only(right: 6),
-              child: Icon(
-                Icons.check_circle,
-                size: 16,
-                color: colors.foreground,
-              ),
-            ),
-          if (isNondeterministic)
-            Padding(
-              padding: const EdgeInsets.only(right: 6),
-              child: Icon(
-                Icons.warning_amber_rounded,
-                size: 16,
-                color: colors.foreground,
-              ),
-            ),
-          InkWell(
-            onTap: onToggleCollapse,
-            borderRadius: BorderRadius.circular(16),
-            child: Icon(
-              isCollapsed ? Icons.expand_more : Icons.expand_less,
+          const SizedBox(width: 8),
+          _HeaderActionButton(
+            buttonKey: initialToggleKey,
+            tooltip: isInitial ? 'Unset initial state' : 'Set as initial state',
+            icon: Icons.play_circle_outline,
+            activeIcon: Icons.play_circle,
+            isActive: isInitial,
+            color: colors.foreground,
+            onPressed: onToggleInitial,
+          ),
+          const SizedBox(width: 4),
+          _HeaderActionButton(
+            buttonKey: acceptingToggleKey,
+            tooltip:
+                isAccepting ? 'Unset accepting state' : 'Set as accepting state',
+            icon: Icons.check_circle_outline,
+            activeIcon: Icons.check_circle,
+            isActive: isAccepting,
+            color: colors.foreground,
+            onPressed: onToggleAccepting,
+          ),
+          if (isNondeterministic) ...[
+            const SizedBox(width: 4),
+            Icon(
+              Icons.warning_amber_rounded,
               size: 18,
               color: colors.foreground,
             ),
+          ],
+          const SizedBox(width: 4),
+          Tooltip(
+            message: isCollapsed ? 'Expand state' : 'Collapse state',
+            child: IconButton(
+              icon: Icon(
+                isCollapsed ? Icons.expand_more : Icons.expand_less,
+                size: 20,
+                color: colors.foreground.withOpacity(0.9),
+              ),
+              onPressed: onToggleCollapse,
+              padding: EdgeInsets.zero,
+              constraints:
+                  const BoxConstraints.tightFor(width: 32, height: 32),
+              splashRadius: 18,
+              visualDensity: VisualDensity.compact,
+            ),
           ),
         ],
+      ),
+    );
+  }
+}
+
+class _HeaderActionButton extends StatelessWidget {
+  const _HeaderActionButton({
+    required this.tooltip,
+    required this.icon,
+    required this.activeIcon,
+    required this.isActive,
+    required this.color,
+    required this.onPressed,
+    this.buttonKey,
+  });
+
+  final String tooltip;
+  final IconData icon;
+  final IconData activeIcon;
+  final bool isActive;
+  final Color color;
+  final VoidCallback onPressed;
+  final Key? buttonKey;
+
+  @override
+  Widget build(BuildContext context) {
+    final resolvedIcon = Icon(
+      isActive ? activeIcon : icon,
+      size: 20,
+      color: isActive ? color : color.withOpacity(0.6),
+    );
+
+    return Tooltip(
+      message: tooltip,
+      child: IconButton(
+        key: buttonKey,
+        icon: resolvedIcon,
+        onPressed: onPressed,
+        padding: EdgeInsets.zero,
+        constraints: const BoxConstraints.tightFor(width: 32, height: 32),
+        splashRadius: 18,
+        visualDensity: VisualDensity.compact,
       ),
     );
   }

--- a/test/widget/presentation/native_canvas_flag_toggles_test.dart
+++ b/test/widget/presentation/native_canvas_flag_toggles_test.dart
@@ -1,0 +1,318 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/pda.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/data/services/automaton_service.dart';
+import 'package:jflutter/features/layout/layout_repository_impl.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+import 'package:jflutter/presentation/widgets/automaton_canvas_native.dart';
+import 'package:jflutter/presentation/widgets/pda_canvas_native.dart';
+import 'package:jflutter/presentation/widgets/tm_canvas_native.dart';
+
+void main() {
+  testWidgets('Automaton node header toggles initial and accepting flags',
+      (tester) async {
+    final q0 = automaton_state.State(
+      id: 'q0',
+      label: 'q0',
+      position: Vector2.zero(),
+      isInitial: true,
+      isAccepting: false,
+    );
+    final q1 = automaton_state.State(
+      id: 'q1',
+      label: 'q1',
+      position: Vector2(120, 0),
+      isInitial: false,
+      isAccepting: false,
+    );
+    final automaton = FSA(
+      id: 'test-fsa',
+      name: 'Test FSA',
+      states: {q0, q1},
+      transitions: <Transition>{},
+      alphabet: const {'a'},
+      initialState: q0,
+      acceptingStates: <automaton_state.State>{},
+      created: DateTime.now(),
+      modified: DateTime.now(),
+      bounds: math.Rectangle<double>(0, 0, 400, 400),
+      zoomLevel: 1,
+      panOffset: Vector2.zero(),
+    );
+
+    late AutomatonProvider automatonNotifier;
+    final canvasKey = GlobalKey();
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          automatonProvider.overrideWith((ref) {
+            automatonNotifier = AutomatonProvider(
+              automatonService: AutomatonService(),
+              layoutRepository: LayoutRepositoryImpl(),
+            );
+            automatonNotifier.state =
+                AutomatonState(currentAutomaton: automaton);
+            return automatonNotifier;
+          }),
+        ],
+        child: MaterialApp(
+          home: Consumer(
+            builder: (context, ref, _) {
+              final state = ref.watch(automatonProvider);
+              return Scaffold(
+                body: SizedBox(
+                  width: 600,
+                  height: 400,
+                  child: AutomatonCanvas(
+                    automaton: state.currentAutomaton,
+                    canvasKey: canvasKey,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final initialToggleFinder =
+        find.byKey(const Key('automaton-node-q1-initial-toggle'));
+    final acceptingToggleFinder =
+        find.byKey(const Key('automaton-node-q1-accepting-toggle'));
+
+    expect(initialToggleFinder, findsOneWidget);
+    expect(acceptingToggleFinder, findsOneWidget);
+
+    final initialIconBefore = tester.widget<Icon>(
+      find.descendant(
+        of: initialToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+
+    await tester.tap(initialToggleFinder);
+    await tester.pumpAndSettle();
+
+    expect(
+      automatonNotifier.state.currentAutomaton?.initialState?.id,
+      equals('q1'),
+    );
+
+    final initialIconAfter = tester.widget<Icon>(
+      find.descendant(
+        of: initialToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+    expect(initialIconAfter.color!.opacity,
+        greaterThan(initialIconBefore.color!.opacity));
+
+    await tester.tap(acceptingToggleFinder);
+    await tester.pumpAndSettle();
+
+    final acceptingIcon = tester.widget<Icon>(
+      find.descendant(
+        of: acceptingToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+
+    expect(
+      automatonNotifier.state.currentAutomaton?.acceptingStates
+          .any((state) => state.id == 'q1'),
+      isTrue,
+    );
+    expect(acceptingIcon.color!.opacity, closeTo(1, 0.01));
+  });
+
+  testWidgets('TM node header toggles state flags via notifier', (tester) async {
+    late TMEditorNotifier tmNotifier;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          tmEditorProvider.overrideWith((ref) {
+            tmNotifier = TMEditorNotifier();
+            tmNotifier.upsertState(
+              id: 'q0',
+              label: 'q0',
+              x: 60,
+              y: 60,
+              isInitial: true,
+            );
+            tmNotifier.upsertState(
+              id: 'q1',
+              label: 'q1',
+              x: 200,
+              y: 60,
+            );
+            return tmNotifier;
+          }),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: TMCanvasNative(
+                onTMModified: _noopOnTMModified,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final initialToggleFinder =
+        find.byKey(const Key('tm-node-q1-initial-toggle'));
+    final acceptingToggleFinder =
+        find.byKey(const Key('tm-node-q1-accepting-toggle'));
+
+    expect(initialToggleFinder, findsOneWidget);
+    expect(acceptingToggleFinder, findsOneWidget);
+
+    final initialIconBefore = tester.widget<Icon>(
+      find.descendant(
+        of: initialToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+
+    await tester.tap(initialToggleFinder);
+    await tester.pumpAndSettle();
+
+    expect(tmNotifier.state.tm?.initialState.id, equals('q1'));
+
+    final initialIconAfter = tester.widget<Icon>(
+      find.descendant(
+        of: initialToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+    expect(initialIconAfter.color!.opacity,
+        greaterThan(initialIconBefore.color!.opacity));
+
+    await tester.tap(acceptingToggleFinder);
+    await tester.pumpAndSettle();
+
+    final acceptingIcon = tester.widget<Icon>(
+      find.descendant(
+        of: acceptingToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+
+    expect(
+      tmNotifier.state.tm?.acceptingStates.any((state) => state.id == 'q1'),
+      isTrue,
+    );
+    expect(acceptingIcon.color!.opacity, closeTo(1, 0.01));
+  });
+
+  testWidgets('PDA node header toggles state flags via notifier',
+      (tester) async {
+    late PDAEditorNotifier pdaNotifier;
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          pdaEditorProvider.overrideWith((ref) {
+            pdaNotifier = PDAEditorNotifier();
+            pdaNotifier.addOrUpdateState(
+              id: 'q0',
+              label: 'q0',
+              x: 80,
+              y: 80,
+            );
+            pdaNotifier.addOrUpdateState(
+              id: 'q1',
+              label: 'q1',
+              x: 220,
+              y: 80,
+            );
+            return pdaNotifier;
+          }),
+        ],
+        child: const MaterialApp(
+          home: Scaffold(
+            body: SizedBox(
+              width: 600,
+              height: 400,
+              child: PDACanvasNative(
+                onPdaModified: _noopOnPdaModified,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+
+    await tester.pumpAndSettle();
+
+    final initialToggleFinder =
+        find.byKey(const Key('pda-node-q1-initial-toggle'));
+    final acceptingToggleFinder =
+        find.byKey(const Key('pda-node-q1-accepting-toggle'));
+
+    expect(initialToggleFinder, findsOneWidget);
+    expect(acceptingToggleFinder, findsOneWidget);
+
+    final initialIconBefore = tester.widget<Icon>(
+      find.descendant(
+        of: initialToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+
+    await tester.tap(initialToggleFinder);
+    await tester.pumpAndSettle();
+
+    expect(pdaNotifier.state.pda?.initialState?.id, equals('q1'));
+
+    final initialIconAfter = tester.widget<Icon>(
+      find.descendant(
+        of: initialToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+    expect(initialIconAfter.color!.opacity,
+        greaterThan(initialIconBefore.color!.opacity));
+
+    await tester.tap(acceptingToggleFinder);
+    await tester.pumpAndSettle();
+
+    final acceptingIcon = tester.widget<Icon>(
+      find.descendant(
+        of: acceptingToggleFinder,
+        matching: find.byType(Icon),
+      ).first,
+    );
+
+    expect(
+      pdaNotifier.state.pda?.acceptingStates
+          .any((state) => state.id == 'q1'),
+      isTrue,
+    );
+    expect(acceptingIcon.color!.opacity, closeTo(1, 0.01));
+  });
+}
+
+void _noopOnTMModified(TM _) {}
+
+void _noopOnPdaModified(PDA _) {}


### PR DESCRIPTION
## Summary
- add header controls to mark states as initial or accepting in the automaton, TM, and PDA native canvases
- route the new affordances through the existing Riverpod notifiers and refresh styling to reflect state flags immediately
- cover the interactions with widget tests and document the gesture in the user guide

## Testing
- not run (flutter tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e00bdf2f74832e9c7fab552bf01ae7