### PR TITLE
Extend FlNodesCanvasEdge copyWith for PDA metadata

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_models.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_models.dart
@@ -201,6 +201,11 @@ class FlNodesCanvasEdge {
     String? writeSymbol,
     TapeDirection? direction,
     int? tapeNumber,
+    String? popSymbol,
+    String? pushSymbol,
+    bool? isLambdaInput,
+    bool? isLambdaPop,
+    bool? isLambdaPush,
   }) {
     return FlNodesCanvasEdge(
       id: id ?? this.id,

--- a/test/features/canvas/fl_nodes/fl_nodes_canvas_models_test.dart
+++ b/test/features/canvas/fl_nodes/fl_nodes_canvas_models_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/features/canvas/fl_nodes/fl_nodes_canvas_models.dart';
+
+void main() {
+  group('FlNodesCanvasEdge', () {
+    test('copyWith updates PDA metadata fields', () {
+      const baseEdge = FlNodesCanvasEdge(
+        id: 'edge-1',
+        fromStateId: 'q0',
+        toStateId: 'q1',
+        symbols: ['a'],
+        popSymbol: 'A',
+        pushSymbol: 'B',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+
+      final updated = baseEdge.copyWith(
+        popSymbol: 'Z',
+        pushSymbol: 'Y',
+        isLambdaInput: true,
+        isLambdaPop: true,
+        isLambdaPush: true,
+      );
+
+      expect(updated.popSymbol, 'Z');
+      expect(updated.pushSymbol, 'Y');
+      expect(updated.isLambdaInput, isTrue);
+      expect(updated.isLambdaPop, isTrue);
+      expect(updated.isLambdaPush, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- allow FlNodesCanvasEdge.copyWith to update PDA-specific metadata fields
- add a regression test covering updates to PDA metadata via copyWith

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e142e8252c832ea1c976835c3ac70e