### PR TITLE
Add transition editing overlays to native canvases

### DIFF
--- a/USER_GUIDE
+++ b/USER_GUIDE
@@ -30,6 +30,11 @@ fl_nodes primitives:
   area. The controller receives either `addStateAtCenter()` or an
   `AddNodeEvent`, then forwards the mutation to `AutomatonProvider` so the new
   state appears across the app.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L236-L302】【F:lib/presentation/providers/automaton_provider.dart†L83-L166】
+* **Edit transitions** – select a link to reveal the inline editor anchored to
+  that edge. FSAs expose a label field, while TMs and PDAs surface tape or stack
+  controls. Saving commits the change through the respective notifiers
+  (`AutomatonProvider`, `TMEditorNotifier`, `PDAEditorNotifier`), keeping the
+  transition list, alphabets, and metadata synchronised.【F:lib/presentation/widgets/automaton_canvas_native.dart†L227-L269】【F:lib/presentation/widgets/tm_canvas_native.dart†L207-L259】【F:lib/presentation/widgets/pda_canvas_native.dart†L274-L336】
 * **Toggle initial/accepting flags** – tap the play/check icons in a state's
   header to mark it as initial or accepting. The canvases call the respective
   Riverpod notifiers (`AutomatonProvider`, `TMEditorNotifier`,
@@ -71,8 +76,9 @@ Troubleshooting
 * **Canvas not updating**: check that `_isSynchronizing` isn't stuck to `true`
   (e.g., due to an exception while rebuilding nodes). If so, call
   `synchronize()` again after fixing the underlying data issue.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L96-L234】
-* **Labels not sticking**: ensure label edits trigger a submit event—pressing
-  <kbd>Enter</kbd> commits changes, whereas <kbd>Escape</kbd> cancels and keeps
-  the previous value by design.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L304-L327】
+* **Transition edits not sticking**: use the inline editor's **Save** button
+  (or <kbd>Enter</kbd> inside the field) to submit changes. Selecting another
+  edge or pressing **Cancel** dismisses the overlay without persisting
+  updates.【F:lib/presentation/widgets/automaton_canvas_native.dart†L247-L265】【F:lib/presentation/widgets/tm_canvas_native.dart†L233-L257】【F:lib/presentation/widgets/pda_canvas_native.dart†L309-L333】
 * **Highlights not clearing**: verify the `SimulationHighlightService` channel
   is registered and that `clear()` is called after simulations complete.【F:lib/core/services/simulation_highlight_service.dart†L6-L74】

--- a/docs/canvas_bridge.md
+++ b/docs/canvas_bridge.md
@@ -53,6 +53,13 @@ native Flutter affordances:
 * **Adding states** – the "Add state" button emits `addStateAtCenter()`. Double
   clicks are reported through `AddNodeEvent`, which is normalised into
   `AutomatonProvider.addState` and persisted in the Riverpod store.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L236-L302】【F:lib/presentation/providers/automaton_provider.dart†L83-L166】
+* **Editing transitions** – selecting a link spawns the inline overlay wired to
+  the appropriate notifier. FSAs expose the label editor, while TMs and PDAs
+  surface tape and stack controls respectively. Saving routes through
+  `AutomatonProvider.updateTransitionLabel`,
+  `TMEditorNotifier.updateTransitionOperations`, or
+  `PDAEditorNotifier.upsertTransition`, ensuring metadata, alphabets, and traces
+  stay in sync.【F:lib/presentation/widgets/automaton_canvas_native.dart†L227-L269】【F:lib/presentation/widgets/tm_canvas_native.dart†L207-L259】【F:lib/presentation/widgets/pda_canvas_native.dart†L274-L336】
 * **Simulation highlights** – `SimulationHighlightService` forwards each step to
   the controller notifier. The editor decorates nodes and transitions
   immediately and clears them when `clear()` is dispatched at the end of a

--- a/lib/features/canvas/fl_nodes/link_overlay_utils.dart
+++ b/lib/features/canvas/fl_nodes/link_overlay_utils.dart
@@ -1,0 +1,96 @@
+import 'dart:math' as math;
+
+import 'package:fl_nodes/fl_nodes.dart';
+import 'package:flutter/widgets.dart';
+
+import 'fl_nodes_canvas_models.dart';
+
+Offset? resolveLinkAnchorWorld(
+  FlNodeEditorController controller,
+  String linkId,
+  FlNodesCanvasEdge? edge,
+) {
+  final link = controller.linksById[linkId];
+  if (link == null) {
+    return null;
+  }
+
+  final fromNode = controller.nodes[link.fromTo.from];
+  final toNode = controller.nodes[link.fromTo.to];
+  if (fromNode == null || toNode == null) {
+    return null;
+  }
+
+  final fromPort = fromNode.ports[link.fromTo.fromPort];
+  final toPort = toNode.ports[link.fromTo.toPort];
+  if (fromPort == null || toPort == null) {
+    return null;
+  }
+
+  if (edge?.controlPointX != null && edge?.controlPointY != null) {
+    return Offset(edge!.controlPointX!, edge.controlPointY!);
+  }
+
+  final start = fromNode.offset + fromPort.offset;
+  final end = toNode.offset + toPort.offset;
+
+  if (link.fromTo.from == link.fromTo.to) {
+    final loopAnchor = _resolveLoopAnchor(fromNode);
+    return loopAnchor ?? Offset((start.dx + end.dx) / 2, (start.dy + end.dy) / 2);
+  }
+
+  return Offset((start.dx + end.dx) / 2, (start.dy + end.dy) / 2);
+}
+
+Offset? projectCanvasPointToOverlay({
+  required FlNodeEditorController controller,
+  required GlobalKey canvasKey,
+  required Offset worldOffset,
+}) {
+  final renderObject = canvasKey.currentContext?.findRenderObject();
+  if (renderObject is! RenderBox) {
+    return null;
+  }
+
+  final size = renderObject.size;
+  if (size.isEmpty) {
+    return null;
+  }
+
+  final offset = controller.viewportOffset;
+  final zoom = controller.viewportZoom;
+
+  final viewport = Rect.fromLTWH(
+    -size.width / 2 / zoom - offset.dx,
+    -size.height / 2 / zoom - offset.dy,
+    size.width / zoom,
+    size.height / zoom,
+  );
+
+  final dx = ((worldOffset.dx - viewport.left) / viewport.width) * size.width;
+  final dy = ((worldOffset.dy - viewport.top) / viewport.height) * size.height;
+
+  if (dx.isNaN || dy.isNaN || !dx.isFinite || !dy.isFinite) {
+    return null;
+  }
+
+  return Offset(dx, dy);
+}
+
+Offset? _resolveLoopAnchor(NodeInstance node) {
+  final renderObject = node.key.currentContext?.findRenderObject();
+  Size? nodeSize;
+  if (renderObject is RenderBox) {
+    nodeSize = renderObject.size;
+  }
+
+  final width = nodeSize?.width ?? 120;
+  final height = nodeSize?.height ?? 60;
+  final center = Offset(
+    node.offset.dx + width / 2,
+    node.offset.dy + height / 2,
+  );
+
+  final radius = math.sqrt(width * width + height * height) / 2;
+  return center.translate(0, -(radius + 40));
+}

--- a/lib/presentation/widgets/transition_editors/pda_transition_editor.dart
+++ b/lib/presentation/widgets/transition_editors/pda_transition_editor.dart
@@ -1,0 +1,177 @@
+import 'package:flutter/material.dart';
+
+class PdaTransitionEditor extends StatefulWidget {
+  const PdaTransitionEditor({
+    super.key,
+    required this.initialRead,
+    required this.initialPop,
+    required this.initialPush,
+    required this.isLambdaInput,
+    required this.isLambdaPop,
+    required this.isLambdaPush,
+    required this.onSubmit,
+    required this.onCancel,
+  });
+
+  final String initialRead;
+  final String initialPop;
+  final String initialPush;
+  final bool isLambdaInput;
+  final bool isLambdaPop;
+  final bool isLambdaPush;
+  final void Function({
+    required String readSymbol,
+    required String popSymbol,
+    required String pushSymbol,
+    required bool lambdaInput,
+    required bool lambdaPop,
+    required bool lambdaPush,
+  }) onSubmit;
+  final VoidCallback onCancel;
+
+  @override
+  State<PdaTransitionEditor> createState() => _PdaTransitionEditorState();
+}
+
+class _PdaTransitionEditorState extends State<PdaTransitionEditor> {
+  late final TextEditingController _readController =
+      TextEditingController(text: widget.initialRead);
+  late final TextEditingController _popController =
+      TextEditingController(text: widget.initialPop);
+  late final TextEditingController _pushController =
+      TextEditingController(text: widget.initialPush);
+  late bool _lambdaInput = widget.isLambdaInput;
+  late bool _lambdaPop = widget.isLambdaPop;
+  late bool _lambdaPush = widget.isLambdaPush;
+
+  @override
+  void dispose() {
+    _readController.dispose();
+    _popController.dispose();
+    _pushController.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit() {
+    widget.onSubmit(
+      readSymbol: _readController.text.trim(),
+      popSymbol: _popController.text.trim(),
+      pushSymbol: _pushController.text.trim(),
+      lambdaInput: _lambdaInput,
+      lambdaPop: _lambdaPop,
+      lambdaPush: _lambdaPush,
+    );
+  }
+
+  Widget _buildLambdaSwitch({
+    required String label,
+    required bool value,
+    required ValueChanged<bool> onChanged,
+  }) {
+    return SwitchListTile.adaptive(
+      contentPadding: EdgeInsets.zero,
+      title: Text(label),
+      value: value,
+      onChanged: (next) {
+        setState(() {
+          onChanged(next);
+        });
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(8),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 280),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _readController,
+                enabled: !_lambdaInput,
+                decoration: const InputDecoration(
+                  labelText: 'Input symbol',
+                  border: OutlineInputBorder(),
+                ),
+                autofocus: true,
+                onSubmitted: (_) => _handleSubmit(),
+              ),
+              _buildLambdaSwitch(
+                label: 'λ-input',
+                value: _lambdaInput,
+                onChanged: (value) {
+                  _lambdaInput = value;
+                  if (value) {
+                    _readController.text = '';
+                  }
+                },
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _popController,
+                enabled: !_lambdaPop,
+                decoration: const InputDecoration(
+                  labelText: 'Pop symbol',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (_) => _handleSubmit(),
+              ),
+              _buildLambdaSwitch(
+                label: 'λ-pop',
+                value: _lambdaPop,
+                onChanged: (value) {
+                  _lambdaPop = value;
+                  if (value) {
+                    _popController.text = '';
+                  }
+                },
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _pushController,
+                enabled: !_lambdaPush,
+                decoration: const InputDecoration(
+                  labelText: 'Push symbol',
+                  border: OutlineInputBorder(),
+                ),
+                onSubmitted: (_) => _handleSubmit(),
+              ),
+              _buildLambdaSwitch(
+                label: 'λ-push',
+                value: _lambdaPush,
+                onChanged: (value) {
+                  _lambdaPush = value;
+                  if (value) {
+                    _pushController.text = '';
+                  }
+                },
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: widget.onCancel,
+                    child: const Text('Cancel'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: _handleSubmit,
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/transition_editors/tm_transition_operations_editor.dart
+++ b/lib/presentation/widgets/transition_editors/tm_transition_operations_editor.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+
+import '../../../core/models/tm_transition.dart';
+
+class TmTransitionOperationsEditor extends StatefulWidget {
+  const TmTransitionOperationsEditor({
+    super.key,
+    required this.initialRead,
+    required this.initialWrite,
+    required this.initialDirection,
+    required this.onSubmit,
+    required this.onCancel,
+  });
+
+  final String initialRead;
+  final String initialWrite;
+  final TapeDirection initialDirection;
+  final void Function({
+    required String readSymbol,
+    required String writeSymbol,
+    required TapeDirection direction,
+  }) onSubmit;
+  final VoidCallback onCancel;
+
+  @override
+  State<TmTransitionOperationsEditor> createState() =>
+      _TmTransitionOperationsEditorState();
+}
+
+class _TmTransitionOperationsEditorState
+    extends State<TmTransitionOperationsEditor> {
+  late final TextEditingController _readController =
+      TextEditingController(text: widget.initialRead);
+  late final TextEditingController _writeController =
+      TextEditingController(text: widget.initialWrite);
+  late TapeDirection _direction = widget.initialDirection;
+
+  @override
+  void dispose() {
+    _readController.dispose();
+    _writeController.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit() {
+    widget.onSubmit(
+      readSymbol: _readController.text.trim(),
+      writeSymbol: _writeController.text.trim(),
+      direction: _direction,
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Material(
+      elevation: 4,
+      borderRadius: BorderRadius.circular(8),
+      child: ConstrainedBox(
+        constraints: const BoxConstraints(minWidth: 260),
+        child: Padding(
+          padding: const EdgeInsets.all(12),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextField(
+                controller: _readController,
+                decoration: const InputDecoration(
+                  labelText: 'Read symbol',
+                  border: OutlineInputBorder(),
+                ),
+                autofocus: true,
+                textInputAction: TextInputAction.next,
+                onSubmitted: (_) => _handleSubmit(),
+              ),
+              const SizedBox(height: 12),
+              TextField(
+                controller: _writeController,
+                decoration: const InputDecoration(
+                  labelText: 'Write symbol',
+                  border: OutlineInputBorder(),
+                ),
+                textInputAction: TextInputAction.next,
+                onSubmitted: (_) => _handleSubmit(),
+              ),
+              const SizedBox(height: 12),
+              InputDecorator(
+                decoration: const InputDecoration(
+                  labelText: 'Direction',
+                  border: OutlineInputBorder(),
+                ),
+                child: DropdownButtonHideUnderline(
+                  child: DropdownButton<TapeDirection>(
+                    value: _direction,
+                    items: TapeDirection.values
+                        .map(
+                          (direction) => DropdownMenuItem(
+                            value: direction,
+                            child: Text(direction.description),
+                          ),
+                        )
+                        .toList(),
+                    onChanged: (value) {
+                      if (value != null) {
+                        setState(() {
+                          _direction = value;
+                        });
+                      }
+                    },
+                  ),
+                ),
+              ),
+              const SizedBox(height: 12),
+              Row(
+                mainAxisAlignment: MainAxisAlignment.end,
+                children: [
+                  TextButton(
+                    onPressed: widget.onCancel,
+                    child: const Text('Cancel'),
+                  ),
+                  const SizedBox(width: 8),
+                  FilledButton(
+                    onPressed: _handleSubmit,
+                    child: const Text('Save'),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/test/unit/presentation/transition_label_updates_test.dart
+++ b/test/unit/presentation/transition_label_updates_test.dart
@@ -1,0 +1,140 @@
+import 'dart:math' as math;
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/data/services/automaton_service.dart';
+import 'package:jflutter/features/layout/layout_repository_impl.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+
+void main() {
+  group('Transition updates', () {
+    test('AutomatonProvider.updateTransitionLabel updates labels and symbols', () {
+      final provider = AutomatonProvider(
+        automatonService: AutomatonService(),
+        layoutRepository: LayoutRepositoryImpl(),
+      );
+
+      final stateA = automaton_state.State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      final stateB = automaton_state.State(
+        id: 'q1',
+        label: 'q1',
+        position: Vector2(100, 0),
+        isInitial: false,
+        isAccepting: true,
+      );
+      final transition = FSATransition(
+        id: 't0',
+        fromState: stateA,
+        toState: stateB,
+        inputSymbols: const {'a'},
+        label: 'a',
+      );
+      final automaton = FSA(
+        id: 'fa',
+        name: 'test',
+        states: {stateA, stateB},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: stateA,
+        acceptingStates: {stateB},
+        created: DateTime.now(),
+        modified: DateTime.now(),
+        bounds: const math.Rectangle(0, 0, 400, 300),
+      );
+
+      provider.updateAutomaton(automaton);
+      provider.updateTransitionLabel(id: 't0', label: 'b,c');
+
+      final updated = provider.state.currentAutomaton!;
+      final updatedTransition = updated.transitions
+          .whereType<FSATransition>()
+          .firstWhere((element) => element.id == 't0');
+
+      expect(updatedTransition.label, 'b,c');
+      expect(updatedTransition.inputSymbols, {'b', 'c'});
+      expect(updated.alphabet.containsAll({'a', 'b', 'c'}), isTrue);
+    });
+
+    test('TMEditorNotifier.updateTransitionOperations rewrites operations', () {
+      final notifier = TMEditorNotifier();
+
+      notifier.upsertState(id: 'q0', label: 'q0', x: 0, y: 0);
+      notifier.upsertState(id: 'q1', label: 'q1', x: 100, y: 0);
+      notifier.addOrUpdateTransition(
+        id: 't0',
+        fromStateId: 'q0',
+        toStateId: 'q1',
+        readSymbol: 'a',
+        writeSymbol: 'b',
+        direction: TapeDirection.right,
+      );
+
+      notifier.updateTransitionOperations(
+        id: 't0',
+        readSymbol: 'x',
+        writeSymbol: 'y',
+        direction: TapeDirection.left,
+      );
+
+      final tm = notifier.state.tm!;
+      final transition = tm.transitions
+          .whereType<TMTransition>()
+          .firstWhere((element) => element.id == 't0');
+
+      expect(transition.readSymbol, 'x');
+      expect(transition.writeSymbol, 'y');
+      expect(transition.direction, TapeDirection.left);
+      expect(transition.label, 'x/y,L');
+    });
+
+    test('PDAEditorNotifier.upsertTransition updates stack operations', () {
+      final notifier = PDAEditorNotifier();
+
+      notifier.addOrUpdateState(id: 'q0', label: 'q0', x: 0, y: 0);
+      notifier.addOrUpdateState(id: 'q1', label: 'q1', x: 100, y: 0);
+      notifier.upsertTransition(
+        id: 't0',
+        fromStateId: 'q0',
+        toStateId: 'q1',
+        readSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'AZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+
+      notifier.upsertTransition(
+        id: 't0',
+        readSymbol: '',
+        popSymbol: '',
+        pushSymbol: '',
+        isLambdaInput: true,
+        isLambdaPop: true,
+        isLambdaPush: true,
+      );
+
+      final pda = notifier.state.pda!;
+      final transition = pda.pdaTransitions
+          .firstWhere((element) => element.id == 't0');
+
+      expect(transition.isLambdaInput, isTrue);
+      expect(transition.isLambdaPop, isTrue);
+      expect(transition.isLambdaPush, isTrue);
+      expect(transition.label, 'λ, λ/λ');
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add shared link overlay geometry helpers and inline editors for TM and PDA transitions
- surface overlay editors on the automaton, TM, and PDA canvases that follow the selected link
- document the new workflow and add unit coverage for notifier updates

## Testing
- dart format (fails: command not found)
- not run (flutter analyze) (flutter not installed)
- not run (flutter test test/unit/presentation/transition_label_updates_test.dart) (flutter not installed)


------
https://chatgpt.com/codex/tasks/task_e_68e00ececd50832e91ba4e04b24ab888