### PR TITLE
Add undo/redo history to fl_nodes controllers

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -1,5 +1,8 @@
+import 'dart:math' as math;
+
 import 'package:fl_nodes/fl_nodes.dart';
 import 'package:flutter/material.dart';
+import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/fsa.dart';
 import '../../../presentation/providers/automaton_provider.dart';
@@ -19,6 +22,9 @@ class FlNodesCanvasController extends BaseFlNodesCanvasController<AutomatonProvi
         );
 
   AutomatonProvider get _provider => notifier;
+
+  @override
+  FSA? get currentDomainData => _provider.state.currentAutomaton;
 
   @override
   String get statePrototypeId => 'automaton_state';
@@ -47,38 +53,46 @@ class FlNodesCanvasController extends BaseFlNodesCanvasController<AutomatonProvi
 
   @override
   void onCanvasNodeAdded(FlNodesCanvasNode node) {
-    _provider.addState(
-      id: node.id,
-      label: node.label,
-      x: node.x,
-      y: node.y,
-      isInitial: node.isInitial ? true : null,
-      isAccepting: node.isAccepting,
-    );
+    performMutation(() {
+      _provider.addState(
+        id: node.id,
+        label: node.label,
+        x: node.x,
+        y: node.y,
+        isInitial: node.isInitial ? true : null,
+        isAccepting: node.isAccepting,
+      );
+    });
   }
 
   @override
   void onCanvasNodeRemoved(String nodeId) {
-    _provider.removeState(id: nodeId);
+    performMutation(() {
+      _provider.removeState(id: nodeId);
+    });
   }
 
   @override
   void onCanvasNodesMoved(Map<String, FlNodesCanvasNode> updatedNodes) {
-    for (final entry in updatedNodes.entries) {
-      _provider.moveState(
-        id: entry.key,
-        x: entry.value.x,
-        y: entry.value.y,
-      );
-    }
+    performMutation(() {
+      for (final entry in updatedNodes.entries) {
+        _provider.moveState(
+          id: entry.key,
+          x: entry.value.x,
+          y: entry.value.y,
+        );
+      }
+    });
   }
 
   @override
   void onCanvasNodeLabelUpdated(FlNodesCanvasNode node) {
-    _provider.updateStateLabel(
-      id: node.id,
-      label: node.label.isEmpty ? node.id : node.label,
-    );
+    performMutation(() {
+      _provider.updateStateLabel(
+        id: node.id,
+        label: node.label.isEmpty ? node.id : node.label,
+      );
+    });
   }
 
   @override
@@ -96,35 +110,73 @@ class FlNodesCanvasController extends BaseFlNodesCanvasController<AutomatonProvi
 
   @override
   void onCanvasEdgeAdded(FlNodesCanvasEdge edge) {
-    _provider.addOrUpdateTransition(
-      id: edge.id,
-      fromStateId: edge.fromStateId,
-      toStateId: edge.toStateId,
-      label: edge.label,
-      controlPointX: edge.controlPointX,
-      controlPointY: edge.controlPointY,
-    );
+    performMutation(() {
+      _provider.addOrUpdateTransition(
+        id: edge.id,
+        fromStateId: edge.fromStateId,
+        toStateId: edge.toStateId,
+        label: edge.label,
+        controlPointX: edge.controlPointX,
+        controlPointY: edge.controlPointY,
+      );
+    });
   }
 
   @override
   void onCanvasEdgeRemoved(String edgeId) {
-    _provider.removeTransition(id: edgeId);
+    performMutation(() {
+      _provider.removeTransition(id: edgeId);
+    });
   }
 
   @override
   void onCanvasEdgeGeometryUpdated(FlNodesCanvasEdge edge, Offset controlPoint) {
-    _provider.addOrUpdateTransition(
-      id: edge.id,
-      fromStateId: edge.fromStateId,
-      toStateId: edge.toStateId,
-      label: edge.label,
-      controlPointX: controlPoint.dx,
-      controlPointY: controlPoint.dy,
-    );
+    performMutation(() {
+      _provider.addOrUpdateTransition(
+        id: edge.id,
+        fromStateId: edge.fromStateId,
+        toStateId: edge.toStateId,
+        label: edge.label,
+        controlPointX: controlPoint.dx,
+        controlPointY: controlPoint.dy,
+      );
+    });
   }
 
   /// Synchronises the fl_nodes controller with the latest [automaton].
   void synchronize(FSA? automaton) {
     synchronizeCanvas(automaton);
+  }
+
+  @override
+  void applySnapshotToDomain(FlNodesAutomatonSnapshot snapshot) {
+    final template = _provider.state.currentAutomaton ??
+        FSA(
+          id: snapshot.metadata.id ?? 'automaton_${DateTime.now().microsecondsSinceEpoch}',
+          name: snapshot.metadata.name ?? 'Untitled Automaton',
+          states: const {},
+          transitions: const {},
+          alphabet: snapshot.metadata.alphabet.toSet(),
+          initialState: null,
+          acceptingStates: const {},
+          created: DateTime.now(),
+          modified: DateTime.now(),
+          bounds: const math.Rectangle<double>(0, 0, 800, 600),
+          panOffset: Vector2.zero(),
+          zoomLevel: 1.0,
+        );
+
+    final merged = FlNodesAutomatonMapper.mergeIntoTemplate(snapshot, template)
+        .copyWith(
+      id: snapshot.metadata.id ?? template.id,
+      name: snapshot.metadata.name ?? template.name,
+      alphabet: snapshot.metadata.alphabet.isNotEmpty
+          ? snapshot.metadata.alphabet.toSet()
+          : template.alphabet,
+      modified: DateTime.now(),
+    );
+
+    _provider.updateAutomaton(merged);
+    synchronize(merged);
   }
 }

--- a/lib/presentation/widgets/fl_nodes_canvas_toolbar.dart
+++ b/lib/presentation/widgets/fl_nodes_canvas_toolbar.dart
@@ -10,6 +10,10 @@ class FlNodesCanvasToolbar extends StatelessWidget {
     required this.onFitToContent,
     required this.onResetView,
     this.onClear,
+    this.onUndo,
+    this.onRedo,
+    this.canUndo = false,
+    this.canRedo = false,
     this.statusMessage,
     this.layout = FlNodesCanvasToolbarLayout.desktop,
   });
@@ -20,13 +24,21 @@ class FlNodesCanvasToolbar extends StatelessWidget {
   final VoidCallback onFitToContent;
   final VoidCallback onResetView;
   final VoidCallback? onClear;
+  final VoidCallback? onUndo;
+  final VoidCallback? onRedo;
+  final bool canUndo;
+  final bool canRedo;
   final String? statusMessage;
   final FlNodesCanvasToolbarLayout layout;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final actions = <(_ToolbarAction action, VoidCallback handler)>[
+    final actions = <(_ToolbarAction action, VoidCallback? handler)>[
+      if (onUndo != null)
+        (_ToolbarAction.undo, canUndo ? onUndo : null),
+      if (onRedo != null)
+        (_ToolbarAction.redo, canRedo ? onRedo : null),
       (_ToolbarAction.addState, onAddState),
       (_ToolbarAction.zoomIn, onZoomIn),
       (_ToolbarAction.zoomOut, onZoomOut),
@@ -61,7 +73,7 @@ class _DesktopToolbar extends StatelessWidget {
     required this.theme,
   });
 
-  final List<(_ToolbarAction, VoidCallback)> actions;
+  final List<(_ToolbarAction, VoidCallback?)> actions;
   final String? statusMessage;
   final ThemeData theme;
 
@@ -137,7 +149,7 @@ class _MobileToolbar extends StatelessWidget {
     required this.theme,
   });
 
-  final List<(_ToolbarAction, VoidCallback)> actions;
+  final List<(_ToolbarAction, VoidCallback?)> actions;
   final String? statusMessage;
   final ThemeData theme;
 
@@ -202,7 +214,7 @@ class _MobileToolbarButton extends StatelessWidget {
   });
 
   final _ToolbarAction action;
-  final VoidCallback onPressed;
+  final VoidCallback? onPressed;
 
   @override
   Widget build(BuildContext context) {
@@ -221,6 +233,8 @@ class _MobileToolbarButton extends StatelessWidget {
 }
 
 enum _ToolbarAction {
+  undo(Icons.undo, 'Undo'),
+  redo(Icons.redo, 'Redo'),
   addState(Icons.add, 'Add state'),
   zoomIn(Icons.zoom_in, 'Zoom in'),
   zoomOut(Icons.zoom_out, 'Zoom out'),

--- a/test/widget/presentation/fl_nodes_canvas_toolbar_test.dart
+++ b/test/widget/presentation/fl_nodes_canvas_toolbar_test.dart
@@ -84,6 +84,35 @@ void main() {
     expect(find.text('Add state'), findsOneWidget);
     expect(find.text('Zoom in'), findsOneWidget);
   });
+
+  testWidgets('renders undo and redo buttons with enabled state', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: FlNodesCanvasToolbar(
+            onAddState: _noop,
+            onZoomIn: _noop,
+            onZoomOut: _noop,
+            onFitToContent: _noop,
+            onResetView: _noop,
+            onUndo: _noop,
+            onRedo: _noop,
+            canUndo: false,
+            canRedo: true,
+            layout: FlNodesCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    final undoButton =
+        tester.widget<IconButton>(find.widgetWithIcon(IconButton, Icons.undo));
+    final redoButton =
+        tester.widget<IconButton>(find.widgetWithIcon(IconButton, Icons.redo));
+
+    expect(undoButton.onPressed, isNull);
+    expect(redoButton.onPressed, isNotNull);
+  });
 }
 
 void _noop() {}


### PR DESCRIPTION
## Summary
- add undo/redo controls to the fl_nodes toolbar on desktop and mobile layouts
- push history snapshots for automaton, TM, and PDA canvas controllers with undo/redo APIs that resync Riverpod state
- cover undo/redo behaviour with controller tests and verify toolbar rendering of the new actions

## Testing
- not run (flutter CLI unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e12e75d8ac832e95dceddfdf3e8caf