### PR TITLE
Extract shared viewport highlight helpers for fl_nodes controllers

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
@@ -9,17 +9,19 @@ import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/tm.dart';
 import '../../../core/models/tm_transition.dart';
-import '../../../core/models/simulation_highlight.dart';
 import '../../../presentation/providers/tm_editor_provider.dart';
 import 'fl_nodes_canvas_models.dart';
 import 'fl_nodes_highlight_controller.dart';
 import 'fl_nodes_label_field_editor.dart';
 import 'fl_nodes_tm_mapper.dart';
+import 'fl_nodes_viewport_highlight_mixin.dart';
 import 'link_geometry_event_utils.dart';
 
 /// Controller responsible for synchronising the fl_nodes editor with the
 /// [TMEditorNotifier].
-class FlNodesTmCanvasController implements FlNodesHighlightController {
+class FlNodesTmCanvasController
+    with FlNodesViewportHighlightMixin
+    implements FlNodesHighlightController {
   FlNodesTmCanvasController({
     required TMEditorNotifier editorNotifier,
     FlNodeEditorController? editorController,
@@ -34,10 +36,6 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
 
   final Map<String, FlNodesCanvasNode> _nodes = {};
   final Map<String, FlNodesCanvasEdge> _edges = {};
-  final ValueNotifier<SimulationHighlight> highlightNotifier = ValueNotifier(
-    SimulationHighlight.empty,
-  );
-  final Set<String> _highlightedTransitionIds = <String>{};
   StreamSubscription<NodeEditorEvent>? _subscription;
   bool _isSynchronizing = false;
 
@@ -47,6 +45,9 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
   Iterable<FlNodesCanvasEdge> get edges => _edges.values;
   FlNodesCanvasNode? nodeById(String id) => _nodes[id];
   FlNodesCanvasEdge? edgeById(String id) => _edges[id];
+
+  @override
+  Map<String, FlNodesCanvasNode> get nodesCache => _nodes;
 
   static const String _statePrototypeId = 'tm_state';
   static const String _inPortId = 'incoming';
@@ -108,74 +109,13 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
 
   void dispose() {
     _subscription?.cancel();
-    highlightNotifier.dispose();
+    disposeViewportHighlight();
     controller.dispose();
-  }
-
-  void zoomIn() {
-    controller.setViewportZoom(
-      (controller.viewportZoom * 1.2).clamp(0.05, 10.0),
-    );
-  }
-
-  void zoomOut() {
-    controller.setViewportZoom(
-      (controller.viewportZoom / 1.2).clamp(0.05, 10.0),
-    );
-  }
-
-  void resetView() {
-    controller.setViewportOffset(Offset.zero, absolute: true);
-    controller.setViewportZoom(1.0);
-  }
-
-  void fitToContent() {
-    if (_nodes.isEmpty) {
-      resetView();
-      return;
-    }
-
-    final previousNodeSelection = controller.selectedNodeIds.toList();
-    final previousLinkSelection = controller.selectedLinkIds.toList();
-
-    controller.focusNodesById(_nodes.keys.toSet());
-    controller.clearSelection(isHandled: true);
-
-    if (previousNodeSelection.isNotEmpty) {
-      controller.selectNodesById(
-        previousNodeSelection.toSet(),
-        holdSelection: false,
-        isHandled: true,
-      );
-    }
-
-    if (previousLinkSelection.isNotEmpty) {
-      controller.selectLinkById(
-        previousLinkSelection.first,
-        holdSelection: false,
-        isHandled: true,
-      );
-      for (final linkId in previousLinkSelection.skip(1)) {
-        controller.selectLinkById(linkId, holdSelection: true, isHandled: true);
-      }
-    }
   }
 
   void addStateAtCenter() {
     final center = -controller.viewportOffset;
     controller.addNode(_statePrototypeId, offset: center);
-  }
-
-  @override
-  void applyHighlight(SimulationHighlight highlight) {
-    _updateLinkHighlights(highlight.transitionIds);
-    highlightNotifier.value = highlight;
-  }
-
-  @override
-  void clearHighlight() {
-    _updateLinkHighlights(const <String>{});
-    highlightNotifier.value = SimulationHighlight.empty;
   }
 
   void _registerPrototypes() {
@@ -201,9 +141,9 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
       controller.addLinkFromExisting(_buildLink(edge), isHandled: true);
     }
 
-    if (_highlightedTransitionIds.isNotEmpty ||
+    if (highlightedTransitionIds.isNotEmpty ||
         highlightNotifier.value.transitionIds.isNotEmpty) {
-      _updateLinkHighlights(_highlightedTransitionIds);
+      updateLinkHighlights(highlightedTransitionIds);
     }
 
     _isSynchronizing = false;
@@ -399,8 +339,8 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
       tapeNumber: 0,
     );
     _edges[edge.id] = edge;
-    if (_highlightedTransitionIds.contains(edge.id)) {
-      _updateLinkHighlights(_highlightedTransitionIds);
+    if (highlightedTransitionIds.contains(edge.id)) {
+      updateLinkHighlights(highlightedTransitionIds);
     }
     _notifier.addOrUpdateTransition(
       id: edge.id,
@@ -417,10 +357,6 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
     _notifier.removeTransition(id: link.id);
   }
 
-  FlNodesCanvasNode? nodeById(String id) => _nodes[id];
-
-  FlNodesCanvasEdge? edgeById(String id) => _edges[id];
-
   String _resolveLabel(NodeInstance node) {
     final field = node.fields[_labelFieldId];
     final data = field?.data;
@@ -428,35 +364,5 @@ class FlNodesTmCanvasController implements FlNodesHighlightController {
       return data.trim();
     }
     return node.id;
-  }
-
-  void _updateLinkHighlights(Set<String> transitionIds) {
-    final desiredIds = Set<String>.from(transitionIds);
-    final idsToVisit = <String>{..._highlightedTransitionIds, ...desiredIds};
-
-    final manualSelection = controller.selectedLinkIds.toSet();
-    var hasChanged = false;
-
-    for (final linkId in idsToVisit) {
-      final link = controller.linksById[linkId];
-      if (link == null) {
-        continue;
-      }
-      final shouldSelect =
-          desiredIds.contains(linkId) || manualSelection.contains(linkId);
-      if (link.state.isSelected != shouldSelect) {
-        link.state.isSelected = shouldSelect;
-        hasChanged = true;
-      }
-    }
-
-    if (hasChanged) {
-      controller.linksDataDirty = true;
-      controller.notifyListeners();
-    }
-
-    _highlightedTransitionIds
-      ..clear()
-      ..addAll(desiredIds);
   }
 }

--- a/lib/features/canvas/fl_nodes/fl_nodes_viewport_highlight_mixin.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_viewport_highlight_mixin.dart
@@ -1,0 +1,125 @@
+import 'package:fl_nodes/fl_nodes.dart';
+import 'package:flutter/material.dart';
+
+import '../../../core/models/simulation_highlight.dart';
+import 'fl_nodes_canvas_models.dart';
+import 'fl_nodes_highlight_controller.dart';
+
+/// Shared viewport and highlight helpers for fl_nodes canvas controllers.
+mixin FlNodesViewportHighlightMixin on FlNodesHighlightController {
+  /// Exposes the underlying editor controller.
+  FlNodeEditorController get controller;
+
+  /// Provides access to the cached canvas nodes.
+  Map<String, FlNodesCanvasNode> get nodesCache;
+
+  /// Notifier used to broadcast highlight updates to listeners.
+  final ValueNotifier<SimulationHighlight> highlightNotifier = ValueNotifier(
+    SimulationHighlight.empty,
+  );
+
+  /// Tracks the ids of the transitions currently highlighted.
+  final Set<String> highlightedTransitionIds = <String>{};
+
+  /// Releases the resources owned by the mixin.
+  void disposeViewportHighlight() {
+    highlightNotifier.dispose();
+  }
+
+  /// Increases the viewport zoom while respecting reasonable bounds.
+  void zoomIn() {
+    controller.setViewportZoom(
+      (controller.viewportZoom * 1.2).clamp(0.05, 10.0),
+    );
+  }
+
+  /// Decreases the viewport zoom while respecting reasonable bounds.
+  void zoomOut() {
+    controller.setViewportZoom(
+      (controller.viewportZoom / 1.2).clamp(0.05, 10.0),
+    );
+  }
+
+  /// Resets the viewport offset and zoom to their defaults.
+  void resetView() {
+    controller.setViewportOffset(Offset.zero, absolute: true);
+    controller.setViewportZoom(1.0);
+  }
+
+  /// Adjusts the viewport to focus on the available nodes while
+  /// preserving the previous selection.
+  void fitToContent() {
+    if (nodesCache.isEmpty) {
+      resetView();
+      return;
+    }
+
+    final previousNodeSelection = controller.selectedNodeIds.toList();
+    final previousLinkSelection = controller.selectedLinkIds.toList();
+
+    controller.focusNodesById(nodesCache.keys.toSet());
+    controller.clearSelection(isHandled: true);
+
+    if (previousNodeSelection.isNotEmpty) {
+      controller.selectNodesById(
+        previousNodeSelection.toSet(),
+        holdSelection: false,
+        isHandled: true,
+      );
+    }
+
+    if (previousLinkSelection.isNotEmpty) {
+      controller.selectLinkById(
+        previousLinkSelection.first,
+        holdSelection: false,
+        isHandled: true,
+      );
+      for (final linkId in previousLinkSelection.skip(1)) {
+        controller.selectLinkById(linkId, holdSelection: true, isHandled: true);
+      }
+    }
+  }
+
+  @override
+  void applyHighlight(SimulationHighlight highlight) {
+    updateLinkHighlights(highlight.transitionIds);
+    highlightNotifier.value = highlight;
+  }
+
+  @override
+  void clearHighlight() {
+    updateLinkHighlights(const <String>{});
+    highlightNotifier.value = SimulationHighlight.empty;
+  }
+
+  /// Updates the link selection to match the provided highlighted ids.
+  void updateLinkHighlights(Set<String> transitionIds) {
+    final desiredIds = Set<String>.from(transitionIds);
+    final idsToVisit = <String>{...highlightedTransitionIds, ...desiredIds};
+
+    final manualSelection = controller.selectedLinkIds.toSet();
+    var hasChanged = false;
+
+    for (final linkId in idsToVisit) {
+      final link = controller.linksById[linkId];
+      if (link == null) {
+        continue;
+      }
+      final shouldSelect =
+          desiredIds.contains(linkId) || manualSelection.contains(linkId);
+      if (link.state.isSelected != shouldSelect) {
+        link.state.isSelected = shouldSelect;
+        hasChanged = true;
+      }
+    }
+
+    if (hasChanged) {
+      controller.linksDataDirty = true;
+      controller.notifyListeners();
+    }
+
+    highlightedTransitionIds
+      ..clear()
+      ..addAll(desiredIds);
+  }
+}

--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
@@ -202,6 +202,50 @@ void main() {
       controller.dispose();
     });
 
+    test('viewport helpers adjust zoom and offset', () {
+      controller.resetView();
+      final initialZoom = controller.controller.viewportZoom;
+
+      controller.zoomIn();
+      expect(controller.controller.viewportZoom, greaterThan(initialZoom));
+
+      controller.zoomOut();
+      expect(
+        controller.controller.viewportZoom,
+        closeTo(initialZoom, 1e-6),
+      );
+
+      controller.controller.setViewportOffset(const Offset(12, -24));
+      controller.controller.setViewportZoom(1.5);
+
+      controller.resetView();
+      expect(controller.controller.viewportOffset, equals(Offset.zero));
+      expect(controller.controller.viewportZoom, closeTo(1.0, 1e-6));
+    });
+
+    test('fitToContent resets view when no nodes exist', () {
+      controller.controller.setViewportOffset(const Offset(-48, 32));
+      controller.controller.setViewportZoom(0.4);
+
+      controller.fitToContent();
+
+      expect(controller.controller.viewportOffset, equals(Offset.zero));
+      expect(controller.controller.viewportZoom, closeTo(1.0, 1e-6));
+    });
+
+    test('highlight helpers update notifier state', () {
+      const highlight = SimulationHighlight(transitionIds: {'t42'});
+
+      controller.applyHighlight(highlight);
+      expect(
+        controller.highlightNotifier.value.transitionIds,
+        contains('t42'),
+      );
+
+      controller.clearHighlight();
+      expect(controller.highlightNotifier.value.transitionIds, isEmpty);
+    });
+
     test('synchronize populates nodes and edges from automaton', () {
       final q0 = State(
         id: 'q0',

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
@@ -169,6 +169,50 @@ void main() {
       controller.dispose();
     });
 
+    test('viewport helpers adjust zoom and offset', () {
+      controller.resetView();
+      final initialZoom = controller.controller.viewportZoom;
+
+      controller.zoomIn();
+      expect(controller.controller.viewportZoom, greaterThan(initialZoom));
+
+      controller.zoomOut();
+      expect(
+        controller.controller.viewportZoom,
+        closeTo(initialZoom, 1e-6),
+      );
+
+      controller.controller.setViewportOffset(const Offset(-16, 24));
+      controller.controller.setViewportZoom(1.4);
+
+      controller.resetView();
+      expect(controller.controller.viewportOffset, equals(Offset.zero));
+      expect(controller.controller.viewportZoom, closeTo(1.0, 1e-6));
+    });
+
+    test('fitToContent resets view when no nodes exist', () {
+      controller.controller.setViewportOffset(const Offset(32, -12));
+      controller.controller.setViewportZoom(0.3);
+
+      controller.fitToContent();
+
+      expect(controller.controller.viewportOffset, equals(Offset.zero));
+      expect(controller.controller.viewportZoom, closeTo(1.0, 1e-6));
+    });
+
+    test('highlight helpers update notifier state', () {
+      const highlight = SimulationHighlight(transitionIds: {'edge'});
+
+      controller.applyHighlight(highlight);
+      expect(
+        controller.highlightNotifier.value.transitionIds,
+        contains('edge'),
+      );
+
+      controller.clearHighlight();
+      expect(controller.highlightNotifier.value.transitionIds, isEmpty);
+    });
+
     test('synchronize mirrors PDA data into controller state', () {
       final q0 = State(
         id: 'q0',

--- a/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
@@ -155,6 +155,50 @@ void main() {
       controller.dispose();
     });
 
+    test('viewport helpers adjust zoom and offset', () {
+      controller.resetView();
+      final initialZoom = controller.controller.viewportZoom;
+
+      controller.zoomIn();
+      expect(controller.controller.viewportZoom, greaterThan(initialZoom));
+
+      controller.zoomOut();
+      expect(
+        controller.controller.viewportZoom,
+        closeTo(initialZoom, 1e-6),
+      );
+
+      controller.controller.setViewportOffset(const Offset(18, -30));
+      controller.controller.setViewportZoom(1.3);
+
+      controller.resetView();
+      expect(controller.controller.viewportOffset, equals(Offset.zero));
+      expect(controller.controller.viewportZoom, closeTo(1.0, 1e-6));
+    });
+
+    test('fitToContent resets view when no nodes exist', () {
+      controller.controller.setViewportOffset(const Offset(-28, 16));
+      controller.controller.setViewportZoom(0.6);
+
+      controller.fitToContent();
+
+      expect(controller.controller.viewportOffset, equals(Offset.zero));
+      expect(controller.controller.viewportZoom, closeTo(1.0, 1e-6));
+    });
+
+    test('highlight helpers update notifier state', () {
+      const highlight = SimulationHighlight(transitionIds: {'edge'});
+
+      controller.applyHighlight(highlight);
+      expect(
+        controller.highlightNotifier.value.transitionIds,
+        contains('edge'),
+      );
+
+      controller.clearHighlight();
+      expect(controller.highlightNotifier.value.transitionIds, isEmpty);
+    });
+
     test('synchronize rebuilds controller state from TM', () {
       final q0 = State(
         id: 'q0',


### PR DESCRIPTION
## Summary
- introduce a shared viewport/highlight mixin for fl_nodes controllers and migrate the FSA, PDA, and TM implementations to it
- keep mapper/provider logic in the concrete controllers while delegating viewport utilities to the mixin
- extend controller unit tests to verify the shared helpers without changing the public API

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e041f771f8832e90968ef0dd6de1f3