### PR TITLE
Fix pan offset accumulation on automaton canvas

### DIFF
--- a/lib/presentation/widgets/automaton_canvas_native.dart
+++ b/lib/presentation/widgets/automaton_canvas_native.dart
@@ -438,8 +438,12 @@ class _AutomatonCanvasState extends ConsumerState<AutomatonCanvas> {
       return;
     }
 
+    final currentOffset = controller.viewportOffset;
     controller.setViewportOffset(
-      Offset(-delta.dx / zoom, -delta.dy / zoom),
+      Offset(
+        currentOffset.dx + (delta.dx / zoom),
+        currentOffset.dy + (delta.dy / zoom),
+      ),
       animate: false,
     );
     _canvasPanStartGlobalPosition = details.globalPosition;


### PR DESCRIPTION
## Summary
- update the canvas pan handler to add drag deltas to the current viewport offset while preserving zoom scaling

## Testing
- not run (UI interaction requires a device outside this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e173bd2214832ea406ad1b3d445e09