### PR TITLE
Refactor fl_nodes canvas controllers into shared base

### DIFF
--- a/lib/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart
@@ -1,0 +1,388 @@
+import 'dart:async';
+
+import 'package:fl_nodes/fl_nodes.dart';
+// ignore: implementation_imports
+import 'package:fl_nodes/src/core/models/events.dart' show DragSelectionEndEvent;
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+
+import 'fl_nodes_canvas_models.dart';
+import 'fl_nodes_highlight_controller.dart';
+import 'fl_nodes_label_field_editor.dart';
+import 'fl_nodes_viewport_highlight_mixin.dart';
+import 'link_geometry_event_utils.dart';
+
+/// Base controller that coordinates fl_nodes interactions with domain notifiers.
+abstract class BaseFlNodesCanvasController<TNotifier, TSnapshot>
+    with FlNodesViewportHighlightMixin
+    implements FlNodesHighlightController {
+  BaseFlNodesCanvasController({
+    required TNotifier notifier,
+    FlNodeEditorController? editorController,
+  })  : notifier = notifier,
+        controller = editorController ?? FlNodeEditorController() {
+    controller.registerNodePrototype(statePrototype);
+    _subscription = controller.eventBus.events.listen(_handleEvent);
+  }
+
+  @protected
+  final TNotifier notifier;
+
+  @override
+  final FlNodeEditorController controller;
+
+  final Map<String, FlNodesCanvasNode> _nodes = {};
+  final Map<String, FlNodesCanvasEdge> _edges = {};
+
+  StreamSubscription<NodeEditorEvent>? _subscription;
+  bool _isSynchronizing = false;
+
+  static const String inPortId = 'incoming';
+  static const String outPortId = 'outgoing';
+  static const String labelFieldId = 'label';
+  static const double dragEpsilon = 0.001;
+
+  late final ControlInputPortPrototype inputPortPrototype =
+      ControlInputPortPrototype(
+        idName: inPortId,
+        displayName: (_) => 'Entrada',
+      );
+
+  late final ControlOutputPortPrototype outputPortPrototype =
+      ControlOutputPortPrototype(
+        idName: outPortId,
+        displayName: (_) => 'Saída',
+      );
+
+  late final FieldPrototype labelFieldPrototype = FieldPrototype(
+    idName: labelFieldId,
+    displayName: (_) => 'Rótulo',
+    dataType: String,
+    defaultData: '',
+    style: const FlFieldStyle(),
+    visualizerBuilder: (value) {
+      final text = (value as String?)?.trim();
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: Text(
+          text == null || text.isEmpty ? 'Sem nome' : text,
+          style: const TextStyle(fontWeight: FontWeight.w600),
+        ),
+      );
+    },
+    editorBuilder: (context, removeOverlay, value, setData) {
+      return FlNodesLabelFieldEditor(
+        initialValue: (value as String?) ?? '',
+        onSubmit: (label) {
+          setData(label, eventType: FieldEventType.submit);
+          removeOverlay();
+        },
+        onCancel: () {
+          setData(value, eventType: FieldEventType.cancel);
+          removeOverlay();
+        },
+      );
+    },
+  );
+
+  late final NodePrototype statePrototype = NodePrototype(
+    idName: statePrototypeId,
+    displayName: (_) => stateDisplayName,
+    description: (_) => stateDescription,
+    ports: [inputPortPrototype, outputPortPrototype],
+    fields: [labelFieldPrototype],
+    onExecute: (ports, fields, execState, forward, put) async {},
+  );
+
+  /// Unique identifier for the primary node prototype handled by the canvas.
+  String get statePrototypeId;
+
+  /// Human readable description for the canvas node prototype.
+  String get stateDescription;
+
+  /// Display name used for the canvas node prototype.
+  String get stateDisplayName => 'Estado';
+
+  /// Converts domain state into a snapshot consumed by the canvas.
+  @protected
+  FlNodesAutomatonSnapshot toSnapshot(TSnapshot? data);
+
+  /// Builds a canvas node representation from the emitted [NodeInstance].
+  @protected
+  FlNodesCanvasNode createCanvasNode(NodeInstance node);
+
+  /// Notifies subclasses that [node] was added to the canvas.
+  @protected
+  void onCanvasNodeAdded(FlNodesCanvasNode node);
+
+  /// Notifies subclasses that the node with [nodeId] was removed from the canvas.
+  @protected
+  void onCanvasNodeRemoved(String nodeId);
+
+  /// Notifies subclasses that a batch of nodes changed their coordinates.
+  @protected
+  void onCanvasNodesMoved(Map<String, FlNodesCanvasNode> updatedNodes);
+
+  /// Notifies subclasses that [node] had its label updated.
+  @protected
+  void onCanvasNodeLabelUpdated(FlNodesCanvasNode node);
+
+  /// Creates the canvas edge representation for the provided [link].
+  @protected
+  FlNodesCanvasEdge? createEdgeForLink(Link link);
+
+  /// Notifies subclasses that [edge] was added to the canvas.
+  @protected
+  void onCanvasEdgeAdded(FlNodesCanvasEdge edge);
+
+  /// Notifies subclasses that the edge with [edgeId] was removed from the canvas.
+  @protected
+  void onCanvasEdgeRemoved(String edgeId);
+
+  /// Notifies subclasses that [edge] received a new control point [controlPoint].
+  @protected
+  void onCanvasEdgeGeometryUpdated(FlNodesCanvasEdge edge, Offset controlPoint);
+
+  /// Exposes the cached edges to subclasses.
+  @protected
+  Map<String, FlNodesCanvasEdge> get edgesCache => _edges;
+
+  int get nodeCount => _nodes.length;
+  int get edgeCount => _edges.length;
+  Iterable<FlNodesCanvasNode> get nodes => _nodes.values;
+  Iterable<FlNodesCanvasEdge> get edges => _edges.values;
+  FlNodesCanvasNode? nodeById(String id) => _nodes[id];
+  FlNodesCanvasEdge? edgeById(String id) => _edges[id];
+
+  @override
+  Map<String, FlNodesCanvasNode> get nodesCache => _nodes;
+
+  /// Releases the resources owned by the controller.
+  void dispose() {
+    _subscription?.cancel();
+    disposeViewportHighlight();
+    controller.dispose();
+  }
+
+  /// Adds a new state centred in the current viewport.
+  void addStateAtCenter() {
+    final center = -controller.viewportOffset;
+    controller.addNode(statePrototypeId, offset: center);
+  }
+
+  /// Adds a new state at the provided [worldPosition].
+  void addStateAt(Offset worldPosition) {
+    controller.addNode(statePrototypeId, offset: worldPosition);
+  }
+
+  /// Synchronises the canvas with the provided domain [data].
+  @protected
+  void synchronizeCanvas(TSnapshot? data) {
+    final snapshot = toSnapshot(data);
+    _isSynchronizing = true;
+    controller.clear();
+    _nodes
+      ..clear()
+      ..addEntries(snapshot.nodes.map((node) => MapEntry(node.id, node)));
+    _edges
+      ..clear()
+      ..addEntries(snapshot.edges.map((edge) => MapEntry(edge.id, edge)));
+
+    for (final node in snapshot.nodes) {
+      controller.addNodeFromExisting(_buildNodeInstance(node), isHandled: true);
+    }
+
+    for (final edge in snapshot.edges) {
+      controller.addLinkFromExisting(_buildLink(edge), isHandled: true);
+    }
+
+    if (highlightedTransitionIds.isNotEmpty ||
+        highlightNotifier.value.transitionIds.isNotEmpty) {
+      updateLinkHighlights(highlightedTransitionIds);
+    }
+
+    _isSynchronizing = false;
+  }
+
+  NodeInstance _buildNodeInstance(FlNodesCanvasNode node) {
+    final ports = {
+      inPortId: PortInstance(
+        prototype: inputPortPrototype,
+        state: PortState(),
+      ),
+      outPortId: PortInstance(
+        prototype: outputPortPrototype,
+        state: PortState(),
+      ),
+    };
+
+    final fields = {
+      labelFieldId: FieldInstance(
+        prototype: labelFieldPrototype,
+        data: node.label,
+      ),
+    };
+
+    return NodeInstance(
+      id: node.id,
+      prototype: statePrototype,
+      ports: ports,
+      fields: fields,
+      state: NodeState(),
+      offset: Offset(node.x, node.y),
+    );
+  }
+
+  Link _buildLink(FlNodesCanvasEdge edge) {
+    return Link(
+      id: edge.id,
+      fromTo: (
+        from: edge.fromStateId,
+        to: edge.toStateId,
+        fromPort: outPortId,
+        toPort: inPortId,
+      ),
+      state: LinkState(),
+    );
+  }
+
+  void _handleEvent(NodeEditorEvent event) {
+    if (_isSynchronizing || event.isHandled) {
+      return;
+    }
+
+    final geometryPayload = parseLinkGeometryEvent(event);
+    if (geometryPayload != null) {
+      _handleLinkGeometryEvent(geometryPayload);
+      return;
+    }
+
+    if (event is AddNodeEvent) {
+      _handleNodeAdded(event.node);
+    } else if (event is RemoveNodeEvent) {
+      _handleNodeRemoved(event.node);
+    } else if (event is DragSelectionEndEvent) {
+      _handleSelectionDragged(event.nodeIds);
+    } else if (event is NodeFieldEvent) {
+      _handleNodeField(event);
+    } else if (event is AddLinkEvent) {
+      _handleLinkAdded(event.link);
+    } else if (event is RemoveLinkEvent) {
+      _handleLinkRemoved(event.link);
+    }
+  }
+
+  void _handleLinkGeometryEvent(LinkGeometryEventPayload payload) {
+    final edge = _edges[payload.linkId];
+    if (edge == null || !payload.hasControlPoint) {
+      return;
+    }
+
+    final double updatedX = payload.controlPoint?.dx ?? 0;
+    final double updatedY = payload.controlPoint?.dy ?? 0;
+
+    if ((edge.controlPointX ?? 0) == updatedX &&
+        (edge.controlPointY ?? 0) == updatedY) {
+      return;
+    }
+
+    final updatedEdge = edge.copyWith(
+      controlPointX: updatedX,
+      controlPointY: updatedY,
+    );
+    _edges[payload.linkId] = updatedEdge;
+
+    onCanvasEdgeGeometryUpdated(updatedEdge, Offset(updatedX, updatedY));
+  }
+
+  void _handleNodeAdded(NodeInstance node) {
+    final canvasNode = createCanvasNode(node);
+    _nodes[node.id] = canvasNode;
+    onCanvasNodeAdded(canvasNode);
+  }
+
+  void _handleNodeRemoved(NodeInstance node) {
+    _nodes.remove(node.id);
+    onCanvasNodeRemoved(node.id);
+  }
+
+  void _handleSelectionDragged(Set<String> nodeIds) {
+    final updatedNodes = <String, FlNodesCanvasNode>{};
+
+    for (final nodeId in nodeIds) {
+      final instance = controller.nodes[nodeId];
+      final cachedNode = _nodes[nodeId];
+      if (instance == null || cachedNode == null) {
+        continue;
+      }
+
+      final deltaX = (instance.offset.dx - cachedNode.x).abs();
+      final deltaY = (instance.offset.dy - cachedNode.y).abs();
+      if (deltaX < dragEpsilon && deltaY < dragEpsilon) {
+        continue;
+      }
+
+      final updatedNode = cachedNode.copyWith(
+        x: instance.offset.dx,
+        y: instance.offset.dy,
+      );
+      _nodes[nodeId] = updatedNode;
+      updatedNodes[nodeId] = updatedNode;
+    }
+
+    if (updatedNodes.isNotEmpty) {
+      onCanvasNodesMoved(updatedNodes);
+    }
+  }
+
+  void _handleNodeField(NodeFieldEvent event) {
+    if (event.eventType != FieldEventType.submit) {
+      return;
+    }
+    final updatedNode = _nodes[event.nodeId]?.copyWith(
+      label: (event.value as String?)?.trim() ?? '',
+    );
+    if (updatedNode != null) {
+      _nodes[event.nodeId] = updatedNode;
+      onCanvasNodeLabelUpdated(updatedNode);
+    }
+  }
+
+  void _handleLinkAdded(Link link) {
+    final fromStateId = link.fromTo.from;
+    final toStateId = link.fromTo.to;
+    final fromPortId = link.fromTo.fromPort;
+    final toPortId = link.fromTo.toPort;
+
+    if (fromPortId != outPortId || toPortId != inPortId) {
+      return;
+    }
+
+    final edge = createEdgeForLink(link);
+    if (edge == null) {
+      return;
+    }
+
+    _edges[edge.id] = edge;
+    if (highlightedTransitionIds.contains(edge.id)) {
+      updateLinkHighlights(highlightedTransitionIds);
+    }
+    onCanvasEdgeAdded(edge);
+  }
+
+  void _handleLinkRemoved(Link link) {
+    _edges.remove(link.id);
+    onCanvasEdgeRemoved(link.id);
+  }
+
+  /// Resolves the display label for the provided [node] instance.
+  @protected
+  String resolveLabel(NodeInstance node) {
+    final field = node.fields[labelFieldId];
+    final data = field?.data;
+    if (data is String && data.trim().isNotEmpty) {
+      return data.trim();
+    }
+    return node.id;
+  }
+}

--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -1,265 +1,41 @@
-import 'dart:async';
-
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart'
-    show DragSelectionEndEvent;
 import 'package:flutter/material.dart';
 
 import '../../../core/models/fsa.dart';
 import '../../../presentation/providers/automaton_provider.dart';
+import 'base_fl_nodes_canvas_controller.dart';
 import 'fl_nodes_automaton_mapper.dart';
 import 'fl_nodes_canvas_models.dart';
-import 'fl_nodes_highlight_controller.dart';
-import 'fl_nodes_label_field_editor.dart';
-import 'fl_nodes_viewport_highlight_mixin.dart';
-import 'link_geometry_event_utils.dart';
 
 /// Controller that keeps the [FlNodeEditorController] in sync with the
 /// [AutomatonProvider].
-class FlNodesCanvasController
-    with FlNodesViewportHighlightMixin
-    implements FlNodesHighlightController {
+class FlNodesCanvasController extends BaseFlNodesCanvasController<AutomatonProvider, FSA> {
   FlNodesCanvasController({
     required AutomatonProvider automatonProvider,
     FlNodeEditorController? editorController,
-  }) : _provider = automatonProvider,
-       controller = editorController ?? FlNodeEditorController() {
-    _registerPrototypes();
-    _subscription = controller.eventBus.events.listen(_handleEvent);
-  }
+  }) : super(
+          notifier: automatonProvider,
+          editorController: editorController,
+        );
 
-  final AutomatonProvider _provider;
+  AutomatonProvider get _provider => notifier;
 
-  /// Underlying controller exposed to widgets embedding fl_nodes.
-  final FlNodeEditorController controller;
+  @override
+  String get statePrototypeId => 'automaton_state';
 
-  final Map<String, FlNodesCanvasNode> _nodes = {};
-  final Map<String, FlNodesCanvasEdge> _edges = {};
-  StreamSubscription<NodeEditorEvent>? _subscription;
-  bool _isSynchronizing = false;
+  @override
+  String get stateDescription => 'Estado do autômato finito';
 
-  int get nodeCount => _nodes.length;
-  int get edgeCount => _edges.length;
-  Iterable<FlNodesCanvasNode> get nodes => _nodes.values;
-  Iterable<FlNodesCanvasEdge> get edges => _edges.values;
-  FlNodesCanvasNode? nodeById(String id) => _nodes[id];
-  FlNodesCanvasEdge? edgeById(String id) => _edges[id];
-
-  static const String _statePrototypeId = 'automaton_state';
-  static const String _inPortId = 'incoming';
-  static const String _outPortId = 'outgoing';
-  static const String _labelFieldId = 'label';
-  static const double _dragEpsilon = 0.001;
-
-  late final ControlInputPortPrototype _inputPortPrototype =
-      ControlInputPortPrototype(
-        idName: _inPortId,
-        displayName: (_) => 'Entrada',
-      );
-
-  late final ControlOutputPortPrototype _outputPortPrototype =
-      ControlOutputPortPrototype(
-        idName: _outPortId,
-        displayName: (_) => 'Saída',
-      );
-
-  late final FieldPrototype _labelFieldPrototype = FieldPrototype(
-    idName: _labelFieldId,
-    displayName: (_) => 'Rótulo',
-    dataType: String,
-    defaultData: '',
-    style: const FlFieldStyle(),
-    visualizerBuilder: (value) {
-      final text = (value as String?)?.trim();
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Text(
-          text == null || text.isEmpty ? 'Sem nome' : text,
-          style: const TextStyle(fontWeight: FontWeight.w600),
-        ),
-      );
-    },
-    editorBuilder: (context, removeOverlay, value, setData) {
-      return FlNodesLabelFieldEditor(
-        initialValue: (value as String?) ?? '',
-        onSubmit: (label) {
-          setData(label, eventType: FieldEventType.submit);
-          removeOverlay();
-        },
-        onCancel: () {
-          setData(value, eventType: FieldEventType.cancel);
-          removeOverlay();
-        },
-      );
-    },
-  );
-
-  late final NodePrototype _statePrototype = NodePrototype(
-    idName: _statePrototypeId,
-    displayName: (_) => 'Estado',
-    description: (_) => 'Estado do autômato finito',
-    ports: [_inputPortPrototype, _outputPortPrototype],
-    fields: [_labelFieldPrototype],
-    onExecute: (ports, fields, execState, forward, put) async {},
-  );
-
-  /// Releases resources held by the controller.
-  void dispose() {
-    _subscription?.cancel();
-    disposeViewportHighlight();
-    controller.dispose();
-  }
-
-  void addStateAtCenter() {
-    final center = -controller.viewportOffset;
-    controller.addNode(_statePrototypeId, offset: center);
-  }
-
-  void addStateAt(Offset worldPosition) {
-    controller.addNode(_statePrototypeId, offset: worldPosition);
+  @override
+  FlNodesAutomatonSnapshot toSnapshot(FSA? automaton) {
+    return FlNodesAutomatonMapper.toSnapshot(automaton);
   }
 
   @override
-  Map<String, FlNodesCanvasNode> get nodesCache => _nodes;
-
-  void _registerPrototypes() {
-    controller.registerNodePrototype(_statePrototype);
-  }
-
-  /// Synchronises the fl_nodes controller with the latest [automaton].
-  void synchronize(FSA? automaton) {
-    final snapshot = FlNodesAutomatonMapper.toSnapshot(automaton);
-    _isSynchronizing = true;
-    controller.clear();
-    _nodes
-      ..clear()
-      ..addEntries(snapshot.nodes.map((node) => MapEntry(node.id, node)));
-    _edges
-      ..clear()
-      ..addEntries(snapshot.edges.map((edge) => MapEntry(edge.id, edge)));
-
-    for (final node in snapshot.nodes) {
-      controller.addNodeFromExisting(_buildNodeInstance(node), isHandled: true);
-    }
-
-    for (final edge in snapshot.edges) {
-      controller.addLinkFromExisting(_buildLink(edge), isHandled: true);
-    }
-
-    if (highlightedTransitionIds.isNotEmpty ||
-        highlightNotifier.value.transitionIds.isNotEmpty) {
-      updateLinkHighlights(highlightedTransitionIds);
-    }
-
-    _isSynchronizing = false;
-  }
-
-  NodeInstance _buildNodeInstance(FlNodesCanvasNode node) {
-    final ports = {
-      _inPortId: PortInstance(
-        prototype: _inputPortPrototype,
-        state: PortState(),
-      ),
-      _outPortId: PortInstance(
-        prototype: _outputPortPrototype,
-        state: PortState(),
-      ),
-    };
-
-    final fields = {
-      _labelFieldId: FieldInstance(
-        prototype: _labelFieldPrototype,
-        data: node.label,
-      ),
-    };
-
-    return NodeInstance(
-      id: node.id,
-      prototype: _statePrototype,
-      ports: ports,
-      fields: fields,
-      state: NodeState(),
-      offset: Offset(node.x, node.y),
-    );
-  }
-
-  Link _buildLink(FlNodesCanvasEdge edge) {
-    return Link(
-      id: edge.id,
-      fromTo: (
-        from: edge.fromStateId,
-        to: edge.toStateId,
-        fromPort: _outPortId,
-        toPort: _inPortId,
-      ),
-      state: LinkState(),
-    );
-  }
-
-  void _handleEvent(NodeEditorEvent event) {
-    if (_isSynchronizing || event.isHandled) {
-      return;
-    }
-
-    final geometryPayload = parseLinkGeometryEvent(event);
-    if (geometryPayload != null) {
-      _handleLinkGeometryEvent(geometryPayload);
-      return;
-    }
-
-    if (event is AddNodeEvent) {
-      _handleNodeAdded(event.node);
-    } else if (event is RemoveNodeEvent) {
-      _handleNodeRemoved(event.node);
-    } else if (event is DragSelectionEndEvent) {
-      _handleSelectionDragged(event.nodeIds);
-    } else if (event is NodeFieldEvent) {
-      _handleNodeField(event);
-    } else if (event is AddLinkEvent) {
-      _handleLinkAdded(event.link);
-    } else if (event is RemoveLinkEvent) {
-      _handleLinkRemoved(event.link);
-    }
-  }
-
-  void _handleLinkGeometryEvent(LinkGeometryEventPayload payload) {
-    final edge = _edges[payload.linkId];
-    if (edge == null) {
-      return;
-    }
-
-    if (!payload.hasControlPoint) {
-      return;
-    }
-
-    final double updatedX = payload.controlPoint?.dx ?? 0;
-    final double updatedY = payload.controlPoint?.dy ?? 0;
-    if ((edge.controlPointX ?? 0) == updatedX &&
-        (edge.controlPointY ?? 0) == updatedY) {
-      return;
-    }
-
-    final updatedEdge = edge.copyWith(
-      controlPointX: updatedX,
-      controlPointY: updatedY,
-    );
-    _edges[payload.linkId] = updatedEdge;
-
-    _provider.addOrUpdateTransition(
-      id: updatedEdge.id,
-      fromStateId: updatedEdge.fromStateId,
-      toStateId: updatedEdge.toStateId,
-      label: updatedEdge.label,
-      controlPointX: updatedX,
-      controlPointY: updatedY,
-    );
-  }
-
-  void _handleNodeAdded(NodeInstance node) {
-    final label = _resolveLabel(node);
-    final isFirstState = _nodes.isEmpty;
-    final canvasNode = FlNodesCanvasNode(
+  FlNodesCanvasNode createCanvasNode(NodeInstance node) {
+    final label = resolveLabel(node);
+    final isFirstState = nodesCache.isEmpty;
+    return FlNodesCanvasNode(
       id: node.id,
       label: label,
       x: node.offset.dx,
@@ -267,106 +43,88 @@ class FlNodesCanvasController
       isInitial: isFirstState,
       isAccepting: false,
     );
-    _nodes[node.id] = canvasNode;
+  }
+
+  @override
+  void onCanvasNodeAdded(FlNodesCanvasNode node) {
     _provider.addState(
-      id: canvasNode.id,
-      label: canvasNode.label,
-      x: canvasNode.x,
-      y: canvasNode.y,
-      isInitial: isFirstState ? true : null,
-      isAccepting: canvasNode.isAccepting,
+      id: node.id,
+      label: node.label,
+      x: node.x,
+      y: node.y,
+      isInitial: node.isInitial ? true : null,
+      isAccepting: node.isAccepting,
     );
   }
 
-  void _handleNodeRemoved(NodeInstance node) {
-    _nodes.remove(node.id);
-    _provider.removeState(id: node.id);
+  @override
+  void onCanvasNodeRemoved(String nodeId) {
+    _provider.removeState(id: nodeId);
   }
 
-  void _handleSelectionDragged(Set<String> nodeIds) {
-    for (final nodeId in nodeIds) {
-      final instance = controller.nodes[nodeId];
-      final cachedNode = _nodes[nodeId];
-      if (instance == null || cachedNode == null) continue;
-
-      final deltaX = (instance.offset.dx - cachedNode.x).abs();
-      final deltaY = (instance.offset.dy - cachedNode.y).abs();
-      if (deltaX < _dragEpsilon && deltaY < _dragEpsilon) {
-        continue;
-      }
-
-      final updatedNode = cachedNode.copyWith(
-        x: instance.offset.dx,
-        y: instance.offset.dy,
-      );
-      _nodes[nodeId] = updatedNode;
+  @override
+  void onCanvasNodesMoved(Map<String, FlNodesCanvasNode> updatedNodes) {
+    for (final entry in updatedNodes.entries) {
       _provider.moveState(
-        id: nodeId,
-        x: updatedNode.x,
-        y: updatedNode.y,
+        id: entry.key,
+        x: entry.value.x,
+        y: entry.value.y,
       );
     }
   }
 
-  void _handleNodeField(NodeFieldEvent event) {
-    if (event.eventType != FieldEventType.submit) {
-      return;
-    }
-    final updatedNode = _nodes[event.nodeId]?.copyWith(
-      label: (event.value as String?)?.trim() ?? '',
+  @override
+  void onCanvasNodeLabelUpdated(FlNodesCanvasNode node) {
+    _provider.updateStateLabel(
+      id: node.id,
+      label: node.label.isEmpty ? node.id : node.label,
     );
-    if (updatedNode != null) {
-      _nodes[event.nodeId] = updatedNode;
-      _provider.updateStateLabel(
-        id: event.nodeId,
-        label: updatedNode.label.isEmpty ? event.nodeId : updatedNode.label,
-      );
-    }
   }
 
-  void _handleLinkAdded(Link link) {
-    final fromStateId = link.fromTo.from;
-    final toStateId = link.fromTo.to;
-    final fromPortId = link.fromTo.fromPort;
-    final toPortId = link.fromTo.toPort;
-
-    if (fromPortId != _outPortId || toPortId != _inPortId) {
-      return;
-    }
-
-    final edge = FlNodesCanvasEdge(
+  @override
+  FlNodesCanvasEdge? createEdgeForLink(Link link) {
+    return FlNodesCanvasEdge(
       id: link.id,
-      fromStateId: fromStateId,
-      toStateId: toStateId,
+      fromStateId: link.fromTo.from,
+      toStateId: link.fromTo.to,
       symbols: const <String>[],
       lambdaSymbol: null,
       controlPointX: null,
       controlPointY: null,
     );
-    _edges[edge.id] = edge;
-    if (highlightedTransitionIds.contains(edge.id)) {
-      updateLinkHighlights(highlightedTransitionIds);
-    }
+  }
+
+  @override
+  void onCanvasEdgeAdded(FlNodesCanvasEdge edge) {
     _provider.addOrUpdateTransition(
       id: edge.id,
       fromStateId: edge.fromStateId,
       toStateId: edge.toStateId,
       label: edge.label,
+      controlPointX: edge.controlPointX,
+      controlPointY: edge.controlPointY,
     );
   }
 
-  void _handleLinkRemoved(Link link) {
-    _edges.remove(link.id);
-    _provider.removeTransition(id: link.id);
+  @override
+  void onCanvasEdgeRemoved(String edgeId) {
+    _provider.removeTransition(id: edgeId);
   }
 
-  String _resolveLabel(NodeInstance node) {
-    final field = node.fields[_labelFieldId];
-    final data = field?.data;
-    if (data is String && data.trim().isNotEmpty) {
-      return data.trim();
-    }
-    return node.id;
+  @override
+  void onCanvasEdgeGeometryUpdated(FlNodesCanvasEdge edge, Offset controlPoint) {
+    _provider.addOrUpdateTransition(
+      id: edge.id,
+      fromStateId: edge.fromStateId,
+      toStateId: edge.toStateId,
+      label: edge.label,
+      controlPointX: controlPoint.dx,
+      controlPointY: controlPoint.dy,
+    );
   }
 
+  /// Synchronises the fl_nodes controller with the latest [automaton].
+  void synchronize(FSA? automaton) {
+    synchronizeCanvas(automaton);
+  }
 }

--- a/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart
@@ -1,356 +1,105 @@
-import 'dart:async';
-
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart'
-    show DragSelectionEndEvent;
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/pda.dart';
 import '../../../presentation/providers/pda_editor_provider.dart';
+import 'base_fl_nodes_canvas_controller.dart';
 import 'fl_nodes_canvas_models.dart';
-import 'fl_nodes_highlight_controller.dart';
-import 'fl_nodes_label_field_editor.dart';
 import 'fl_nodes_pda_mapper.dart';
-import 'fl_nodes_viewport_highlight_mixin.dart';
-import 'link_geometry_event_utils.dart';
 
 /// Controller responsible for synchronising the fl_nodes editor with the
 /// [PDAEditorNotifier].
 class FlNodesPdaCanvasController
-    with FlNodesViewportHighlightMixin
-    implements FlNodesHighlightController {
+    extends BaseFlNodesCanvasController<PDAEditorNotifier, PDA> {
   FlNodesPdaCanvasController({
     required PDAEditorNotifier editorNotifier,
     FlNodeEditorController? editorController,
-  }) : _notifier = editorNotifier,
-       controller = editorController ?? FlNodeEditorController() {
-    _registerPrototypes();
-    _subscription = controller.eventBus.events.listen(_handleEvent);
-  }
+  }) : super(
+          notifier: editorNotifier,
+          editorController: editorController,
+        );
 
-  final PDAEditorNotifier _notifier;
-  final FlNodeEditorController controller;
-
-  final Map<String, FlNodesCanvasNode> _nodes = {};
-  final Map<String, FlNodesCanvasEdge> _edges = {};
-  StreamSubscription<NodeEditorEvent>? _subscription;
-  bool _isSynchronizing = false;
-
-  int get nodeCount => _nodes.length;
-  int get edgeCount => _edges.length;
-  Iterable<FlNodesCanvasNode> get nodes => _nodes.values;
-  Iterable<FlNodesCanvasEdge> get edges => _edges.values;
-  FlNodesCanvasNode? nodeById(String id) => _nodes[id];
-  FlNodesCanvasEdge? edgeById(String id) => _edges[id];
+  PDAEditorNotifier get _notifier => notifier;
 
   @override
-  Map<String, FlNodesCanvasNode> get nodesCache => _nodes;
+  String get statePrototypeId => 'pda_state';
 
-  static const String _statePrototypeId = 'pda_state';
-  static const String _inPortId = 'incoming';
-  static const String _outPortId = 'outgoing';
-  static const String _labelFieldId = 'label';
-  static const double _dragEpsilon = 0.001;
+  @override
+  String get stateDescription => 'Estado do autômato com pilha';
 
-  late final ControlInputPortPrototype _inputPortPrototype =
-      ControlInputPortPrototype(
-        idName: _inPortId,
-        displayName: (_) => 'Entrada',
-      );
-
-  late final ControlOutputPortPrototype _outputPortPrototype =
-      ControlOutputPortPrototype(
-        idName: _outPortId,
-        displayName: (_) => 'Saída',
-      );
-
-  late final FieldPrototype _labelFieldPrototype = FieldPrototype(
-    idName: _labelFieldId,
-    displayName: (_) => 'Rótulo',
-    dataType: String,
-    defaultData: '',
-    style: const FlFieldStyle(),
-    visualizerBuilder: (value) {
-      final text = (value as String?)?.trim();
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Text(
-          text == null || text.isEmpty ? 'Sem nome' : text,
-          style: const TextStyle(fontWeight: FontWeight.w600),
-        ),
-      );
-    },
-    editorBuilder: (context, removeOverlay, value, setData) {
-      return FlNodesLabelFieldEditor(
-        initialValue: (value as String?) ?? '',
-        onSubmit: (label) {
-          setData(label, eventType: FieldEventType.submit);
-          removeOverlay();
-        },
-        onCancel: () {
-          setData(value, eventType: FieldEventType.cancel);
-          removeOverlay();
-        },
-      );
-    },
-  );
-
-  late final NodePrototype _statePrototype = NodePrototype(
-    idName: _statePrototypeId,
-    displayName: (_) => 'Estado',
-    description: (_) => 'Estado do autômato com pilha',
-    ports: [_inputPortPrototype, _outputPortPrototype],
-    fields: [_labelFieldPrototype],
-    onExecute: (ports, fields, execState, forward, put) async {},
-  );
-
-  void dispose() {
-    _subscription?.cancel();
-    disposeViewportHighlight();
-    controller.dispose();
+  @override
+  FlNodesAutomatonSnapshot toSnapshot(PDA? automaton) {
+    return FlNodesPdaMapper.toSnapshot(automaton);
   }
 
-  void addStateAtCenter() {
-    final center = -controller.viewportOffset;
-    controller.addNode(_statePrototypeId, offset: center);
-  }
-
-  void addStateAt(Offset worldPosition) {
-    controller.addNode(_statePrototypeId, offset: worldPosition);
-  }
-
-  void _registerPrototypes() {
-    controller.registerNodePrototype(_statePrototype);
-  }
-
-  void synchronize(PDA? automaton) {
-    final snapshot = FlNodesPdaMapper.toSnapshot(automaton);
-    _isSynchronizing = true;
-    controller.clear();
-    _nodes
-      ..clear()
-      ..addEntries(snapshot.nodes.map((node) => MapEntry(node.id, node)));
-    _edges
-      ..clear()
-      ..addEntries(snapshot.edges.map((edge) => MapEntry(edge.id, edge)));
-
-    for (final node in snapshot.nodes) {
-      controller.addNodeFromExisting(_buildNodeInstance(node), isHandled: true);
-    }
-
-    for (final edge in snapshot.edges) {
-      controller.addLinkFromExisting(_buildLink(edge), isHandled: true);
-    }
-
-    if (highlightedTransitionIds.isNotEmpty ||
-        highlightNotifier.value.transitionIds.isNotEmpty) {
-      updateLinkHighlights(highlightedTransitionIds);
-    }
-
-    _isSynchronizing = false;
-  }
-
-  NodeInstance _buildNodeInstance(FlNodesCanvasNode node) {
-    final ports = {
-      _inPortId: PortInstance(
-        prototype: _inputPortPrototype,
-        state: PortState(),
-      ),
-      _outPortId: PortInstance(
-        prototype: _outputPortPrototype,
-        state: PortState(),
-      ),
-    };
-
-    final fields = {
-      _labelFieldId: FieldInstance(
-        prototype: _labelFieldPrototype,
-        data: node.label,
-      ),
-    };
-
-    return NodeInstance(
-      id: node.id,
-      prototype: _statePrototype,
-      ports: ports,
-      fields: fields,
-      state: NodeState(),
-      offset: Offset(node.x, node.y),
-    );
-  }
-
-  Link _buildLink(FlNodesCanvasEdge edge) {
-    return Link(
-      id: edge.id,
-      fromTo: (
-        from: edge.fromStateId,
-        to: edge.toStateId,
-        fromPort: _outPortId,
-        toPort: _inPortId,
-      ),
-      state: LinkState(),
-    );
-  }
-
-  void _handleEvent(NodeEditorEvent event) {
-    if (_isSynchronizing || event.isHandled) {
-      return;
-    }
-
-    final geometryPayload = parseLinkGeometryEvent(event);
-    if (geometryPayload != null) {
-      _handleLinkGeometryEvent(geometryPayload);
-      return;
-    }
-
-    if (event is AddNodeEvent) {
-      _handleNodeAdded(event.node);
-    } else if (event is RemoveNodeEvent) {
-      _handleNodeRemoved(event.node);
-    } else if (event is DragSelectionEndEvent) {
-      _handleSelectionDragged(event.nodeIds);
-    } else if (event is NodeFieldEvent) {
-      _handleNodeField(event);
-    } else if (event is AddLinkEvent) {
-      _handleLinkAdded(event.link);
-    } else if (event is RemoveLinkEvent) {
-      _handleLinkRemoved(event.link);
-    }
-  }
-
-  void _handleLinkGeometryEvent(LinkGeometryEventPayload payload) {
-    final edge = _edges[payload.linkId];
-    if (edge == null) {
-      return;
-    }
-
-    if (!payload.hasControlPoint) {
-      return;
-    }
-
-    final double updatedX = payload.controlPoint?.dx ?? 0;
-    final double updatedY = payload.controlPoint?.dy ?? 0;
-    if ((edge.controlPointX ?? 0) == updatedX &&
-        (edge.controlPointY ?? 0) == updatedY) {
-      return;
-    }
-
-    final updatedEdge = edge.copyWith(
-      controlPointX: updatedX,
-      controlPointY: updatedY,
-    );
-    _edges[payload.linkId] = updatedEdge;
-
-    final vectorControlPoint = Vector2(updatedX, updatedY);
-
-    _notifier.upsertTransition(
-      id: updatedEdge.id,
-      fromStateId: updatedEdge.fromStateId,
-      toStateId: updatedEdge.toStateId,
-      label: updatedEdge.label,
-      readSymbol: updatedEdge.readSymbol,
-      popSymbol: updatedEdge.popSymbol,
-      pushSymbol: updatedEdge.pushSymbol,
-      isLambdaInput: updatedEdge.isLambdaInput,
-      isLambdaPop: updatedEdge.isLambdaPop,
-      isLambdaPush: updatedEdge.isLambdaPush,
-      controlPoint: vectorControlPoint,
-    );
-  }
-
-  void _handleNodeAdded(NodeInstance node) {
-    final label = _resolveLabel(node);
-    final canvasNode = FlNodesCanvasNode(
+  @override
+  FlNodesCanvasNode createCanvasNode(NodeInstance node) {
+    final label = resolveLabel(node);
+    return FlNodesCanvasNode(
       id: node.id,
       label: label,
       x: node.offset.dx,
       y: node.offset.dy,
-      isInitial: _nodes.isEmpty,
+      isInitial: nodesCache.isEmpty,
       isAccepting: false,
-    );
-    _nodes[node.id] = canvasNode;
-    _notifier.addOrUpdateState(
-      id: canvasNode.id,
-      label: canvasNode.label,
-      x: canvasNode.x,
-      y: canvasNode.y,
     );
   }
 
-  void _handleNodeRemoved(NodeInstance node) {
-    _nodes.remove(node.id);
-    final orphanedEdges = _edges.entries
+  @override
+  void onCanvasNodeAdded(FlNodesCanvasNode node) {
+    _notifier.addOrUpdateState(
+      id: node.id,
+      label: node.label,
+      x: node.x,
+      y: node.y,
+    );
+  }
+
+  @override
+  void onCanvasNodeRemoved(String nodeId) {
+    final orphanedEdges = edgesCache.entries
         .where(
           (entry) =>
-              entry.value.fromStateId == node.id ||
-              entry.value.toStateId == node.id,
+              entry.value.fromStateId == nodeId ||
+              entry.value.toStateId == nodeId,
         )
         .map((entry) => entry.key)
         .toList(growable: false);
+
     for (final edgeId in orphanedEdges) {
-      _edges.remove(edgeId);
+      edgesCache.remove(edgeId);
       _notifier.removeTransition(id: edgeId);
     }
-    _notifier.removeState(id: node.id);
+
+    _notifier.removeState(id: nodeId);
   }
 
-  void _handleSelectionDragged(Set<String> nodeIds) {
-    for (final nodeId in nodeIds) {
-      final instance = controller.nodes[nodeId];
-      final cachedNode = _nodes[nodeId];
-      if (instance == null || cachedNode == null) continue;
-
-      final deltaX = (instance.offset.dx - cachedNode.x).abs();
-      final deltaY = (instance.offset.dy - cachedNode.y).abs();
-      if (deltaX < _dragEpsilon && deltaY < _dragEpsilon) {
-        continue;
-      }
-
-      final updatedNode = cachedNode.copyWith(
-        x: instance.offset.dx,
-        y: instance.offset.dy,
-      );
-      _nodes[nodeId] = updatedNode;
+  @override
+  void onCanvasNodesMoved(Map<String, FlNodesCanvasNode> updatedNodes) {
+    for (final entry in updatedNodes.entries) {
       _notifier.moveState(
-        id: nodeId,
-        x: updatedNode.x,
-        y: updatedNode.y,
+        id: entry.key,
+        x: entry.value.x,
+        y: entry.value.y,
       );
     }
   }
 
-  void _handleNodeField(NodeFieldEvent event) {
-    if (event.eventType != FieldEventType.submit) {
-      return;
-    }
-    final updatedNode = _nodes[event.nodeId]?.copyWith(
-      label: (event.value as String?)?.trim() ?? '',
+  @override
+  void onCanvasNodeLabelUpdated(FlNodesCanvasNode node) {
+    _notifier.updateStateLabel(
+      id: node.id,
+      label: node.label.isEmpty ? node.id : node.label,
     );
-    if (updatedNode != null) {
-      _nodes[event.nodeId] = updatedNode;
-      _notifier.updateStateLabel(
-        id: event.nodeId,
-        label: updatedNode.label.isEmpty ? event.nodeId : updatedNode.label,
-      );
-    }
   }
 
-  void _handleLinkAdded(Link link) {
-    final fromStateId = link.fromTo.from;
-    final toStateId = link.fromTo.to;
-    final fromPortId = link.fromTo.fromPort;
-    final toPortId = link.fromTo.toPort;
-
-    if (fromPortId != _outPortId || toPortId != _inPortId) {
-      return;
-    }
-
-    final edge = FlNodesCanvasEdge(
+  @override
+  FlNodesCanvasEdge? createEdgeForLink(Link link) {
+    return FlNodesCanvasEdge(
       id: link.id,
-      fromStateId: fromStateId,
-      toStateId: toStateId,
+      fromStateId: link.fromTo.from,
+      toStateId: link.fromTo.to,
       symbols: const <String>[],
       readSymbol: '',
       popSymbol: '',
@@ -359,10 +108,10 @@ class FlNodesPdaCanvasController
       isLambdaPop: true,
       isLambdaPush: true,
     );
-    _edges[edge.id] = edge;
-    if (highlightedTransitionIds.contains(edge.id)) {
-      updateLinkHighlights(highlightedTransitionIds);
-    }
+  }
+
+  @override
+  void onCanvasEdgeAdded(FlNodesCanvasEdge edge) {
     _notifier.upsertTransition(
       id: edge.id,
       fromStateId: edge.fromStateId,
@@ -376,17 +125,30 @@ class FlNodesPdaCanvasController
     );
   }
 
-  void _handleLinkRemoved(Link link) {
-    _edges.remove(link.id);
-    _notifier.removeTransition(id: link.id);
+  @override
+  void onCanvasEdgeRemoved(String edgeId) {
+    _notifier.removeTransition(id: edgeId);
   }
 
-  String _resolveLabel(NodeInstance node) {
-    final field = node.fields[_labelFieldId];
-    final data = field?.data;
-    if (data is String && data.trim().isNotEmpty) {
-      return data.trim();
-    }
-    return node.id;
+  @override
+  void onCanvasEdgeGeometryUpdated(FlNodesCanvasEdge edge, Offset controlPoint) {
+    _notifier.upsertTransition(
+      id: edge.id,
+      fromStateId: edge.fromStateId,
+      toStateId: edge.toStateId,
+      label: edge.label,
+      readSymbol: edge.readSymbol,
+      popSymbol: edge.popSymbol,
+      pushSymbol: edge.pushSymbol,
+      isLambdaInput: edge.isLambdaInput,
+      isLambdaPop: edge.isLambdaPop,
+      isLambdaPush: edge.isLambdaPush,
+      controlPoint: Vector2(controlPoint.dx, controlPoint.dy),
+    );
+  }
+
+  /// Synchronises the fl_nodes controller with the latest [automaton].
+  void synchronize(PDA? automaton) {
+    synchronizeCanvas(automaton);
   }
 }

--- a/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart
@@ -1,265 +1,43 @@
-import 'dart:async';
-
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart'
-    show DragSelectionEndEvent;
 import 'package:flutter/material.dart';
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/tm.dart';
 import '../../../core/models/tm_transition.dart';
 import '../../../presentation/providers/tm_editor_provider.dart';
+import 'base_fl_nodes_canvas_controller.dart';
 import 'fl_nodes_canvas_models.dart';
-import 'fl_nodes_highlight_controller.dart';
-import 'fl_nodes_label_field_editor.dart';
 import 'fl_nodes_tm_mapper.dart';
-import 'fl_nodes_viewport_highlight_mixin.dart';
-import 'link_geometry_event_utils.dart';
 
 /// Controller responsible for synchronising the fl_nodes editor with the
 /// [TMEditorNotifier].
 class FlNodesTmCanvasController
-    with FlNodesViewportHighlightMixin
-    implements FlNodesHighlightController {
+    extends BaseFlNodesCanvasController<TMEditorNotifier, TM> {
   FlNodesTmCanvasController({
     required TMEditorNotifier editorNotifier,
     FlNodeEditorController? editorController,
-  }) : _notifier = editorNotifier,
-       controller = editorController ?? FlNodeEditorController() {
-    _registerPrototypes();
-    _subscription = controller.eventBus.events.listen(_handleEvent);
-  }
+  }) : super(
+          notifier: editorNotifier,
+          editorController: editorController,
+        );
 
-  final TMEditorNotifier _notifier;
-  final FlNodeEditorController controller;
-
-  final Map<String, FlNodesCanvasNode> _nodes = {};
-  final Map<String, FlNodesCanvasEdge> _edges = {};
-  StreamSubscription<NodeEditorEvent>? _subscription;
-  bool _isSynchronizing = false;
-
-  int get nodeCount => _nodes.length;
-  int get edgeCount => _edges.length;
-  Iterable<FlNodesCanvasNode> get nodes => _nodes.values;
-  Iterable<FlNodesCanvasEdge> get edges => _edges.values;
-  FlNodesCanvasNode? nodeById(String id) => _nodes[id];
-  FlNodesCanvasEdge? edgeById(String id) => _edges[id];
+  TMEditorNotifier get _notifier => notifier;
 
   @override
-  Map<String, FlNodesCanvasNode> get nodesCache => _nodes;
+  String get statePrototypeId => 'tm_state';
 
-  static const String _statePrototypeId = 'tm_state';
-  static const String _inPortId = 'incoming';
-  static const String _outPortId = 'outgoing';
-  static const String _labelFieldId = 'label';
-  static const double _dragEpsilon = 0.001;
+  @override
+  String get stateDescription => 'Estado da Máquina de Turing';
 
-  late final ControlInputPortPrototype _inputPortPrototype =
-      ControlInputPortPrototype(
-        idName: _inPortId,
-        displayName: (_) => 'Entrada',
-      );
-
-  late final ControlOutputPortPrototype _outputPortPrototype =
-      ControlOutputPortPrototype(
-        idName: _outPortId,
-        displayName: (_) => 'Saída',
-      );
-
-  late final FieldPrototype _labelFieldPrototype = FieldPrototype(
-    idName: _labelFieldId,
-    displayName: (_) => 'Rótulo',
-    dataType: String,
-    defaultData: '',
-    style: const FlFieldStyle(),
-    visualizerBuilder: (value) {
-      final text = (value as String?)?.trim();
-      return Padding(
-        padding: const EdgeInsets.symmetric(vertical: 4),
-        child: Text(
-          text == null || text.isEmpty ? 'Sem nome' : text,
-          style: const TextStyle(fontWeight: FontWeight.w600),
-        ),
-      );
-    },
-    editorBuilder: (context, removeOverlay, value, setData) {
-      return FlNodesLabelFieldEditor(
-        initialValue: (value as String?) ?? '',
-        onSubmit: (label) {
-          setData(label, eventType: FieldEventType.submit);
-          removeOverlay();
-        },
-        onCancel: () {
-          setData(value, eventType: FieldEventType.cancel);
-          removeOverlay();
-        },
-      );
-    },
-  );
-
-  late final NodePrototype _statePrototype = NodePrototype(
-    idName: _statePrototypeId,
-    displayName: (_) => 'Estado',
-    description: (_) => 'Estado da Máquina de Turing',
-    ports: [_inputPortPrototype, _outputPortPrototype],
-    fields: [_labelFieldPrototype],
-    onExecute: (ports, fields, execState, forward, put) async {},
-  );
-
-  void dispose() {
-    _subscription?.cancel();
-    disposeViewportHighlight();
-    controller.dispose();
+  @override
+  FlNodesAutomatonSnapshot toSnapshot(TM? machine) {
+    return FlNodesTmMapper.toSnapshot(machine);
   }
 
-  void addStateAtCenter() {
-    final center = -controller.viewportOffset;
-    controller.addNode(_statePrototypeId, offset: center);
-  }
-
-  void addStateAt(Offset worldPosition) {
-    controller.addNode(_statePrototypeId, offset: worldPosition);
-  }
-
-  void _registerPrototypes() {
-    controller.registerNodePrototype(_statePrototype);
-  }
-
-  void synchronize(TM? machine) {
-    final snapshot = FlNodesTmMapper.toSnapshot(machine);
-    _isSynchronizing = true;
-    controller.clear();
-    _nodes
-      ..clear()
-      ..addEntries(snapshot.nodes.map((node) => MapEntry(node.id, node)));
-    _edges
-      ..clear()
-      ..addEntries(snapshot.edges.map((edge) => MapEntry(edge.id, edge)));
-
-    for (final node in snapshot.nodes) {
-      controller.addNodeFromExisting(_buildNodeInstance(node), isHandled: true);
-    }
-
-    for (final edge in snapshot.edges) {
-      controller.addLinkFromExisting(_buildLink(edge), isHandled: true);
-    }
-
-    if (highlightedTransitionIds.isNotEmpty ||
-        highlightNotifier.value.transitionIds.isNotEmpty) {
-      updateLinkHighlights(highlightedTransitionIds);
-    }
-
-    _isSynchronizing = false;
-  }
-
-  NodeInstance _buildNodeInstance(FlNodesCanvasNode node) {
-    final ports = {
-      _inPortId: PortInstance(
-        prototype: _inputPortPrototype,
-        state: PortState(),
-      ),
-      _outPortId: PortInstance(
-        prototype: _outputPortPrototype,
-        state: PortState(),
-      ),
-    };
-
-    final fields = {
-      _labelFieldId: FieldInstance(
-        prototype: _labelFieldPrototype,
-        data: node.label,
-      ),
-    };
-
-    return NodeInstance(
-      id: node.id,
-      prototype: _statePrototype,
-      ports: ports,
-      fields: fields,
-      state: NodeState(),
-      offset: Offset(node.x, node.y),
-    );
-  }
-
-  Link _buildLink(FlNodesCanvasEdge edge) {
-    return Link(
-      id: edge.id,
-      fromTo: (
-        from: edge.fromStateId,
-        to: edge.toStateId,
-        fromPort: _outPortId,
-        toPort: _inPortId,
-      ),
-      state: LinkState(),
-    );
-  }
-
-  void _handleEvent(NodeEditorEvent event) {
-    if (_isSynchronizing || event.isHandled) {
-      return;
-    }
-
-    final geometryPayload = parseLinkGeometryEvent(event);
-    if (geometryPayload != null) {
-      _handleLinkGeometryEvent(geometryPayload);
-      return;
-    }
-
-    if (event is AddNodeEvent) {
-      _handleNodeAdded(event.node);
-    } else if (event is RemoveNodeEvent) {
-      _handleNodeRemoved(event.node);
-    } else if (event is DragSelectionEndEvent) {
-      _handleSelectionDragged(event.nodeIds);
-    } else if (event is NodeFieldEvent) {
-      _handleNodeField(event);
-    } else if (event is AddLinkEvent) {
-      _handleLinkAdded(event.link);
-    } else if (event is RemoveLinkEvent) {
-      _handleLinkRemoved(event.link);
-    }
-  }
-
-  void _handleLinkGeometryEvent(LinkGeometryEventPayload payload) {
-    final edge = _edges[payload.linkId];
-    if (edge == null) {
-      return;
-    }
-
-    if (!payload.hasControlPoint) {
-      return;
-    }
-
-    final double updatedX = payload.controlPoint?.dx ?? 0;
-    final double updatedY = payload.controlPoint?.dy ?? 0;
-    if ((edge.controlPointX ?? 0) == updatedX &&
-        (edge.controlPointY ?? 0) == updatedY) {
-      return;
-    }
-
-    final updatedEdge = edge.copyWith(
-      controlPointX: updatedX,
-      controlPointY: updatedY,
-    );
-    _edges[payload.linkId] = updatedEdge;
-
-    final controlPointVector = Vector2(updatedX, updatedY);
-
-    _notifier.addOrUpdateTransition(
-      id: updatedEdge.id,
-      fromStateId: updatedEdge.fromStateId,
-      toStateId: updatedEdge.toStateId,
-      readSymbol: updatedEdge.readSymbol,
-      writeSymbol: updatedEdge.writeSymbol,
-      direction: updatedEdge.direction,
-      controlPoint: controlPointVector,
-    );
-  }
-
-  void _handleNodeAdded(NodeInstance node) {
-    final label = _resolveLabel(node);
-    final canvasNode = FlNodesCanvasNode(
+  @override
+  FlNodesCanvasNode createCanvasNode(NodeInstance node) {
+    final label = resolveLabel(node);
+    return FlNodesCanvasNode(
       id: node.id,
       label: label,
       x: node.offset.dx,
@@ -267,85 +45,58 @@ class FlNodesTmCanvasController
       isInitial: false,
       isAccepting: false,
     );
-    _nodes[node.id] = canvasNode;
+  }
+
+  @override
+  void onCanvasNodeAdded(FlNodesCanvasNode node) {
     _notifier.upsertState(
-      id: canvasNode.id,
-      label: canvasNode.label,
-      x: canvasNode.x,
-      y: canvasNode.y,
+      id: node.id,
+      label: node.label,
+      x: node.x,
+      y: node.y,
     );
   }
 
-  void _handleNodeRemoved(NodeInstance node) {
-    _nodes.remove(node.id);
-    _notifier.removeState(id: node.id);
+  @override
+  void onCanvasNodeRemoved(String nodeId) {
+    _notifier.removeState(id: nodeId);
   }
 
-  void _handleSelectionDragged(Set<String> nodeIds) {
-    for (final nodeId in nodeIds) {
-      final instance = controller.nodes[nodeId];
-      final cachedNode = _nodes[nodeId];
-      if (instance == null || cachedNode == null) continue;
-
-      final deltaX = (instance.offset.dx - cachedNode.x).abs();
-      final deltaY = (instance.offset.dy - cachedNode.y).abs();
-      if (deltaX < _dragEpsilon && deltaY < _dragEpsilon) {
-        continue;
-      }
-
-      final updatedNode = cachedNode.copyWith(
-        x: instance.offset.dx,
-        y: instance.offset.dy,
-      );
-      _nodes[nodeId] = updatedNode;
+  @override
+  void onCanvasNodesMoved(Map<String, FlNodesCanvasNode> updatedNodes) {
+    for (final entry in updatedNodes.entries) {
       _notifier.moveState(
-        id: nodeId,
-        x: updatedNode.x,
-        y: updatedNode.y,
+        id: entry.key,
+        x: entry.value.x,
+        y: entry.value.y,
       );
     }
   }
 
-  void _handleNodeField(NodeFieldEvent event) {
-    if (event.eventType != FieldEventType.submit) {
-      return;
-    }
-    final updatedNode = _nodes[event.nodeId]?.copyWith(
-      label: (event.value as String?)?.trim() ?? '',
+  @override
+  void onCanvasNodeLabelUpdated(FlNodesCanvasNode node) {
+    _notifier.updateStateLabel(
+      id: node.id,
+      label: node.label.isEmpty ? node.id : node.label,
     );
-    if (updatedNode != null) {
-      _nodes[event.nodeId] = updatedNode;
-      _notifier.updateStateLabel(
-        id: event.nodeId,
-        label: updatedNode.label.isEmpty ? event.nodeId : updatedNode.label,
-      );
-    }
   }
 
-  void _handleLinkAdded(Link link) {
-    final fromStateId = link.fromTo.from;
-    final toStateId = link.fromTo.to;
-    final fromPortId = link.fromTo.fromPort;
-    final toPortId = link.fromTo.toPort;
-
-    if (fromPortId != _outPortId || toPortId != _inPortId) {
-      return;
-    }
-
-    final edge = FlNodesCanvasEdge(
+  @override
+  FlNodesCanvasEdge? createEdgeForLink(Link link) {
+    return FlNodesCanvasEdge(
       id: link.id,
-      fromStateId: fromStateId,
-      toStateId: toStateId,
+      fromStateId: link.fromTo.from,
+      toStateId: link.fromTo.to,
       symbols: const <String>[],
       readSymbol: '',
       writeSymbol: '',
       direction: TapeDirection.right,
       tapeNumber: 0,
     );
-    _edges[edge.id] = edge;
-    if (highlightedTransitionIds.contains(edge.id)) {
-      updateLinkHighlights(highlightedTransitionIds);
-    }
+  }
+
+  @override
+  void onCanvasEdgeAdded(FlNodesCanvasEdge edge) {
     _notifier.addOrUpdateTransition(
       id: edge.id,
       fromStateId: edge.fromStateId,
@@ -356,17 +107,26 @@ class FlNodesTmCanvasController
     );
   }
 
-  void _handleLinkRemoved(Link link) {
-    _edges.remove(link.id);
-    _notifier.removeTransition(id: link.id);
+  @override
+  void onCanvasEdgeRemoved(String edgeId) {
+    _notifier.removeTransition(id: edgeId);
   }
 
-  String _resolveLabel(NodeInstance node) {
-    final field = node.fields[_labelFieldId];
-    final data = field?.data;
-    if (data is String && data.trim().isNotEmpty) {
-      return data.trim();
-    }
-    return node.id;
+  @override
+  void onCanvasEdgeGeometryUpdated(FlNodesCanvasEdge edge, Offset controlPoint) {
+    _notifier.addOrUpdateTransition(
+      id: edge.id,
+      fromStateId: edge.fromStateId,
+      toStateId: edge.toStateId,
+      readSymbol: edge.readSymbol,
+      writeSymbol: edge.writeSymbol,
+      direction: edge.direction,
+      controlPoint: Vector2(controlPoint.dx, controlPoint.dy),
+    );
+  }
+
+  /// Synchronises the fl_nodes controller with the latest [machine].
+  void synchronize(TM? machine) {
+    synchronizeCanvas(machine);
   }
 }

--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
@@ -17,6 +17,7 @@ import 'package:jflutter/core/models/simulation_highlight.dart';
 import 'package:jflutter/core/repositories/automaton_repository.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:jflutter/data/services/automaton_service.dart';
+import 'package:jflutter/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart';
 import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart';
 import 'package:jflutter/presentation/providers/automaton_provider.dart';
 
@@ -200,6 +201,10 @@ void main() {
 
     tearDown(() {
       controller.dispose();
+    });
+
+    test('inherits from BaseFlNodesCanvasController', () {
+      expect(controller, isA<BaseFlNodesCanvasController>());
     });
 
     test('viewport helpers adjust zoom and offset', () {

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
@@ -14,6 +14,7 @@ import 'package:jflutter/core/models/pda_transition.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';
 import 'package:jflutter/core/models/state.dart';
 import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart';
 import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart';
 import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
 
@@ -167,6 +168,10 @@ void main() {
 
     tearDown(() {
       controller.dispose();
+    });
+
+    test('inherits from BaseFlNodesCanvasController', () {
+      expect(controller, isA<BaseFlNodesCanvasController>());
     });
 
     test('viewport helpers adjust zoom and offset', () {

--- a/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
@@ -13,6 +13,7 @@ import 'package:jflutter/core/models/state.dart';
 import 'package:jflutter/core/models/tm.dart';
 import 'package:jflutter/core/models/tm_transition.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';
+import 'package:jflutter/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart';
 import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart';
 import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
 
@@ -153,6 +154,10 @@ void main() {
 
     tearDown(() {
       controller.dispose();
+    });
+
+    test('inherits from BaseFlNodesCanvasController', () {
+      expect(controller, isA<BaseFlNodesCanvasController>());
     });
 
     test('viewport helpers adjust zoom and offset', () {


### PR DESCRIPTION
## Summary
- extract a generic BaseFlNodesCanvasController to centralise prototype registration, synchronisation, and shared event handling
- refactor the automaton, PDA, and TM canvas controllers to extend the base class and provide notifier-specific hooks
- update the existing canvas controller tests to assert the new inheritance structure while keeping behavioural coverage intact

## Testing
- flutter analyze *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e04ed41990832e88e63871b53daeee