### PR TITLE
Ensure sequential labels for new canvas states

### DIFF
--- a/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
+++ b/lib/features/canvas/fl_nodes/fl_nodes_canvas_controller.dart
@@ -37,13 +37,45 @@ class FlNodesCanvasController extends BaseFlNodesCanvasController<AutomatonProvi
     return FlNodesAutomatonMapper.toSnapshot(automaton);
   }
 
+  String _nextAvailableStateLabel() {
+    final reservedLabels = <String>{};
+
+    final automaton = _provider.state.currentAutomaton;
+    if (automaton != null) {
+      for (final state in automaton.states) {
+        final label = state.label.trim();
+        if (label.isNotEmpty) {
+          reservedLabels.add(label);
+        }
+      }
+    }
+
+    for (final node in nodesCache.values) {
+      final label = node.label.trim();
+      if (label.isNotEmpty) {
+        reservedLabels.add(label);
+      }
+    }
+
+    var index = 0;
+    while (reservedLabels.contains('q$index')) {
+      index++;
+    }
+    return 'q$index';
+  }
+
   @override
   FlNodesCanvasNode createCanvasNode(NodeInstance node) {
-    final label = resolveLabel(node);
+    final label = _nextAvailableStateLabel();
+    final labelField = node.fields[labelFieldId];
+    if (labelField != null) {
+      labelField.data = label;
+    }
+    final resolvedLabel = resolveLabel(node);
     final isFirstState = nodesCache.isEmpty;
     return FlNodesCanvasNode(
       id: node.id,
-      label: label,
+      label: resolvedLabel,
       x: node.offset.dx,
       y: node.offset.dy,
       isInitial: isFirstState,


### PR DESCRIPTION
## Summary
- add a helper in `FlNodesCanvasController` to scan existing state labels and pick the next available `q<n>`
- persist the generated label in the new node instance before constructing the canvas node
- extend the controller smoke tests to verify sequential labels and collision avoidance after manual renames while keeping provider state up to date

## Testing
- flutter test test/features/canvas/fl_nodes/fl_nodes_canvas_controller_test.dart *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e1655e56fc832e96d800c3750f3111