### PR TITLE
Refine mobile toolbar controls

### DIFF
--- a/lib/presentation/widgets/fl_nodes_canvas_toolbar.dart
+++ b/lib/presentation/widgets/fl_nodes_canvas_toolbar.dart
@@ -174,17 +174,20 @@ class _MobileToolbar extends StatelessWidget {
               child: Column(
                 mainAxisSize: MainAxisSize.min,
                 children: [
-                  Wrap(
-                    alignment: WrapAlignment.center,
-                    spacing: 12,
-                    runSpacing: 12,
-                    children: [
-                      for (final entry in actions)
-                        _MobileToolbarButton(
-                          action: entry.$1,
-                          onPressed: entry.$2,
-                        ),
-                    ],
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 4),
+                    child: Wrap(
+                      alignment: WrapAlignment.center,
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        for (final entry in actions)
+                          _MobileToolbarButton(
+                            action: entry.$1,
+                            onPressed: entry.$2,
+                          ),
+                      ],
+                    ),
                   ),
                   if (statusMessage != null && statusMessage!.isNotEmpty)
                     Padding(
@@ -219,15 +222,16 @@ class _MobileToolbarButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    return FilledButton.icon(
-      style: FilledButton.styleFrom(
-        backgroundColor: colorScheme.surfaceContainerHigh,
-        foregroundColor: colorScheme.onSurface,
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+    return Tooltip(
+      message: action.label,
+      child: IconButton.filledTonal(
+        onPressed: onPressed,
+        icon: Icon(action.icon),
+        style: IconButton.styleFrom(
+          foregroundColor: colorScheme.onSecondaryContainer,
+          backgroundColor: colorScheme.secondaryContainer,
+        ),
       ),
-      onPressed: onPressed,
-      icon: Icon(action.icon),
-      label: Text(action.label),
     );
   }
 }


### PR DESCRIPTION
## Summary
- replace the mobile toolbar buttons with tonal icon buttons wrapped in tooltips for accessible labels
- tighten wrap spacing and padding to balance the smaller icon-only buttons

## Testing
- dart format . *(fails: `dart` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e165641fa8832ea9f50850fb561af8