### PR TITLE
Clear removed transition highlights from canvas controllers

### DIFF
--- a/test/widget/presentation/automaton_canvas_highlight_test.dart
+++ b/test/widget/presentation/automaton_canvas_highlight_test.dart
@@ -67,6 +67,51 @@ void main() {
   );
 
   testWidgets(
+    'Canvas controller clears transition highlight when highlighted link is removed',
+    (tester) async {
+      final container = ProviderContainer();
+      addTearDown(container.dispose);
+
+      final controller = FlNodesCanvasController(
+        automatonProvider: container.read(automatonProvider.notifier),
+      );
+      addTearDown(controller.dispose);
+
+      final highlightService = SimulationHighlightService(
+        channel: FlNodesSimulationHighlightChannel(controller),
+      );
+      addTearDown(highlightService.clear);
+
+      await tester.pumpWidget(
+        UncontrolledProviderScope(
+          container: container,
+          child: MaterialApp(
+            home: Scaffold(body: _HighlightProbe(controller: controller)),
+          ),
+        ),
+      );
+      await tester.pump();
+
+      highlightService.dispatch(
+        const SimulationHighlight(transitionIds: {'t1'}),
+      );
+      await tester.pump();
+
+      expect(controller.highlightedTransitionIds, contains('t1'));
+      expect(
+        controller.highlightNotifier.value.transitionIds,
+        contains('t1'),
+      );
+
+      controller.pruneLinkHighlight('t1');
+      await tester.pump();
+
+      expect(controller.highlightedTransitionIds, isEmpty);
+      expect(controller.highlightNotifier.value, SimulationHighlight.empty);
+    },
+  );
+
+  testWidgets(
     'AutomatonCanvas attaches highlight channel to the owned controller',
     (tester) async {
       final container = ProviderContainer();


### PR DESCRIPTION
## Summary
- ensure removed links clear canvas highlight state and notify listeners when no transitions remain
- expose a testing hook for pruning link highlights and cover the behaviour with a widget test

## Testing
- flutter test *(fails: command not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e122999fa8832e803f7ed1217c35ec