### PR TITLE
Make neutral automaton nodes transparent

### DIFF
--- a/lib/presentation/widgets/automaton_state_node.dart
+++ b/lib/presentation/widgets/automaton_state_node.dart
@@ -368,6 +368,21 @@ class _AutomatonStateNodeState extends State<AutomatonStateNode> {
       return colorScheme.outlineVariant;
     }();
 
+    final shouldGlow = widget.isHighlighted || widget.isCurrent;
+    final boxShadows = <BoxShadow>[
+      BoxShadow(
+        color: theme.colorScheme.shadow.withOpacity(0.18),
+        blurRadius: 12,
+        offset: const Offset(0, 4),
+      ),
+      if (shouldGlow)
+        BoxShadow(
+          color: theme.colorScheme.primary.withOpacity(0.35),
+          blurRadius: 16,
+          spreadRadius: 2,
+        ),
+    ];
+
     final circle = AnimatedContainer(
       duration: const Duration(milliseconds: 200),
       width: AutomatonStateNode.nodeDiameter,
@@ -379,15 +394,7 @@ class _AutomatonStateNodeState extends State<AutomatonStateNode> {
           color: borderColor,
           width: 2,
         ),
-        boxShadow: widget.isHighlighted || widget.isCurrent
-            ? [
-                BoxShadow(
-                  color: theme.colorScheme.primary.withOpacity(0.35),
-                  blurRadius: 16,
-                  spreadRadius: 2,
-                ),
-              ]
-            : const [],
+        boxShadow: boxShadows,
       ),
       child: Center(
         child: Padding(
@@ -951,7 +958,7 @@ class _AutomatonStateNodeState extends State<AutomatonStateNode> {
       );
     }
     return _NodeColors(
-      background: colorScheme.surface,
+      background: Colors.transparent,
       foreground: colorScheme.onSurface,
     );
   }


### PR DESCRIPTION
## Summary
- render neutral automaton nodes with a transparent fill while keeping visited/highlighted colors
- add a base shadow so borders and highlight glow remain visible without an opaque fill

## Testing
- not run (flutter not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68e173b5abcc832e8356f2b135a414c5