### PR TITLE
Refactor fl_nodes linking to center-based transitions

### DIFF
--- a/lib/core/constants/automaton_canvas.dart
+++ b/lib/core/constants/automaton_canvas.dart
@@ -1,0 +1,2 @@
+/// Shared layout constants for the automaton canvas widgets.
+const double kAutomatonStateDiameter = 96;


### PR DESCRIPTION
## Summary
- replace the two-port node prototype with a single center connector and add geometry revision notifications for overlays
- update the automaton state widget to start transition gestures from the node center and draw a subtle anchor indicator instead of port handles
- compute default control points for multi-edge/self-loop links and render custom arrowed curves via a new overlay painter

## Testing
- not run (dart toolchain unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e173c35e0c832e9489516143ac90a3