### PR TITLE
Remove deprecated AutomatonCanvas callback parameter

### DIFF
--- a/API_DOCUMENTATION.md
+++ b/API_DOCUMENTATION.md
@@ -213,7 +213,10 @@ Interactive canvas for drawing automata:
 class AutomatonCanvas extends StatefulWidget {
   final FSA? automaton;
   final GlobalKey canvasKey;
-  final ValueChanged<FSA> onAutomatonChanged;
+  final SimulationResult? simulationResult;
+  final int? currentStepIndex;
+  final bool showTrace;
+  final FlNodesCanvasController? controller;
 }
 ```
 

--- a/lib/presentation/widgets/automaton_canvas_native.dart
+++ b/lib/presentation/widgets/automaton_canvas_native.dart
@@ -32,27 +32,15 @@ class AutomatonCanvas extends ConsumerStatefulWidget {
     super.key,
     required this.automaton,
     required this.canvasKey,
-    @Deprecated(
-      'No longer used; the canvas writes directly to AutomatonProvider.',
-    )
-    ValueChanged<FSA>? onAutomatonChanged,
     this.simulationResult,
     this.currentStepIndex,
     this.showTrace = false,
     this.controller,
-  }) : _deprecatedOnAutomatonChanged = onAutomatonChanged;
+  });
 
   final FSA? automaton;
   final GlobalKey canvasKey;
   final FlNodesCanvasController? controller;
-
-  /// Legacy callback kept for compatibility with pre-fl_nodes canvases. All
-  /// mutations now happen directly through [AutomatonProvider].
-  // ignore: unused_field
-  @Deprecated(
-    'No longer used; the canvas writes directly to AutomatonProvider.',
-  )
-  final ValueChanged<FSA>? _deprecatedOnAutomatonChanged;
 
   final SimulationResult? simulationResult;
   final int? currentStepIndex;

--- a/specs/003-ui-improvement-taskforce/contracts/canvas_rendering_contract.md
+++ b/specs/003-ui-improvement-taskforce/contracts/canvas_rendering_contract.md
@@ -386,7 +386,6 @@ testWidgets('AutomatonCanvas renders and responds to tap', (tester) async {
       body: AutomatonCanvas(
         automaton: TestFixtures.simpleDFA.toProductionModel(),
         canvasKey: GlobalKey(),
-        onAutomatonChanged: (_) {},
       ),
     ),
   ));
@@ -407,7 +406,6 @@ testGoldens('AutomatonCanvas DFA rendering', (tester) async {
     AutomatonCanvas(
       automaton: TestFixtures.simpleDFA.toProductionModel(),
       canvasKey: GlobalKey(),
-      onAutomatonChanged: (_) {},
     ),
   );
   

--- a/specs/003-ui-improvement-taskforce/contracts/golden_test_contract.md
+++ b/specs/003-ui-improvement-taskforce/contracts/golden_test_contract.md
@@ -187,7 +187,6 @@ testGoldens('AutomatonCanvas empty state', (tester) async {
     AutomatonCanvas(
       automaton: null,  // Empty state
       canvasKey: GlobalKey(),
-      onAutomatonChanged: (_) {},
     ),
     wrapper: materialAppWrapper(
       theme: ThemeData.light(),

--- a/specs/003-ui-improvement-taskforce/contracts/widget_test_contract.md
+++ b/specs/003-ui-improvement-taskforce/contracts/widget_test_contract.md
@@ -101,7 +101,6 @@ testWidgets('AutomatonCanvas renders DFA correctly', (tester) async {
         body: AutomatonCanvas(
           automaton: testDFA.toProductionModel(),
           canvasKey: canvasKey,
-          onAutomatonChanged: (_) {},
         ),
       ),
     ),
@@ -206,7 +205,6 @@ testWidgets('Canvas controls accessible on mobile', (tester) async {
         body: AutomatonCanvas(
           automaton: TestFixtures.simpleDFA.toProductionModel(),
           canvasKey: GlobalKey(),
-          onAutomatonChanged: (_) {},
         ),
       ),
     ),

--- a/specs/003-ui-improvement-taskforce/research.md
+++ b/specs/003-ui-improvement-taskforce/research.md
@@ -249,7 +249,6 @@ testGoldens('AutomatonCanvas renders DFA correctly', (tester) async {
     AutomatonCanvas(
       automaton: createTestDFA(),
       canvasKey: GlobalKey(),
-      onAutomatonChanged: (_) {},
     ),
   );
 

--- a/test/widget/presentation/automaton_canvas_web_highlight_test.dart
+++ b/test/widget/presentation/automaton_canvas_web_highlight_test.dart
@@ -33,7 +33,6 @@ void main() {
             body: AutomatonCanvas(
               automaton: automaton,
               canvasKey: canvasKey,
-              onAutomatonChanged: (_) {},
               controller: controller,
             ),
           ),

--- a/test/widget/presentation/immutable_traces_visualization_test.dart
+++ b/test/widget/presentation/immutable_traces_visualization_test.dart
@@ -54,7 +54,6 @@ void main() {
               body: AutomatonCanvas(
                 automaton: automaton,
                 canvasKey: GlobalKey(),
-                onAutomatonChanged: (_) {},
                 controller: controller,
               ),
             ),
@@ -289,7 +288,6 @@ void main() {
               body: AutomatonCanvas(
                 automaton: largeDFA,
                 canvasKey: canvasKey,
-                onAutomatonChanged: (_) {},
                 controller: controller,
               ),
             ),


### PR DESCRIPTION
## Summary
- remove the deprecated `onAutomatonChanged` parameter and backing field from `AutomatonCanvas`
- update widget tests, specs, and API docs to stop passing the obsolete callback

## Testing
- `flutter test test/widget/presentation/automaton_canvas_web_highlight_test.dart` *(fails: flutter command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0400df1ec832e903e895d936c7bdf