### PR TITLE
Avoid redundant drag updates when selection doesn't move

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -51,6 +51,7 @@ class FlNodesCanvasController implements FlNodesHighlightController {
   static const String _inPortId = 'incoming';
   static const String _outPortId = 'outgoing';
   static const String _labelFieldId = 'label';
+  static const double _dragEpsilon = 0.001;
 
   late final ControlInputPortPrototype _inputPortPrototype =
       ControlInputPortPrototype(
@@ -301,18 +302,24 @@ class FlNodesCanvasController implements FlNodesHighlightController {
   void _handleSelectionDragged(Set<String> nodeIds) {
     for (final nodeId in nodeIds) {
       final instance = controller.nodes[nodeId];
-      if (instance == null) continue;
-      final updatedNode = _nodes[nodeId]?.copyWith(
+      final cachedNode = _nodes[nodeId];
+      if (instance == null || cachedNode == null) continue;
+
+      final deltaX = (instance.offset.dx - cachedNode.x).abs();
+      final deltaY = (instance.offset.dy - cachedNode.y).abs();
+      if (deltaX < _dragEpsilon && deltaY < _dragEpsilon) {
+        continue;
+      }
+
+      final updatedNode = cachedNode.copyWith(
         x: instance.offset.dx,
         y: instance.offset.dy,
       );
-      if (updatedNode != null) {
-        _nodes[nodeId] = updatedNode;
-      }
+      _nodes[nodeId] = updatedNode;
       _provider.moveState(
         id: nodeId,
-        x: instance.offset.dx,
-        y: instance.offset.dy,
+        x: updatedNode.x,
+        y: updatedNode.y,
       );
     }
   }

--- a/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
@@ -49,6 +49,7 @@ class FlNodesPdaCanvasController implements FlNodesHighlightController {
   static const String _inPortId = 'incoming';
   static const String _outPortId = 'outgoing';
   static const String _labelFieldId = 'label';
+  static const double _dragEpsilon = 0.001;
 
   late final ControlInputPortPrototype _inputPortPrototype =
       ControlInputPortPrototype(
@@ -306,18 +307,24 @@ class FlNodesPdaCanvasController implements FlNodesHighlightController {
   void _handleSelectionDragged(Set<String> nodeIds) {
     for (final nodeId in nodeIds) {
       final instance = controller.nodes[nodeId];
-      if (instance == null) continue;
-      final updatedNode = _nodes[nodeId]?.copyWith(
+      final cachedNode = _nodes[nodeId];
+      if (instance == null || cachedNode == null) continue;
+
+      final deltaX = (instance.offset.dx - cachedNode.x).abs();
+      final deltaY = (instance.offset.dy - cachedNode.y).abs();
+      if (deltaX < _dragEpsilon && deltaY < _dragEpsilon) {
+        continue;
+      }
+
+      final updatedNode = cachedNode.copyWith(
         x: instance.offset.dx,
         y: instance.offset.dy,
       );
-      if (updatedNode != null) {
-        _nodes[nodeId] = updatedNode;
-      }
+      _nodes[nodeId] = updatedNode;
       _notifier.moveState(
         id: nodeId,
-        x: instance.offset.dx,
-        y: instance.offset.dy,
+        x: updatedNode.x,
+        y: updatedNode.y,
       );
     }
   }

--- a/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
@@ -50,6 +50,7 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
   static const String _inPortId = 'incoming';
   static const String _outPortId = 'outgoing';
   static const String _labelFieldId = 'label';
+  static const double _dragEpsilon = 0.001;
 
   late final ControlInputPortPrototype _inputPortPrototype =
       ControlInputPortPrototype(
@@ -295,18 +296,24 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
   void _handleSelectionDragged(Set<String> nodeIds) {
     for (final nodeId in nodeIds) {
       final instance = controller.nodes[nodeId];
-      if (instance == null) continue;
-      final updatedNode = _nodes[nodeId]?.copyWith(
+      final cachedNode = _nodes[nodeId];
+      if (instance == null || cachedNode == null) continue;
+
+      final deltaX = (instance.offset.dx - cachedNode.x).abs();
+      final deltaY = (instance.offset.dy - cachedNode.y).abs();
+      if (deltaX < _dragEpsilon && deltaY < _dragEpsilon) {
+        continue;
+      }
+
+      final updatedNode = cachedNode.copyWith(
         x: instance.offset.dx,
         y: instance.offset.dy,
       );
-      if (updatedNode != null) {
-        _nodes[nodeId] = updatedNode;
-      }
+      _nodes[nodeId] = updatedNode;
       _notifier.moveState(
         id: nodeId,
-        x: instance.offset.dx,
-        y: instance.offset.dy,
+        x: updatedNode.x,
+        y: updatedNode.y,
       );
     }
   }

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:fl_nodes/fl_nodes.dart';
+// ignore: implementation_imports
+import 'package:fl_nodes/src/core/models/events.dart' show DragSelectionEndEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -240,6 +242,42 @@ void main() {
       expect(call['label'], equals('mid'));
       expect(call['x'], equals(12.0));
       expect(call['y'], equals(18.0));
+    });
+
+    test('does not call moveState when drag ends without movement', () async {
+      final node = _buildNode(
+        controller,
+        id: 'p0',
+        label: 'start',
+        offset: const Offset(30, 40),
+      );
+
+      controller.controller.eventBus.emit(
+        AddNodeEvent(node, id: 'seed-static'),
+      );
+
+      await _flushEvents();
+
+      final instance = controller.controller.nodes['p0']!;
+      controller.controller.eventBus.emit(
+        DragSelectionEndEvent(
+          instance.offset,
+          {'p0'},
+          id: 'drag-static',
+        ),
+      );
+
+      await _flushEvents();
+
+      final moveCalls = notifier.stateCalls
+          .where((call) => call['type'] == 'move')
+          .toList();
+      expect(moveCalls, isEmpty);
+
+      final cached = controller.nodeById('p0');
+      expect(cached, isNotNull);
+      expect(cached!.x, equals(30.0));
+      expect(cached.y, equals(40.0));
     });
 
     test('updates labels via NodeFieldEvent submissions', () async {


### PR DESCRIPTION
## Summary
- add a shared epsilon guard to skip move updates when drag selections end where they started across the automaton, PDA, and TM controllers
- keep internal node caches untouched on no-op drags and ensure providers are not notified unnecessarily
- extend controller tests to assert no provider updates are emitted for zero-displacement drags

## Testing
- ⚠️ `flutter test` *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e026249b40832e9930cef0bc68d3b9