### PR TITLE
Add responsive canvas toolbar layout

### DIFF
--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -373,19 +373,18 @@ class _FSAPageState extends ConsumerState<FSAPage> {
       return Stack(
         children: [
           Positioned.fill(child: child),
-          Positioned(
-            top: 12,
-            right: 12,
-            child: FlNodesCanvasToolbar(
-              onAddState: _canvasController.addStateAtCenter,
-              onZoomIn: _canvasController.zoomIn,
-              onZoomOut: _canvasController.zoomOut,
-              onFitToContent: _canvasController.fitToContent,
-              onResetView: _canvasController.resetView,
-              onClear: () =>
-                  ref.read(automatonProvider.notifier).clearAutomaton(),
-              statusMessage: statusMessage,
-            ),
+          FlNodesCanvasToolbar(
+            layout: isMobile
+                ? FlNodesCanvasToolbarLayout.mobile
+                : FlNodesCanvasToolbarLayout.desktop,
+            onAddState: _canvasController.addStateAtCenter,
+            onZoomIn: _canvasController.zoomIn,
+            onZoomOut: _canvasController.zoomOut,
+            onFitToContent: _canvasController.fitToContent,
+            onResetView: _canvasController.resetView,
+            onClear:
+                () => ref.read(automatonProvider.notifier).clearAutomaton(),
+            statusMessage: statusMessage,
           ),
         ],
       );

--- a/lib/presentation/pages/pda_page.dart
+++ b/lib/presentation/pages/pda_page.dart
@@ -99,6 +99,7 @@ class _PDAPageState extends ConsumerState<PDAPage> {
                       controller: _canvasController,
                       onPdaModified: _handlePdaModified,
                     ),
+                    isMobile: true,
                   ),
                 ),
               ),
@@ -294,6 +295,7 @@ class _PDAPageState extends ConsumerState<PDAPage> {
                 controller: _canvasController,
                 onPdaModified: _handlePdaModified,
               ),
+              isMobile: false,
             ),
           ),
         ),
@@ -377,28 +379,30 @@ class _PDAPageState extends ConsumerState<PDAPage> {
     );
   }
 
-  Widget _buildCanvasWithToolbar(Widget canvas) {
+  Widget _buildCanvasWithToolbar(
+    Widget canvas, {
+    required bool isMobile,
+  }) {
     final editorState = ref.watch(pdaEditorProvider);
     final statusMessage = _buildToolbarStatusMessage(editorState);
 
     return Stack(
       children: [
         Positioned.fill(child: canvas),
-        Positioned(
-          top: 12,
-          right: 12,
-          child: FlNodesCanvasToolbar(
-            onAddState: _canvasController.addStateAtCenter,
-            onZoomIn: _canvasController.zoomIn,
-            onZoomOut: _canvasController.zoomOut,
-            onFitToContent: _canvasController.fitToContent,
-            onResetView: _canvasController.resetView,
-            onClear: () => ref.read(pdaEditorProvider.notifier).updateFromCanvas(
-                  states: const <automaton_state.State>[],
-                  transitions: const <PDATransition>[],
-                ),
-            statusMessage: statusMessage,
-          ),
+        FlNodesCanvasToolbar(
+          layout: isMobile
+              ? FlNodesCanvasToolbarLayout.mobile
+              : FlNodesCanvasToolbarLayout.desktop,
+          onAddState: _canvasController.addStateAtCenter,
+          onZoomIn: _canvasController.zoomIn,
+          onZoomOut: _canvasController.zoomOut,
+          onFitToContent: _canvasController.fitToContent,
+          onResetView: _canvasController.resetView,
+          onClear: () => ref.read(pdaEditorProvider.notifier).updateFromCanvas(
+                states: const <automaton_state.State>[],
+                transitions: const <PDATransition>[],
+              ),
+          statusMessage: statusMessage,
         ),
       ],
     );

--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -131,7 +131,7 @@ class _TMPageState extends ConsumerState<TMPage> {
           Expanded(
             child: Padding(
               padding: const EdgeInsets.all(8),
-              child: _buildCanvasWithToolbar(),
+              child: _buildCanvasWithToolbar(isMobile: true),
             ),
           ),
         ],
@@ -147,7 +147,7 @@ class _TMPageState extends ConsumerState<TMPage> {
           flex: 2,
           child: Container(
             margin: const EdgeInsets.all(8),
-            child: _buildCanvasWithToolbar(),
+            child: _buildCanvasWithToolbar(isMobile: false),
           ),
         ),
         const SizedBox(width: 16),
@@ -181,7 +181,7 @@ class _TMPageState extends ConsumerState<TMPage> {
     );
   }
 
-  Widget _buildCanvasWithToolbar() {
+  Widget _buildCanvasWithToolbar({required bool isMobile}) {
     final editorState = ref.watch(tmEditorProvider);
     final statusMessage = _buildToolbarStatusMessage(editorState);
 
@@ -193,23 +193,22 @@ class _TMPageState extends ConsumerState<TMPage> {
             onTMModified: _handleTMUpdate,
           ),
         ),
-        Positioned(
-          top: 12,
-          right: 12,
-          child: FlNodesCanvasToolbar(
-            onAddState: _canvasController.addStateAtCenter,
-            onZoomIn: _canvasController.zoomIn,
-            onZoomOut: _canvasController.zoomOut,
-            onFitToContent: _canvasController.fitToContent,
-            onResetView: _canvasController.resetView,
-            onClear: () {
-              ref.read(tmEditorProvider.notifier).updateFromCanvas(
-                    states: const <automaton_state.State>[],
-                    transitions: const <TMTransition>[],
-                  );
-            },
-            statusMessage: statusMessage,
-          ),
+        FlNodesCanvasToolbar(
+          layout: isMobile
+              ? FlNodesCanvasToolbarLayout.mobile
+              : FlNodesCanvasToolbarLayout.desktop,
+          onAddState: _canvasController.addStateAtCenter,
+          onZoomIn: _canvasController.zoomIn,
+          onZoomOut: _canvasController.zoomOut,
+          onFitToContent: _canvasController.fitToContent,
+          onResetView: _canvasController.resetView,
+          onClear: () {
+            ref.read(tmEditorProvider.notifier).updateFromCanvas(
+                  states: const <automaton_state.State>[],
+                  transitions: const <TMTransition>[],
+                );
+          },
+          statusMessage: statusMessage,
         ),
       ],
     );

--- a/lib/presentation/widgets/fl_nodes_canvas_toolbar.dart
+++ b/lib/presentation/widgets/fl_nodes_canvas_toolbar.dart
@@ -11,6 +11,7 @@ class FlNodesCanvasToolbar extends StatelessWidget {
     required this.onResetView,
     this.onClear,
     this.statusMessage,
+    this.layout = FlNodesCanvasToolbarLayout.desktop,
   });
 
   final VoidCallback onAddState;
@@ -20,12 +21,11 @@ class FlNodesCanvasToolbar extends StatelessWidget {
   final VoidCallback onResetView;
   final VoidCallback? onClear;
   final String? statusMessage;
+  final FlNodesCanvasToolbarLayout layout;
 
   @override
   Widget build(BuildContext context) {
-    final colorScheme = Theme.of(context).colorScheme;
-    final textTheme = Theme.of(context).textTheme;
-
+    final theme = Theme.of(context);
     final actions = <(_ToolbarAction action, VoidCallback handler)>[
       (_ToolbarAction.addState, onAddState),
       (_ToolbarAction.zoomIn, onZoomIn),
@@ -35,57 +35,187 @@ class FlNodesCanvasToolbar extends StatelessWidget {
       if (onClear != null) (_ToolbarAction.clear, onClear!),
     ];
 
-    final toolbar = Container(
-      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
-      decoration: BoxDecoration(
-        color: colorScheme.surface,
-        borderRadius: BorderRadius.circular(12),
-        boxShadow: [
-          BoxShadow(
-            color: Colors.black.withOpacity(0.08),
-            blurRadius: 12,
-            offset: const Offset(0, 4),
-          ),
-        ],
-      ),
-      child: Row(
-        mainAxisSize: MainAxisSize.min,
-        children: [
-          for (final entry in actions) ...[
-            IconButton(
-              tooltip: entry.$1.tooltip,
-              icon: Icon(entry.$1.icon),
-              onPressed: entry.$2,
+    switch (layout) {
+      case FlNodesCanvasToolbarLayout.mobile:
+        return _MobileToolbar(
+          actions: actions,
+          statusMessage: statusMessage,
+          theme: theme,
+        );
+      case FlNodesCanvasToolbarLayout.desktop:
+        return _DesktopToolbar(
+          actions: actions,
+          statusMessage: statusMessage,
+          theme: theme,
+        );
+    }
+  }
+}
+
+enum FlNodesCanvasToolbarLayout { desktop, mobile }
+
+class _DesktopToolbar extends StatelessWidget {
+  const _DesktopToolbar({
+    required this.actions,
+    required this.statusMessage,
+    required this.theme,
+  });
+
+  final List<(_ToolbarAction, VoidCallback)> actions;
+  final String? statusMessage;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Align(
+      alignment: Alignment.topRight,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.08),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (final entry in actions) ...[
+                    IconButton(
+                      tooltip: entry.$1.label,
+                      icon: Icon(entry.$1.icon),
+                      onPressed: entry.$2,
+                    ),
+                    if (entry != actions.last)
+                      Container(
+                        width: 1,
+                        height: 24,
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        color:
+                            colorScheme.outlineVariant.withOpacity(0.35),
+                      ),
+                  ],
+                ],
+              ),
             ),
-            if (entry != actions.last)
-              Container(
-                width: 1,
-                height: 24,
-                margin: const EdgeInsets.symmetric(horizontal: 4),
-                color: colorScheme.outlineVariant.withOpacity(0.35),
+            if (statusMessage != null && statusMessage!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  statusMessage!,
+                  style: textTheme.labelSmall?.copyWith(
+                    color: colorScheme.onSurfaceVariant,
+                  ),
+                  textAlign: TextAlign.center,
+                ),
               ),
           ],
-        ],
+        ),
       ),
     );
+  }
+}
 
-    return Column(
-      mainAxisSize: MainAxisSize.min,
-      crossAxisAlignment: CrossAxisAlignment.center,
-      children: [
-        toolbar,
-        if (statusMessage != null && statusMessage!.isNotEmpty)
-          Padding(
-            padding: const EdgeInsets.only(top: 8),
-            child: Text(
-              statusMessage!,
-              style: textTheme.labelSmall?.copyWith(
-                color: colorScheme.onSurfaceVariant,
+class _MobileToolbar extends StatelessWidget {
+  const _MobileToolbar({
+    required this.actions,
+    required this.statusMessage,
+    required this.theme,
+  });
+
+  final List<(_ToolbarAction, VoidCallback)> actions;
+  final String? statusMessage;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: SafeArea(
+        minimum: const EdgeInsets.all(12),
+        child: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 520),
+          child: Material(
+            elevation: 8,
+            borderRadius: BorderRadius.circular(24),
+            color: colorScheme.surface,
+            child: Padding(
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Wrap(
+                    alignment: WrapAlignment.center,
+                    spacing: 12,
+                    runSpacing: 12,
+                    children: [
+                      for (final entry in actions)
+                        _MobileToolbarButton(
+                          action: entry.$1,
+                          onPressed: entry.$2,
+                        ),
+                    ],
+                  ),
+                  if (statusMessage != null && statusMessage!.isNotEmpty)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 12),
+                      child: Text(
+                        statusMessage!,
+                        style: textTheme.bodySmall?.copyWith(
+                          color: colorScheme.onSurfaceVariant,
+                        ),
+                        textAlign: TextAlign.center,
+                      ),
+                    ),
+                ],
               ),
-              textAlign: TextAlign.center,
             ),
           ),
-      ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileToolbarButton extends StatelessWidget {
+  const _MobileToolbarButton({
+    required this.action,
+    required this.onPressed,
+  });
+
+  final _ToolbarAction action;
+  final VoidCallback onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    return FilledButton.icon(
+      style: FilledButton.styleFrom(
+        backgroundColor: colorScheme.surfaceContainerHigh,
+        foregroundColor: colorScheme.onSurface,
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+      ),
+      onPressed: onPressed,
+      icon: Icon(action.icon),
+      label: Text(action.label),
     );
   }
 }
@@ -98,8 +228,8 @@ enum _ToolbarAction {
   resetView(Icons.center_focus_strong, 'Reset view'),
   clear(Icons.delete_outline, 'Clear canvas');
 
-  const _ToolbarAction(this.icon, this.tooltip);
+  const _ToolbarAction(this.icon, this.label);
 
   final IconData icon;
-  final String tooltip;
+  final String label;
 }

--- a/test/widget/presentation/fl_nodes_canvas_toolbar_test.dart
+++ b/test/widget/presentation/fl_nodes_canvas_toolbar_test.dart
@@ -15,6 +15,7 @@ void main() {
             onFitToContent: _noop,
             onResetView: _noop,
             statusMessage: '3 states · 4 transitions',
+            layout: FlNodesCanvasToolbarLayout.desktop,
           ),
         ),
       ),
@@ -33,6 +34,7 @@ void main() {
             onZoomOut: _noop,
             onFitToContent: _noop,
             onResetView: _noop,
+            layout: FlNodesCanvasToolbarLayout.desktop,
           ),
         ),
       ),
@@ -40,6 +42,47 @@ void main() {
 
     expect(find.textContaining('states'), findsNothing);
     expect(find.textContaining('transitions'), findsNothing);
+  });
+
+  testWidgets('Desktop layout renders compact icon buttons', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FlNodesCanvasToolbar(
+            onAddState: _noop,
+            onZoomIn: _noop,
+            onZoomOut: _noop,
+            onFitToContent: _noop,
+            onResetView: _noop,
+            layout: FlNodesCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(IconButton), findsNWidgets(5));
+    expect(find.byType(FilledButton), findsNothing);
+  });
+
+  testWidgets('Mobile layout renders filled buttons with labels', (tester) async {
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: Scaffold(
+          body: FlNodesCanvasToolbar(
+            onAddState: _noop,
+            onZoomIn: _noop,
+            onZoomOut: _noop,
+            onFitToContent: _noop,
+            onResetView: _noop,
+            layout: FlNodesCanvasToolbarLayout.mobile,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(FilledButton), findsNWidgets(5));
+    expect(find.text('Add state'), findsOneWidget);
+    expect(find.text('Zoom in'), findsOneWidget);
   });
 }
 


### PR DESCRIPTION
## Summary
- refactor `FlNodesCanvasToolbar` into desktop and mobile variants with shared callbacks
- update FSA, PDA, and TM canvas stacks to select the new responsive layout based on breakpoint
- add widget tests that verify compact desktop buttons and mobile filled buttons

## Testing
- Not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68e0455fdadc832e9e5eb43c90c88d07