### PR TITLE
canvas: add node editor event shims

### DIFF
--- a/docs/canvas_bridge.md
+++ b/docs/canvas_bridge.md
@@ -27,14 +27,24 @@ Riverpod state (`AutomatonProvider`) perfectly aligned.
 `FlNodesCanvasController` listens to the editor `eventBus` and forwards user
 edits back to `AutomatonProvider`:
 
-* `AddNodeEvent`, `RemoveNodeEvent`, and `DragSelectionEndEvent` translate into
-  `addState`, `removeState`, and `moveState` calls, keeping coordinates and
-  labels aligned with the automaton model.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L236-L302】【F:lib/presentation/providers/automaton_provider.dart†L83-L166】
+* `AddNodeEvent`, `RemoveNodeEvent`, and drag-selection end notifications
+  translate into `addState`, `removeState`, and `moveState` calls, keeping
+  coordinates and labels aligned with the automaton
+  model.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L236-L302】【F:lib/presentation/providers/automaton_provider.dart†L83-L166】
 * Node label edits invoke `updateStateLabel`, normalising blank labels to the
   node identifier so existing transitions remain consistent.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L304-L327】【F:lib/presentation/providers/automaton_provider.dart†L168-L214】
 * Link creation and deletion map to `addOrUpdateTransition` and
   `removeTransition`, ensuring the Riverpod graph stays in sync with the visual
   wiring.【F:lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart†L329-L355】【F:lib/presentation/providers/automaton_provider.dart†L216-L260】
+
+### Compatibility Layer
+
+Some canvas events (`DragSelectionEndEvent`, `LinkSelectionEvent`,
+`LinkDeselectionEvent`, and `RemoveLinkEvent`) still surface through private
+`fl_nodes` classes. The bridge now exposes local shims that pattern-match the
+runtime payload and forward typed data to the controller and widgets. This keeps
+the integration on the public package surface while remaining resilient to
+upstream refactors.【F:lib/features/canvas/fl_nodes/node_editor_event_shims.dart†L1-L178】【F:lib/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart†L248-L282】【F:lib/presentation/widgets/automaton_canvas_native.dart†L600-L641】
 
 Toolbar buttons (zoom, fit, reset, add state) now call directly into the
 controller instead of posting JavaScript messages. This keeps the ergonomics of

--- a/lib/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/base_fl_nodes_canvas_controller.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
 
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart' show DragSelectionEndEvent;
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
@@ -11,6 +9,7 @@ import 'fl_nodes_highlight_controller.dart';
 import 'fl_nodes_label_field_editor.dart';
 import 'fl_nodes_viewport_highlight_mixin.dart';
 import 'link_geometry_event_utils.dart';
+import 'node_editor_event_shims.dart';
 
 /// Base controller that coordinates fl_nodes interactions with domain notifiers.
 abstract class BaseFlNodesCanvasController<TNotifier, TSnapshot>
@@ -257,12 +256,16 @@ abstract class BaseFlNodesCanvasController<TNotifier, TSnapshot>
       return;
     }
 
+    final dragSelectionPayload = parseDragSelectionEndEvent(event);
+    if (dragSelectionPayload != null) {
+      _handleSelectionDragged(dragSelectionPayload.nodeIds);
+      return;
+    }
+
     if (event is AddNodeEvent) {
       _handleNodeAdded(event.node);
     } else if (event is RemoveNodeEvent) {
       _handleNodeRemoved(event.node);
-    } else if (event is DragSelectionEndEvent) {
-      _handleSelectionDragged(event.nodeIds);
     } else if (event is NodeFieldEvent) {
       _handleNodeField(event);
     } else if (event is AddLinkEvent) {

--- a/lib/features/canvas/fl_nodes/node_editor_event_shims.dart
+++ b/lib/features/canvas/fl_nodes/node_editor_event_shims.dart
@@ -1,0 +1,261 @@
+import 'dart:ui';
+
+import 'package:fl_nodes/fl_nodes.dart';
+
+/// Payload extracted from drag-selection end events emitted by fl_nodes.
+class DragSelectionEndEventPayload {
+  const DragSelectionEndEventPayload({
+    required this.nodeIds,
+    this.position,
+  });
+
+  /// Identifiers of the nodes involved in the drag gesture.
+  final Set<String> nodeIds;
+
+  /// World-space position reported by the event, when available.
+  final Offset? position;
+}
+
+/// Payload extracted from link-selection events emitted by fl_nodes.
+class LinkSelectionEventPayload {
+  const LinkSelectionEventPayload({required this.linkIds});
+
+  /// Identifiers of the selected links.
+  final Set<String> linkIds;
+}
+
+/// Payload extracted from link-deselection events emitted by fl_nodes.
+class LinkDeselectionEventPayload {
+  const LinkDeselectionEventPayload({required this.linkIds});
+
+  /// Identifiers of the links that were deselected.
+  final Set<String> linkIds;
+}
+
+/// Payload extracted from link-removal events emitted by fl_nodes.
+class RemoveLinkEventPayload {
+  const RemoveLinkEventPayload({required this.link});
+
+  /// Link instance associated with the removal event.
+  final Link link;
+}
+
+/// Attempts to coerce a drag-selection end event into a typed payload.
+DragSelectionEndEventPayload? parseDragSelectionEndEvent(
+  NodeEditorEvent event,
+) {
+  if (!_matchesRuntimeType(event, 'DragSelectionEndEvent')) {
+    return null;
+  }
+
+  final dynamic dynamicEvent = event;
+
+  final Set<String>? nodeIds = _extractIdSet(() {
+    try {
+      return dynamicEvent.nodeIds;
+    } catch (_) {
+      return null;
+    }
+  });
+
+  if (nodeIds == null) {
+    return null;
+  }
+
+  final Offset? position = _extractOffset(() {
+    try {
+      return dynamicEvent.position;
+    } catch (_) {
+      return null;
+    }
+  });
+
+  return DragSelectionEndEventPayload(
+    nodeIds: nodeIds,
+    position: position,
+  );
+}
+
+/// Attempts to coerce a link-selection event into a typed payload.
+LinkSelectionEventPayload? parseLinkSelectionEvent(NodeEditorEvent event) {
+  if (!_matchesRuntimeType(event, 'LinkSelectionEvent')) {
+    return null;
+  }
+
+  final dynamic dynamicEvent = event;
+  final Set<String>? linkIds = _extractIdSet(() {
+    try {
+      return dynamicEvent.linkIds;
+    } catch (_) {
+      return null;
+    }
+  });
+
+  if (linkIds == null) {
+    return null;
+  }
+
+  return LinkSelectionEventPayload(linkIds: linkIds);
+}
+
+/// Attempts to coerce a link-deselection event into a typed payload.
+LinkDeselectionEventPayload? parseLinkDeselectionEvent(
+  NodeEditorEvent event,
+) {
+  if (!_matchesRuntimeType(event, 'LinkDeselectionEvent')) {
+    return null;
+  }
+
+  final dynamic dynamicEvent = event;
+  final Set<String>? linkIds = _extractIdSet(() {
+    try {
+      return dynamicEvent.linkIds;
+    } catch (_) {
+      return null;
+    }
+  });
+
+  if (linkIds == null) {
+    return null;
+  }
+
+  return LinkDeselectionEventPayload(linkIds: linkIds);
+}
+
+/// Attempts to coerce a link-removal event into a typed payload.
+RemoveLinkEventPayload? parseRemoveLinkEvent(NodeEditorEvent event) {
+  if (!_matchesRuntimeType(event, 'RemoveLinkEvent')) {
+    return null;
+  }
+
+  final dynamic dynamicEvent = event;
+  try {
+    final dynamic candidate = dynamicEvent.link;
+    if (candidate is Link) {
+      return RemoveLinkEventPayload(link: candidate);
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}
+
+bool _matchesRuntimeType(NodeEditorEvent event, String expectedName) {
+  final String typeName = event.runtimeType.toString();
+  if (typeName == expectedName) {
+    return true;
+  }
+  if (typeName.endsWith('.$expectedName')) {
+    return true;
+  }
+  return false;
+}
+
+Set<String>? _extractIdSet(dynamic Function() accessor) {
+  try {
+    final dynamic value = accessor();
+    if (value == null) {
+      return null;
+    }
+
+    if (value is Set<String>) {
+      return Set<String>.unmodifiable(value);
+    }
+    if (value is Iterable) {
+      final Set<String> ids = <String>{};
+      for (final dynamic element in value) {
+        final String? id = _extractId(element);
+        if (id != null) {
+          ids.add(id);
+        }
+      }
+      if (ids.isNotEmpty) {
+        return Set<String>.unmodifiable(ids);
+      }
+      if (value is Iterable && value.isEmpty) {
+        return const <String>{};
+      }
+      return null;
+    }
+
+    final String? id = _extractId(value);
+    if (id != null) {
+      return Set<String>.unmodifiable(<String>{id});
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}
+
+String? _extractId(dynamic value) {
+  if (value is String && value.isNotEmpty) {
+    return value;
+  }
+
+  if (value is Map) {
+    final dynamic idCandidate =
+        value['id'] ?? value['linkId'] ?? value['nodeId'];
+    if (idCandidate is String && idCandidate.isNotEmpty) {
+      return idCandidate;
+    }
+  }
+
+  try {
+    final dynamic candidate = value.id;
+    if (candidate is String && candidate.isNotEmpty) {
+      return candidate;
+    }
+  } catch (_) {
+    // Ignore and continue exploring other shapes.
+  }
+
+  try {
+    final dynamic candidate = value.linkId;
+    if (candidate is String && candidate.isNotEmpty) {
+      return candidate;
+    }
+  } catch (_) {
+    // Ignore and continue exploring other shapes.
+  }
+
+  try {
+    final dynamic candidate = value.nodeId;
+    if (candidate is String && candidate.isNotEmpty) {
+      return candidate;
+    }
+  } catch (_) {
+    // Ignore and continue exploring other shapes.
+  }
+
+  return null;
+}
+
+Offset? _extractOffset(dynamic Function() accessor) {
+  try {
+    final dynamic value = accessor();
+    if (value is Offset) {
+      return value;
+    }
+    if (value is List && value.length >= 2) {
+      final dynamic dx = value[0];
+      final dynamic dy = value[1];
+      if (dx is num && dy is num) {
+        return Offset(dx.toDouble(), dy.toDouble());
+      }
+    }
+    if (value is Map) {
+      final dynamic dx = value['dx'] ?? value['x'];
+      final dynamic dy = value['dy'] ?? value['y'];
+      if (dx is num && dy is num) {
+        return Offset(dx.toDouble(), dy.toDouble());
+      }
+    }
+  } catch (_) {
+    return null;
+  }
+
+  return null;
+}

--- a/lib/presentation/widgets/automaton_canvas_native.dart
+++ b/lib/presentation/widgets/automaton_canvas_native.dart
@@ -2,13 +2,6 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:fl_nodes/fl_nodes.dart';
-import 'package:fl_nodes/src/core/models/events.dart'
-    show
-        DragSelectionEndEvent,
-        LinkDeselectionEvent,
-        LinkSelectionEvent,
-        NodeEditorEvent,
-        RemoveLinkEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -24,6 +17,7 @@ import '../../features/canvas/fl_nodes/fl_nodes_canvas_controller.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_label_field_editor.dart';
 import '../../features/canvas/fl_nodes/link_overlay_utils.dart';
+import '../../features/canvas/fl_nodes/node_editor_event_shims.dart';
 import '../providers/automaton_provider.dart';
 import 'canvas_actions_sheet.dart';
 import 'transition_editors/transition_label_editor.dart';
@@ -632,27 +626,38 @@ class _AutomatonCanvasState extends ConsumerState<AutomatonCanvas> {
     if (!mounted) {
       return;
     }
-    if (event is LinkSelectionEvent) {
-      final ids = event.linkIds;
+    final linkSelection = parseLinkSelectionEvent(event);
+    if (linkSelection != null) {
+      final ids = linkSelection.linkIds;
       setState(() {
         _selectedLinkId = ids.length == 1 ? ids.first : null;
       });
-    } else if (event is LinkDeselectionEvent) {
+      return;
+    }
+
+    final linkDeselection = parseLinkDeselectionEvent(event);
+    if (linkDeselection != null) {
       if (_selectedLinkId != null) {
         setState(() {
           _selectedLinkId = null;
         });
       }
-    } else if (event is RemoveLinkEvent) {
-      if (_selectedLinkId == event.link.id) {
+      return;
+    }
+
+    final removeLinkPayload = parseRemoveLinkEvent(event);
+    if (removeLinkPayload != null) {
+      if (_selectedLinkId == removeLinkPayload.link.id) {
         setState(() {
           _selectedLinkId = null;
         });
       }
-    } else if (event is DragSelectionEndEvent) {
-      if (_selectedLinkId != null) {
-        setState(() {});
-      }
+      return;
+    }
+
+    final dragSelection = parseDragSelectionEndEvent(event);
+    if (dragSelection != null && _selectedLinkId != null) {
+      setState(() {});
     }
   }
 

--- a/lib/presentation/widgets/pda_canvas_native.dart
+++ b/lib/presentation/widgets/pda_canvas_native.dart
@@ -2,13 +2,6 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:fl_nodes/fl_nodes.dart';
-import 'package:fl_nodes/src/core/models/events.dart'
-    show
-        DragSelectionEndEvent,
-        LinkDeselectionEvent,
-        LinkSelectionEvent,
-        NodeEditorEvent,
-        RemoveLinkEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -21,6 +14,7 @@ import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_pda_canvas_controller.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import '../../features/canvas/fl_nodes/link_overlay_utils.dart';
+import '../../features/canvas/fl_nodes/node_editor_event_shims.dart';
 import 'canvas_actions_sheet.dart';
 import 'transition_editors/pda_transition_editor.dart';
 import '../providers/pda_editor_provider.dart';
@@ -496,27 +490,39 @@ class _PDACanvasNativeState extends ConsumerState<PDACanvasNative> {
     if (!mounted) {
       return;
     }
-    if (event is LinkSelectionEvent) {
-      final ids = event.linkIds;
+
+    final linkSelection = parseLinkSelectionEvent(event);
+    if (linkSelection != null) {
+      final ids = linkSelection.linkIds;
       setState(() {
         _selectedLinkId = ids.length == 1 ? ids.first : null;
       });
-    } else if (event is LinkDeselectionEvent) {
+      return;
+    }
+
+    final linkDeselection = parseLinkDeselectionEvent(event);
+    if (linkDeselection != null) {
       if (_selectedLinkId != null) {
         setState(() {
           _selectedLinkId = null;
         });
       }
-    } else if (event is RemoveLinkEvent) {
-      if (_selectedLinkId == event.link.id) {
+      return;
+    }
+
+    final removeLinkPayload = parseRemoveLinkEvent(event);
+    if (removeLinkPayload != null) {
+      if (_selectedLinkId == removeLinkPayload.link.id) {
         setState(() {
           _selectedLinkId = null;
         });
       }
-    } else if (event is DragSelectionEndEvent) {
-      if (_selectedLinkId != null) {
-        setState(() {});
-      }
+      return;
+    }
+
+    final dragSelection = parseDragSelectionEndEvent(event);
+    if (dragSelection != null && _selectedLinkId != null) {
+      setState(() {});
     }
   }
 

--- a/lib/presentation/widgets/tm_canvas_native.dart
+++ b/lib/presentation/widgets/tm_canvas_native.dart
@@ -2,13 +2,6 @@ import 'dart:async';
 
 import 'package:collection/collection.dart';
 import 'package:fl_nodes/fl_nodes.dart';
-import 'package:fl_nodes/src/core/models/events.dart'
-    show
-        DragSelectionEndEvent,
-        LinkDeselectionEvent,
-        LinkSelectionEvent,
-        NodeEditorEvent,
-        RemoveLinkEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -20,6 +13,7 @@ import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_tm_canvas_controller.dart';
 import '../../features/canvas/fl_nodes/fl_nodes_highlight_channel.dart';
 import '../../features/canvas/fl_nodes/link_overlay_utils.dart';
+import '../../features/canvas/fl_nodes/node_editor_event_shims.dart';
 import 'canvas_actions_sheet.dart';
 import 'transition_editors/tm_transition_operations_editor.dart';
 import '../providers/tm_editor_provider.dart';
@@ -573,27 +567,39 @@ class _TMCanvasNativeState extends ConsumerState<TMCanvasNative> {
     if (!mounted) {
       return;
     }
-    if (event is LinkSelectionEvent) {
-      final ids = event.linkIds;
+
+    final linkSelection = parseLinkSelectionEvent(event);
+    if (linkSelection != null) {
+      final ids = linkSelection.linkIds;
       setState(() {
         _selectedLinkId = ids.length == 1 ? ids.first : null;
       });
-    } else if (event is LinkDeselectionEvent) {
+      return;
+    }
+
+    final linkDeselection = parseLinkDeselectionEvent(event);
+    if (linkDeselection != null) {
       if (_selectedLinkId != null) {
         setState(() {
           _selectedLinkId = null;
         });
       }
-    } else if (event is RemoveLinkEvent) {
-      if (_selectedLinkId == event.link.id) {
+      return;
+    }
+
+    final removeLinkPayload = parseRemoveLinkEvent(event);
+    if (removeLinkPayload != null) {
+      if (_selectedLinkId == removeLinkPayload.link.id) {
         setState(() {
           _selectedLinkId = null;
         });
       }
-    } else if (event is DragSelectionEndEvent) {
-      if (_selectedLinkId != null) {
-        setState(() {});
-      }
+      return;
+    }
+
+    final dragSelection = parseDragSelectionEndEvent(event);
+    if (dragSelection != null && _selectedLinkId != null) {
+      setState(() {});
     }
   }
 

--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart
@@ -2,9 +2,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart'
-    show DragSelectionEndEvent, NodeEditorEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -149,6 +146,17 @@ class _FakeLinkGeometryEvent extends NodeEditorEvent {
 
   final String linkId;
   final Offset? controlPoint;
+}
+
+class DragSelectionEndEvent extends NodeEditorEvent {
+  DragSelectionEndEvent(
+    this.position,
+    this.nodeIds, {
+    required super.id,
+  });
+
+  final Offset position;
+  final Set<String> nodeIds;
 }
 
 Future<void> _flushEvents() async {

--- a/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_pda_canvas_controller_test.dart
@@ -2,9 +2,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart'
-    show DragSelectionEndEvent, NodeEditorEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -116,6 +113,17 @@ class _FakeLinkGeometryEvent extends NodeEditorEvent {
 
   final String linkId;
   final Offset? controlPoint;
+}
+
+class DragSelectionEndEvent extends NodeEditorEvent {
+  DragSelectionEndEvent(
+    this.position,
+    this.nodeIds, {
+    required super.id,
+  });
+
+  final Offset position;
+  final Set<String> nodeIds;
 }
 
 Future<void> _flushEvents() async {

--- a/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_tm_canvas_controller_test.dart
@@ -2,9 +2,6 @@ import 'dart:async';
 import 'dart:math' as math;
 
 import 'package:fl_nodes/fl_nodes.dart';
-// ignore: implementation_imports
-import 'package:fl_nodes/src/core/models/events.dart'
-    show DragSelectionEndEvent, NodeEditorEvent;
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
@@ -102,6 +99,17 @@ class _FakeLinkGeometryEvent extends NodeEditorEvent {
 
   final String linkId;
   final Offset? controlPoint;
+}
+
+class DragSelectionEndEvent extends NodeEditorEvent {
+  DragSelectionEndEvent(
+    this.position,
+    this.nodeIds, {
+    required super.id,
+  });
+
+  final Offset position;
+  final Set<String> nodeIds;
 }
 
 Future<void> _flushEvents() async {

--- a/test/features/canvas/fl_nodes/node_editor_event_shims_test.dart
+++ b/test/features/canvas/fl_nodes/node_editor_event_shims_test.dart
@@ -1,0 +1,129 @@
+import 'dart:ui';
+
+import 'package:fl_nodes/fl_nodes.dart' as fl;
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/features/canvas/fl_nodes/node_editor_event_shims.dart';
+
+class DragSelectionEndEvent extends fl.NodeEditorEvent {
+  DragSelectionEndEvent(
+    this.position,
+    this.nodeIds, {
+    required super.id,
+  });
+
+  final Offset position;
+  final Set<String> nodeIds;
+}
+
+class LinkSelectionEvent extends fl.NodeEditorEvent {
+  LinkSelectionEvent(
+    this.linkIds, {
+    required super.id,
+  });
+
+  final Set<String> linkIds;
+}
+
+class LinkDeselectionEvent extends fl.NodeEditorEvent {
+  LinkDeselectionEvent(
+    this.linkIds, {
+    required super.id,
+  });
+
+  final Set<String> linkIds;
+}
+
+class RemoveLinkEvent extends fl.NodeEditorEvent {
+  RemoveLinkEvent(
+    this.link, {
+    required super.id,
+  });
+
+  final fl.Link link;
+}
+
+class _UnrelatedEvent extends fl.NodeEditorEvent {
+  const _UnrelatedEvent() : super(id: 'other');
+}
+
+void main() {
+  group('parseDragSelectionEndEvent', () {
+    test('returns payload when node identifiers are available', () {
+      final event = DragSelectionEndEvent(
+        const Offset(12, 24),
+        {'a', 'b'},
+        id: 'drag',
+      );
+
+      final payload = parseDragSelectionEndEvent(event);
+
+      expect(payload, isNotNull);
+      expect(payload!.nodeIds, equals({'a', 'b'}));
+      expect(payload.position, equals(const Offset(12, 24)));
+    });
+
+    test('returns null for unrelated events', () {
+      final payload = parseDragSelectionEndEvent(const _UnrelatedEvent());
+      expect(payload, isNull);
+    });
+  });
+
+  group('parseLinkSelectionEvent', () {
+    test('extracts link identifiers from selection events', () {
+      final event = LinkSelectionEvent({'edge-1', 'edge-2'}, id: 'selection');
+
+      final payload = parseLinkSelectionEvent(event);
+
+      expect(payload, isNotNull);
+      expect(payload!.linkIds, equals({'edge-1', 'edge-2'}));
+    });
+
+    test('ignores non-selection events', () {
+      final payload = parseLinkSelectionEvent(const _UnrelatedEvent());
+      expect(payload, isNull);
+    });
+  });
+
+  group('parseLinkDeselectionEvent', () {
+    test('extracts link identifiers from deselection events', () {
+      final event = LinkDeselectionEvent({'edge-3'}, id: 'deselection');
+
+      final payload = parseLinkDeselectionEvent(event);
+
+      expect(payload, isNotNull);
+      expect(payload!.linkIds, equals({'edge-3'}));
+    });
+
+    test('ignores non-deselection events', () {
+      final payload = parseLinkDeselectionEvent(const _UnrelatedEvent());
+      expect(payload, isNull);
+    });
+  });
+
+  group('parseRemoveLinkEvent', () {
+    test('returns the link associated with the removal event', () {
+      final link = fl.Link(
+        id: 'edge-42',
+        fromTo: (
+          from: 'from-node',
+          to: 'to-node',
+          fromPort: 'outgoing',
+          toPort: 'incoming',
+        ),
+        state: fl.LinkState(),
+      );
+      final event = RemoveLinkEvent(link, id: 'remove');
+
+      final payload = parseRemoveLinkEvent(event);
+
+      expect(payload, isNotNull);
+      expect(payload!.link, equals(link));
+    });
+
+    test('returns null for events without link data', () {
+      final payload = parseRemoveLinkEvent(const _UnrelatedEvent());
+      expect(payload, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add runtime shims for drag selection, link selection, and removal events so the canvas no longer imports fl_nodes src classes
- update controllers, widgets, and tests to consume the new compatibility layer and cover the event guards
- document the local wrapper approach in docs/canvas_bridge.md for future upgrades

## Testing
- not run (Dart/Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e12311e484832e8384ffe5bdcd55b2