### PR TITLE
Add mobile bottom sheet for transition labels

### DIFF
--- a/docs/manual_qa_transition_label_sheet.md
+++ b/docs/manual_qa_transition_label_sheet.md
@@ -1,0 +1,19 @@
+# Manual QA - Transition Label Bottom Sheet
+
+## Scenario: Edit FSA transition label on a narrow viewport
+
+1. Launch the app with an FSA loaded and resize the window (or use an emulator) so the shortest side is below 600 px.
+2. Tap a transition once to select it and trigger the label editor.
+3. Confirm a modal bottom sheet appears with:
+   - A focused text field titled "Rótulo".
+   - Large Cancel and Salvar buttons that are easy to tap.
+4. Enter a new label and press **Salvar**.
+   - The sheet should close, the provider should update the transition label, and the canvas selection should clear.
+5. Repeat the interaction and dismiss the sheet via the Cancel button and by swiping it down.
+   - Verify both dismissal methods clear the transition selection without mutating the label.
+6. Run a simulation (or highlight a transition) before editing and ensure the highlight states persist after editing via the sheet.
+
+## Scenario: Desktop regression check
+
+1. Resize the window so the shortest side is wider than 600 px (or use a desktop platform).
+2. Select a transition and confirm the inline overlay editor still appears with keyboard submission and Escape to cancel.

--- a/lib/features/canvas/fl_nodes/fl_nodes_label_field_editor.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_label_field_editor.dart
@@ -1,7 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:jflutter/presentation/widgets/transition_editors/transition_label_editor.dart';
 
 /// Shared text field overlay used by fl_nodes controllers to edit node labels.
-class FlNodesLabelFieldEditor extends StatefulWidget {
+class FlNodesLabelFieldEditor extends StatelessWidget {
   const FlNodesLabelFieldEditor({
     super.key,
     required this.initialValue,
@@ -14,24 +15,6 @@ class FlNodesLabelFieldEditor extends StatefulWidget {
   final VoidCallback onCancel;
 
   @override
-  State<FlNodesLabelFieldEditor> createState() => _FlNodesLabelFieldEditorState();
-}
-
-class _FlNodesLabelFieldEditorState extends State<FlNodesLabelFieldEditor> {
-  late final TextEditingController _controller =
-      TextEditingController(text: widget.initialValue);
-
-  @override
-  void dispose() {
-    _controller.dispose();
-    super.dispose();
-  }
-
-  void _submit(String value) {
-    widget.onSubmit(value.trim());
-  }
-
-  @override
   Widget build(BuildContext context) {
     return Material(
       elevation: 4,
@@ -40,35 +23,11 @@ class _FlNodesLabelFieldEditorState extends State<FlNodesLabelFieldEditor> {
         constraints: const BoxConstraints(minWidth: 200),
         child: Padding(
           padding: const EdgeInsets.all(12),
-          child: Column(
-            mainAxisSize: MainAxisSize.min,
-            crossAxisAlignment: CrossAxisAlignment.stretch,
-            children: [
-              TextField(
-                controller: _controller,
-                autofocus: true,
-                decoration: const InputDecoration(
-                  labelText: 'Rótulo',
-                  border: OutlineInputBorder(),
-                ),
-                onSubmitted: _submit,
-              ),
-              const SizedBox(height: 8),
-              Row(
-                mainAxisAlignment: MainAxisAlignment.end,
-                children: [
-                  TextButton(
-                    onPressed: widget.onCancel,
-                    child: const Text('Cancelar'),
-                  ),
-                  const SizedBox(width: 8),
-                  FilledButton(
-                    onPressed: () => _submit(_controller.text),
-                    child: const Text('Salvar'),
-                  ),
-                ],
-              ),
-            ],
+          child: TransitionLabelEditorForm(
+            initialValue: initialValue,
+            onSubmit: onSubmit,
+            onCancel: onCancel,
+            autofocus: true,
           ),
         ),
       ),

--- a/lib/presentation/widgets/transition_editors/transition_label_editor.dart
+++ b/lib/presentation/widgets/transition_editors/transition_label_editor.dart
@@ -1,0 +1,151 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+
+class TransitionLabelEditorForm extends StatefulWidget {
+  const TransitionLabelEditorForm({
+    super.key,
+    required this.initialValue,
+    required this.onSubmit,
+    required this.onCancel,
+    this.autofocus = false,
+    this.touchOptimized = false,
+    this.fieldLabel = 'Rótulo',
+    this.cancelLabel = 'Cancelar',
+    this.saveLabel = 'Salvar',
+    this.semanticLabel = 'Editar rótulo da transição',
+  });
+
+  final String initialValue;
+  final ValueChanged<String> onSubmit;
+  final VoidCallback onCancel;
+  final bool autofocus;
+  final bool touchOptimized;
+  final String fieldLabel;
+  final String cancelLabel;
+  final String saveLabel;
+  final String semanticLabel;
+
+  @override
+  State<TransitionLabelEditorForm> createState() =>
+      _TransitionLabelEditorFormState();
+}
+
+class _TransitionLabelEditorFormState
+    extends State<TransitionLabelEditorForm> {
+  late final TextEditingController _controller =
+      TextEditingController(text: widget.initialValue);
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleSubmit() {
+    widget.onSubmit(_controller.text.trim());
+  }
+
+  void _handleCancel() {
+    widget.onCancel();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final shortcuts = <LogicalKeySet, Intent>{
+      LogicalKeySet(LogicalKeyboardKey.enter): const _SubmitIntent(),
+      LogicalKeySet(LogicalKeyboardKey.numpadEnter): const _SubmitIntent(),
+      LogicalKeySet(LogicalKeyboardKey.escape): const _CancelIntent(),
+    };
+
+    return Shortcuts(
+      shortcuts: shortcuts,
+      child: Actions(
+        actions: {
+          _SubmitIntent: CallbackAction<_SubmitIntent>((intent) {
+            _handleSubmit();
+            return null;
+          }),
+          _CancelIntent: CallbackAction<_CancelIntent>((intent) {
+            _handleCancel();
+            return null;
+          }),
+          DismissIntent: CallbackAction<DismissIntent>((intent) {
+            _handleCancel();
+            return null;
+          }),
+        },
+        child: FocusTraversalGroup(
+          child: Semantics(
+            container: true,
+            label: widget.semanticLabel,
+            explicitChildNodes: true,
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              children: [
+                TextField(
+                  controller: _controller,
+                  autofocus: widget.autofocus,
+                  decoration: InputDecoration(
+                    labelText: widget.fieldLabel,
+                    border: const OutlineInputBorder(),
+                  ),
+                  textInputAction: TextInputAction.done,
+                  onSubmitted: (_) => _handleSubmit(),
+                ),
+                SizedBox(height: widget.touchOptimized ? 16 : 8),
+                if (widget.touchOptimized)
+                  Row(
+                    children: [
+                      Expanded(
+                        child: OutlinedButton(
+                          onPressed: _handleCancel,
+                          style: OutlinedButton.styleFrom(
+                            minimumSize: const Size.fromHeight(48),
+                          ),
+                          child: Text(widget.cancelLabel),
+                        ),
+                      ),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: FilledButton(
+                          onPressed: _handleSubmit,
+                          style: FilledButton.styleFrom(
+                            minimumSize: const Size.fromHeight(48),
+                          ),
+                          child: Text(widget.saveLabel),
+                        ),
+                      ),
+                    ],
+                  )
+                else
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.end,
+                    children: [
+                      TextButton(
+                        onPressed: _handleCancel,
+                        child: Text(widget.cancelLabel),
+                      ),
+                      const SizedBox(width: 8),
+                      FilledButton(
+                        onPressed: _handleSubmit,
+                        child: Text(widget.saveLabel),
+                      ),
+                    ],
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _SubmitIntent extends Intent {
+  const _SubmitIntent();
+}
+
+class _CancelIntent extends Intent {
+  const _CancelIntent();
+}


### PR DESCRIPTION
## Summary
- detect compact form factors in the automaton canvas and open a modal sheet for transition label edits while preserving the desktop overlay
- introduce a shared TransitionLabelEditorForm reused by the inline overlay and the new sheet for consistent controls and accessibility
- add manual QA notes for verifying the mobile sheet and desktop regression checks

## Testing
- flutter analyze *(fails: flutter executable not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e0525b9fe8832ead944e960df61d7c