### PR TITLE
Wire highlight channels to native canvases

### DIFF
--- a/lib/presentation/widgets/automaton_canvas_native.dart
+++ b/lib/presentation/widgets/automaton_canvas_native.dart
@@ -18,7 +18,9 @@ import '../../core/models/fsa_transition.dart';
 import '../../core/models/simulation_highlight.dart';
 import '../../core/models/simulation_result.dart';
 import '../../core/models/state.dart' as automaton_state;
+import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_canvas_controller.dart';
+import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_label_field_editor.dart';
 import '../../features/canvas/fl_nodes/link_overlay_utils.dart';
 import '../providers/automaton_provider.dart';
@@ -68,6 +70,9 @@ class _AutomatonCanvasState extends ConsumerState<AutomatonCanvas> {
   bool _isLabelSheetOpen = false;
   String? _activeLabelSheetLinkId;
   SimulationHighlight? _lastHighlight;
+  SimulationHighlightService? _highlightService;
+  SimulationHighlightChannel? _previousHighlightChannel;
+  FlNodesSimulationHighlightChannel? _highlightChannel;
 
   @override
   void initState() {
@@ -81,6 +86,13 @@ class _AutomatonCanvasState extends ConsumerState<AutomatonCanvas> {
         automatonProvider: ref.read(automatonProvider.notifier),
       );
       _ownsController = true;
+      final highlightService = ref.read(canvasHighlightServiceProvider);
+      _highlightService = highlightService;
+      _previousHighlightChannel = highlightService.channel;
+      final highlightChannel =
+          FlNodesSimulationHighlightChannel(_canvasController);
+      _highlightChannel = highlightChannel;
+      highlightService.channel = highlightChannel;
     }
     _canvasController.synchronize(widget.automaton);
     _applyDerivedState(_computeDerivedState());
@@ -220,6 +232,16 @@ class _AutomatonCanvasState extends ConsumerState<AutomatonCanvas> {
           .removeListener(_viewportZoomListener!);
     }
     if (_ownsController) {
+      final highlightService = _highlightService;
+      final highlightChannel = _highlightChannel;
+      if (highlightService != null && highlightChannel != null) {
+        if (identical(highlightService.channel, highlightChannel)) {
+          highlightService.channel = _previousHighlightChannel;
+        }
+        _highlightChannel = null;
+        _highlightService = null;
+        _previousHighlightChannel = null;
+      }
       _canvasController.dispose();
     }
     super.dispose();

--- a/lib/presentation/widgets/pda_canvas_native.dart
+++ b/lib/presentation/widgets/pda_canvas_native.dart
@@ -15,7 +15,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
 import '../../core/models/pda_transition.dart';
 import '../../core/models/state.dart' as automaton_state;
+import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart';
+import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import '../../features/canvas/fl_nodes/link_overlay_utils.dart';
 import 'transition_editors/pda_transition_editor.dart';
 import '../providers/pda_editor_provider.dart';
@@ -48,6 +50,9 @@ class _PDACanvasNativeState extends ConsumerState<PDACanvasNative> {
   VoidCallback? _viewportZoomListener;
   String? _selectedLinkId;
   final GlobalKey _canvasKey = GlobalKey();
+  SimulationHighlightService? _highlightService;
+  SimulationHighlightChannel? _previousHighlightChannel;
+  FlNodesSimulationHighlightChannel? _highlightChannel;
 
   @override
   void initState() {
@@ -61,6 +66,13 @@ class _PDACanvasNativeState extends ConsumerState<PDACanvasNative> {
         editorNotifier: ref.read(pdaEditorProvider.notifier),
       );
       _ownsController = true;
+      final highlightService = ref.read(canvasHighlightServiceProvider);
+      _highlightService = highlightService;
+      _previousHighlightChannel = highlightService.channel;
+      final highlightChannel =
+          FlNodesSimulationHighlightChannel(_canvasController);
+      _highlightChannel = highlightChannel;
+      highlightService.channel = highlightChannel;
     }
     final initialState = ref.read(pdaEditorProvider);
     _canvasController.synchronize(initialState.pda);
@@ -201,6 +213,16 @@ class _PDACanvasNativeState extends ConsumerState<PDACanvasNative> {
           .removeListener(_viewportZoomListener!);
     }
     if (_ownsController) {
+      final highlightService = _highlightService;
+      final highlightChannel = _highlightChannel;
+      if (highlightService != null && highlightChannel != null) {
+        if (identical(highlightService.channel, highlightChannel)) {
+          highlightService.channel = _previousHighlightChannel;
+        }
+        _highlightChannel = null;
+        _highlightService = null;
+        _previousHighlightChannel = null;
+      }
       _canvasController.dispose();
     }
     super.dispose();

--- a/lib/presentation/widgets/tm_canvas_native.dart
+++ b/lib/presentation/widgets/tm_canvas_native.dart
@@ -14,7 +14,9 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/tm.dart';
 import '../../core/models/tm_transition.dart';
+import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart';
+import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import '../../features/canvas/fl_nodes/link_overlay_utils.dart';
 import 'transition_editors/tm_transition_operations_editor.dart';
 import '../providers/tm_editor_provider.dart';
@@ -46,6 +48,9 @@ class _TMCanvasNativeState extends ConsumerState<TMCanvasNative> {
   VoidCallback? _viewportZoomListener;
   String? _selectedLinkId;
   final GlobalKey _canvasKey = GlobalKey();
+  SimulationHighlightService? _highlightService;
+  SimulationHighlightChannel? _previousHighlightChannel;
+  FlNodesSimulationHighlightChannel? _highlightChannel;
 
   @override
   void initState() {
@@ -59,6 +64,13 @@ class _TMCanvasNativeState extends ConsumerState<TMCanvasNative> {
         editorNotifier: ref.read(tmEditorProvider.notifier),
       );
       _ownsController = true;
+      final highlightService = ref.read(canvasHighlightServiceProvider);
+      _highlightService = highlightService;
+      _previousHighlightChannel = highlightService.channel;
+      final highlightChannel =
+          FlNodesSimulationHighlightChannel(_canvasController);
+      _highlightChannel = highlightChannel;
+      highlightService.channel = highlightChannel;
     }
     final initialState = ref.read(tmEditorProvider);
     _canvasController.synchronize(initialState.tm);
@@ -156,6 +168,16 @@ class _TMCanvasNativeState extends ConsumerState<TMCanvasNative> {
           .removeListener(_viewportZoomListener!);
     }
     if (_ownsController) {
+      final highlightService = _highlightService;
+      final highlightChannel = _highlightChannel;
+      if (highlightService != null && highlightChannel != null) {
+        if (identical(highlightService.channel, highlightChannel)) {
+          highlightService.channel = _previousHighlightChannel;
+        }
+        _highlightChannel = null;
+        _highlightService = null;
+        _previousHighlightChannel = null;
+      }
       _canvasController.dispose();
     }
     super.dispose();

--- a/test/widget/presentation/automaton_canvas_highlight_test.dart
+++ b/test/widget/presentation/automaton_canvas_highlight_test.dart
@@ -1,12 +1,25 @@
+import 'dart:math' as math;
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/pda.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/transition.dart';
 import 'package:jflutter/core/services/simulation_highlight_service.dart';
 import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart';
 import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+import 'package:jflutter/presentation/widgets/automaton_canvas_native.dart';
+import 'package:jflutter/presentation/widgets/pda_canvas_native.dart';
+import 'package:jflutter/presentation/widgets/tm_canvas_native.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 void main() {
   testWidgets(
@@ -50,6 +63,187 @@ void main() {
       await tester.pump();
 
       expect(find.text(''), findsOneWidget);
+    },
+  );
+
+  testWidgets(
+    'AutomatonCanvas attaches highlight channel to the owned controller',
+    (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final automaton = _createSampleFsa();
+      final theme = ThemeData.from(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.indigo),
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: theme,
+            home: Scaffold(
+              body: AutomatonCanvas(
+                automaton: automaton,
+                canvasKey: GlobalKey(),
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final highlightService = container.read(canvasHighlightServiceProvider);
+      addTearDown(highlightService.clear);
+
+      final finder = find.text('q0');
+      expect(finder, findsOneWidget);
+
+      final initialText = tester.widget<Text>(finder);
+      expect(
+        initialText.style?.color,
+        isNot(equals(theme.colorScheme.onPrimary)),
+      );
+
+      highlightService.dispatch(
+        const SimulationHighlight(stateIds: {'q0'}, transitionIds: {}),
+      );
+      await tester.pump();
+
+      final highlightedText = tester.widget<Text>(finder);
+      expect(highlightedText.style?.color, theme.colorScheme.onPrimary);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const SizedBox(),
+        ),
+      );
+      await tester.pumpAndSettle();
+    },
+  );
+
+  testWidgets(
+    'PDACanvasNative attaches highlight channel to the owned controller',
+    (tester) async {
+      final pda = _createSamplePda();
+      final container = ProviderContainer(
+        overrides: [
+          pdaEditorProvider.overrideWith(
+            (ref) => _TestPdaEditorNotifier(pda),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final theme = ThemeData.from(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.purple),
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: theme,
+            home: Scaffold(
+              body: PDACanvasNative(
+                onPdaModified: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final highlightService = container.read(canvasHighlightServiceProvider);
+      addTearDown(highlightService.clear);
+
+      final finder = find.text('p0');
+      expect(finder, findsOneWidget);
+
+      final initialText = tester.widget<Text>(finder);
+      expect(
+        initialText.style?.color,
+        isNot(equals(theme.colorScheme.onPrimary)),
+      );
+
+      highlightService.dispatch(
+        const SimulationHighlight(stateIds: {'p0'}, transitionIds: {}),
+      );
+      await tester.pump();
+
+      final highlightedText = tester.widget<Text>(finder);
+      expect(highlightedText.style?.color, theme.colorScheme.onPrimary);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const SizedBox(),
+        ),
+      );
+      await tester.pumpAndSettle();
+    },
+  );
+
+  testWidgets(
+    'TMCanvasNative attaches highlight channel to the owned controller',
+    (tester) async {
+      final tm = _createSampleTm();
+      final container = ProviderContainer(
+        overrides: [
+          tmEditorProvider.overrideWith(
+            (ref) => _TestTmEditorNotifier(tm),
+          ),
+        ],
+      );
+      addTearDown(container.dispose);
+
+      final theme = ThemeData.from(
+        colorScheme: ColorScheme.fromSeed(seedColor: Colors.teal),
+      );
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            theme: theme,
+            home: Scaffold(
+              body: TMCanvasNative(
+                onTMModified: (_) {},
+              ),
+            ),
+          ),
+        ),
+      );
+      await tester.pumpAndSettle();
+
+      final highlightService = container.read(canvasHighlightServiceProvider);
+      addTearDown(highlightService.clear);
+
+      final finder = find.text('t0');
+      expect(finder, findsOneWidget);
+
+      final initialText = tester.widget<Text>(finder);
+      expect(
+        initialText.style?.color,
+        isNot(equals(theme.colorScheme.onPrimary)),
+      );
+
+      highlightService.dispatch(
+        const SimulationHighlight(stateIds: {'t0'}, transitionIds: {}),
+      );
+      await tester.pump();
+
+      final highlightedText = tester.widget<Text>(finder);
+      expect(highlightedText.style?.color, theme.colorScheme.onPrimary);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: const SizedBox(),
+        ),
+      );
+      await tester.pumpAndSettle();
     },
   );
 }
@@ -102,5 +296,90 @@ class _HighlightProbeState extends State<_HighlightProbe> {
         ? ''
         : highlight.stateIds.join(',');
     return Center(child: Text(label));
+  }
+}
+
+FSA _createSampleFsa() {
+  final now = DateTime(2023, 1, 1);
+  final state = automaton_state.State(
+    id: 'q0',
+    label: 'q0',
+    position: Vector2.zero(),
+    isInitial: true,
+  );
+  return FSA(
+    id: 'sample-fsa',
+    name: 'Sample FSA',
+    states: {state},
+    transitions: <Transition>{},
+    alphabet: <String>{},
+    initialState: state,
+    acceptingStates: <automaton_state.State>{},
+    created: now,
+    modified: now,
+    bounds: const math.Rectangle<double>(0, 0, 800, 600),
+  );
+}
+
+PDA _createSamplePda() {
+  final now = DateTime(2023, 1, 1);
+  final state = automaton_state.State(
+    id: 'p0',
+    label: 'p0',
+    position: Vector2.zero(),
+    isInitial: true,
+  );
+  return PDA(
+    id: 'sample-pda',
+    name: 'Sample PDA',
+    states: {state},
+    transitions: <Transition>{},
+    alphabet: <String>{},
+    initialState: state,
+    acceptingStates: <automaton_state.State>{},
+    created: now,
+    modified: now,
+    bounds: const math.Rectangle<double>(0, 0, 800, 600),
+    stackAlphabet: const {'Z'},
+    initialStackSymbol: 'Z',
+  );
+}
+
+TM _createSampleTm() {
+  final now = DateTime(2023, 1, 1);
+  final state = automaton_state.State(
+    id: 't0',
+    label: 't0',
+    position: Vector2.zero(),
+    isInitial: true,
+  );
+  return TM(
+    id: 'sample-tm',
+    name: 'Sample TM',
+    states: {state},
+    transitions: <Transition>{},
+    alphabet: <String>{},
+    initialState: state,
+    acceptingStates: <automaton_state.State>{},
+    created: now,
+    modified: now,
+    bounds: const math.Rectangle<double>(0, 0, 800, 600),
+    tapeAlphabet: const {'B'},
+    blankSymbol: 'B',
+  );
+}
+
+class _TestPdaEditorNotifier extends PDAEditorNotifier {
+  _TestPdaEditorNotifier(PDA pda) {
+    state = state.copyWith(pda: pda);
+  }
+}
+
+class _TestTmEditorNotifier extends TMEditorNotifier {
+  _TestTmEditorNotifier(TM tm) {
+    state = state.copyWith(
+      tm: tm,
+      states: tm.states.toList(),
+    );
   }
 }


### PR DESCRIPTION
## Summary
- attach the simulation highlight service to the automaton, PDA, and TM native canvases whenever they create their own fl_nodes controller and restore the prior channel on dispose
- ensure the owned controllers clean up highlight channels before disposal to avoid dangling references
- add widget tests that verify highlights dispatched through the service reach canvases without external controllers

## Testing
- `flutter test` *(fails: flutter command not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e08ee9b5c8832ea6b7012f65fc360f