### PR TITLE
Add highlight syncing for PDA and TM simulations

### DIFF
--- a/lib/presentation/widgets/pda_simulation_panel.dart
+++ b/lib/presentation/widgets/pda_simulation_panel.dart
@@ -3,12 +3,18 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/algorithms/pda_simulator.dart';
 import '../../core/result.dart';
+import '../../core/services/simulation_highlight_service.dart';
 import '../providers/pda_editor_provider.dart';
 import 'trace_viewers/pda_trace_viewer.dart';
 
 /// Panel for PDA simulation and string testing
 class PDASimulationPanel extends ConsumerStatefulWidget {
-  const PDASimulationPanel({super.key});
+  final SimulationHighlightService highlightService;
+
+  const PDASimulationPanel({
+    super.key,
+    SimulationHighlightService? highlightService,
+  }) : highlightService = highlightService ?? SimulationHighlightService();
 
   @override
   ConsumerState<PDASimulationPanel> createState() => _PDASimulationPanelState();
@@ -29,6 +35,7 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
   void dispose() {
     _inputController.dispose();
     _initialStackController.dispose();
+    widget.highlightService.clear();
     super.dispose();
   }
 
@@ -111,6 +118,14 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
               setState(() {
                 _stepByStep = value;
               });
+              if (!value) {
+                widget.highlightService.clear();
+              } else if (_simulationResult?.steps.isNotEmpty == true) {
+                widget.highlightService.emitFromSteps(
+                  _simulationResult!.steps,
+                  0,
+                );
+              }
             },
           ),
           const SizedBox(height: 8),
@@ -269,7 +284,10 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
               ).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w600),
             ),
             const SizedBox(height: 8),
-            PDATraceViewer(result: simulationResult),
+            PDATraceViewer(
+              result: simulationResult,
+              highlightService: widget.highlightService,
+            ),
           ],
         ],
       ),
@@ -304,6 +322,8 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
       _errorMessage = null;
     });
 
+    widget.highlightService.clear();
+
     final stackAlphabet = {...currentPda.stackAlphabet};
     stackAlphabet.add(initialStack);
 
@@ -324,6 +344,7 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
     }
 
     if (result.isSuccess) {
+      final simulation = result.data;
       setState(() {
         _isSimulating = false;
         _simulationResult = result.data;
@@ -331,12 +352,18 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
             ? result.data!.errorMessage
             : null;
       });
+      if (simulation != null && simulation.steps.isNotEmpty) {
+        widget.highlightService.emitFromSteps(simulation.steps, 0);
+      } else {
+        widget.highlightService.clear();
+      }
     } else {
       setState(() {
         _isSimulating = false;
         _simulationResult = null;
         _errorMessage = result.error;
       });
+      widget.highlightService.clear();
     }
   }
 
@@ -345,6 +372,7 @@ class _PDASimulationPanelState extends ConsumerState<PDASimulationPanel> {
       _errorMessage = message;
       _simulationResult = null;
     });
+    widget.highlightService.clear();
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
         content: Text(message),

--- a/lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
@@ -3,17 +3,25 @@ import 'package:flutter/material.dart';
 import '../../../core/algorithms/pda_simulator.dart';
 import '../../../core/models/simulation_result.dart';
 import '../../../core/models/simulation_step.dart';
+import '../../../core/services/simulation_highlight_service.dart';
 import 'base_trace_viewer.dart';
 
 class PDATraceViewer extends StatelessWidget {
   final PDASimulationResult result;
-  const PDATraceViewer({super.key, required this.result});
+  final SimulationHighlightService? highlightService;
+
+  const PDATraceViewer({
+    super.key,
+    required this.result,
+    this.highlightService,
+  });
 
   @override
   Widget build(BuildContext context) {
     return BaseTraceViewer(
       result: _asSimulationResult(),
       title: 'PDA Trace (${result.steps.length} steps)',
+      highlightService: highlightService,
       buildStepLine: (SimulationStep step, int index) {
         final remaining = step.remainingInput.isEmpty
             ? 'λ'

--- a/lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
@@ -3,17 +3,25 @@ import 'package:flutter/material.dart';
 import '../../../core/algorithms/tm_simulator.dart';
 import '../../../core/models/simulation_result.dart';
 import '../../../core/models/simulation_step.dart';
+import '../../../core/services/simulation_highlight_service.dart';
 import 'base_trace_viewer.dart';
 
 class TMTraceViewer extends StatelessWidget {
   final TMSimulationResult result;
-  const TMTraceViewer({super.key, required this.result});
+  final SimulationHighlightService? highlightService;
+
+  const TMTraceViewer({
+    super.key,
+    required this.result,
+    this.highlightService,
+  });
 
   @override
   Widget build(BuildContext context) {
     return BaseTraceViewer(
       result: _asSimulationResult(),
       title: 'TM Trace (${result.steps.length} steps)',
+      highlightService: highlightService,
       buildStepLine: (SimulationStep step, int index) {
         final tape = step.tapeContents.isEmpty ? '□' : step.tapeContents;
         final transition = step.usedTransition != null


### PR DESCRIPTION
## Summary
- bridge PDA and TM canvas controllers to the simulation highlight service using the shared fl_nodes highlight channel
- extend PDA/TM simulation panels to forward step updates and resets through an injectable SimulationHighlightService
- update PDA/TM trace viewers and the shared trace viewer base to emit highlights when navigating recorded steps

## Testing
- `flutter analyze` *(fails: `flutter` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e018ba18e0832e875af09a6641e9dd