### PR TITLE
Fix accepting state ring layout

### DIFF
--- a/lib/presentation/widgets/automaton_state_node.dart
+++ b/lib/presentation/widgets/automaton_state_node.dart
@@ -240,9 +240,8 @@ class _AutomatonStateNodeState extends State<AutomatonStateNode> {
   }
 
   void _updatePortOffsets() {
-    final padding = widget.isAccepting ? 4.0 : 0.0;
     final radius = AutomatonStateNode.nodeDiameter / 2;
-    final center = Offset(radius + padding, radius + padding);
+    final center = Offset(radius, radius);
     final collapsed = widget.node.state.isCollapsed;
     final effectiveRadius = collapsed ? radius * 0.6 : radius;
 
@@ -360,14 +359,9 @@ class _AutomatonStateNodeState extends State<AutomatonStateNode> {
 
     Widget decoratedCircle = circle;
     if (widget.isAccepting) {
-      decoratedCircle = Container(
-        padding: const EdgeInsets.all(4),
-        decoration: BoxDecoration(
-          shape: BoxShape.circle,
-          border: Border.all(
-            color: colors.foreground.withOpacity(0.9),
-            width: 2,
-          ),
+      decoratedCircle = CustomPaint(
+        painter: _AcceptingRingPainter(
+          color: colors.foreground.withOpacity(0.9),
         ),
         child: circle,
       );
@@ -405,7 +399,6 @@ class _AutomatonStateNodeState extends State<AutomatonStateNode> {
       children: [
         Container(
           key: widget.node.key,
-          padding: EdgeInsets.all(widget.isAccepting ? 4 : 0),
           child: Tooltip(
             message: widget.label,
             child: decoratedCircle,
@@ -955,6 +948,33 @@ class _StateToggleButton extends StatelessWidget {
         splashRadius: 18,
       ),
     );
+  }
+}
+
+class _AcceptingRingPainter extends CustomPainter {
+  const _AcceptingRingPainter({
+    required this.color,
+  });
+
+  final Color color;
+  static const double _ringPadding = 4;
+  static const double _strokeWidth = 2;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final radius = size.shortestSide / 2;
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = _strokeWidth;
+
+    final center = Offset(size.width / 2, size.height / 2);
+    canvas.drawCircle(center, radius + _ringPadding, paint);
+  }
+
+  @override
+  bool shouldRepaint(_AcceptingRingPainter oldDelegate) {
+    return oldDelegate.color != color;
   }
 }
 

--- a/test/widget/presentation/native_canvas_flag_toggles_test.dart
+++ b/test/widget/presentation/native_canvas_flag_toggles_test.dart
@@ -97,6 +97,16 @@ void main() {
     expect(initialToggleFinder, findsOneWidget);
     expect(acceptingToggleFinder, findsOneWidget);
 
+    final automatonNodeTooltipFinder = find.byWidgetPredicate(
+      (widget) => widget is Tooltip && widget.message == 'q1',
+    );
+    final automatonNodeBodyFinder = find.descendant(
+      of: automatonNodeTooltipFinder,
+      matching: find.byType(AnimatedContainer),
+    );
+
+    final initialRect = tester.getRect(automatonNodeBodyFinder);
+
     final initialIconBefore = tester.widget<Icon>(
       find.descendant(
         of: initialToggleFinder,
@@ -124,6 +134,8 @@ void main() {
     await tester.tap(acceptingToggleFinder);
     await tester.pumpAndSettle();
 
+    final acceptingRect = tester.getRect(automatonNodeBodyFinder);
+
     final acceptingIcon = tester.widget<Icon>(
       find.descendant(
         of: acceptingToggleFinder,
@@ -136,6 +148,8 @@ void main() {
           .any((state) => state.id == 'q1'),
       isTrue,
     );
+    expect(acceptingRect.size, equals(initialRect.size));
+    expect(acceptingRect.topLeft, equals(initialRect.topLeft));
     expect(acceptingIcon.color!.opacity, closeTo(1, 0.01));
   });
 
@@ -187,6 +201,16 @@ void main() {
     expect(initialToggleFinder, findsOneWidget);
     expect(acceptingToggleFinder, findsOneWidget);
 
+    final tmNodeTooltipFinder = find.byWidgetPredicate(
+      (widget) => widget is Tooltip && widget.message == 'q1',
+    );
+    final tmNodeBodyFinder = find.descendant(
+      of: tmNodeTooltipFinder,
+      matching: find.byType(AnimatedContainer),
+    );
+
+    final tmInitialRect = tester.getRect(tmNodeBodyFinder);
+
     final initialIconBefore = tester.widget<Icon>(
       find.descendant(
         of: initialToggleFinder,
@@ -211,6 +235,8 @@ void main() {
     await tester.tap(acceptingToggleFinder);
     await tester.pumpAndSettle();
 
+    final tmAcceptingRect = tester.getRect(tmNodeBodyFinder);
+
     final acceptingIcon = tester.widget<Icon>(
       find.descendant(
         of: acceptingToggleFinder,
@@ -222,6 +248,8 @@ void main() {
       tmNotifier.state.tm?.acceptingStates.any((state) => state.id == 'q1'),
       isTrue,
     );
+    expect(tmAcceptingRect.size, equals(tmInitialRect.size));
+    expect(tmAcceptingRect.topLeft, equals(tmInitialRect.topLeft));
     expect(acceptingIcon.color!.opacity, closeTo(1, 0.01));
   });
 
@@ -273,6 +301,16 @@ void main() {
     expect(initialToggleFinder, findsOneWidget);
     expect(acceptingToggleFinder, findsOneWidget);
 
+    final pdaNodeTooltipFinder = find.byWidgetPredicate(
+      (widget) => widget is Tooltip && widget.message == 'q1',
+    );
+    final pdaNodeBodyFinder = find.descendant(
+      of: pdaNodeTooltipFinder,
+      matching: find.byType(AnimatedContainer),
+    );
+
+    final pdaInitialRect = tester.getRect(pdaNodeBodyFinder);
+
     final initialIconBefore = tester.widget<Icon>(
       find.descendant(
         of: initialToggleFinder,
@@ -297,6 +335,8 @@ void main() {
     await tester.tap(acceptingToggleFinder);
     await tester.pumpAndSettle();
 
+    final pdaAcceptingRect = tester.getRect(pdaNodeBodyFinder);
+
     final acceptingIcon = tester.widget<Icon>(
       find.descendant(
         of: acceptingToggleFinder,
@@ -309,6 +349,8 @@ void main() {
           .any((state) => state.id == 'q1'),
       isTrue,
     );
+    expect(pdaAcceptingRect.size, equals(pdaInitialRect.size));
+    expect(pdaAcceptingRect.topLeft, equals(pdaInitialRect.topLeft));
     expect(acceptingIcon.color!.opacity, closeTo(1, 0.01));
   });
 }


### PR DESCRIPTION
## Summary
- draw the accepting-state ring with a custom painter so the widget box no longer grows
- recalculate port offsets from the nominal node radius and add widget tests to lock layout when toggling accepting flags

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e16562fec8832eafe0383524698626