### PR TITLE
Add GraphView canvas scaffolding

### DIFF
--- a/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
@@ -1,0 +1,348 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+
+import '../../../core/models/simulation_highlight.dart';
+import 'graphview_canvas_models.dart';
+import 'graphview_highlight_controller.dart';
+import 'graphview_viewport_highlight_mixin.dart';
+
+class _GraphHistoryEntry {
+  const _GraphHistoryEntry({required this.snapshot, required this.highlight});
+
+  final GraphViewAutomatonSnapshot snapshot;
+  final SimulationHighlight highlight;
+}
+
+/// Base controller that coordinates GraphView interactions with domain notifiers.
+abstract class BaseGraphViewCanvasController<TNotifier, TSnapshot>
+    extends GraphViewHighlightController
+    with GraphViewViewportHighlightMixin {
+  BaseGraphViewCanvasController({
+    required this.notifier,
+    Graph? graph,
+    GraphViewController? viewController,
+    TransformationController? transformationController,
+  })  : graph = graph ?? Graph(),
+        graphController = viewController ??
+            GraphViewController(
+              transformationController:
+                  transformationController ?? TransformationController(),
+            ),
+        _ownsTransformationController =
+            viewController == null && transformationController == null;
+
+  @protected
+  final TNotifier notifier;
+
+  @override
+  final Graph graph;
+
+  @override
+  final GraphViewController graphController;
+
+  final bool _ownsTransformationController;
+
+  final Map<String, GraphViewCanvasNode> _nodes = {};
+  final Map<String, GraphViewCanvasEdge> _edges = {};
+  final Map<String, Node> _graphNodes = {};
+  final Map<String, Edge> _graphEdges = {};
+
+  bool _isSynchronizing = false;
+
+  final List<_GraphHistoryEntry> _undoHistory = [];
+  final List<_GraphHistoryEntry> _redoHistory = [];
+
+  @protected
+  Map<String, Node> get graphNodes => _graphNodes;
+
+  @protected
+  Map<String, Edge> get graphEdges => _graphEdges;
+
+  @override
+  Map<String, GraphViewCanvasNode> get nodesCache => _nodes;
+
+  @override
+  Map<String, GraphViewCanvasEdge> get edgesCache => _edges;
+
+  Iterable<GraphViewCanvasNode> get nodes => _nodes.values;
+  Iterable<GraphViewCanvasEdge> get edges => _edges.values;
+
+  GraphViewCanvasNode? nodeById(String id) => _nodes[id];
+  GraphViewCanvasEdge? edgeById(String id) => _edges[id];
+
+  bool get canUndo => _undoHistory.isNotEmpty;
+  bool get canRedo => _redoHistory.isNotEmpty;
+
+  /// Releases the resources owned by the controller.
+  void dispose() {
+    disposeViewportHighlight();
+    if (_ownsTransformationController) {
+      graphController.transformationController?.dispose();
+    }
+  }
+
+  /// Converts domain state into a snapshot consumed by the canvas.
+  @protected
+  GraphViewAutomatonSnapshot toSnapshot(TSnapshot? data);
+
+  /// Returns the current domain entity rendered on the canvas.
+  @protected
+  TSnapshot? get currentDomainData;
+
+  /// Applies a [snapshot] to the underlying domain notifier and synchronises
+  /// the canvas state accordingly.
+  @protected
+  void applySnapshotToDomain(GraphViewAutomatonSnapshot snapshot);
+
+  /// Creates a GraphView node for the provided canvas [node].
+  @protected
+  Node buildGraphNode(GraphViewCanvasNode node) {
+    final instance = Node.Id(node.id);
+    instance.position = Offset(node.x, node.y);
+    return instance;
+  }
+
+  /// Creates a GraphView edge for the provided canvas [edge].
+  @protected
+  Edge buildGraphEdge(GraphViewCanvasEdge edge, Node from, Node to) {
+    return Edge(from, to, key: ValueKey(edge.id));
+  }
+
+  /// Records the current canvas state before invoking [mutation].
+  @protected
+  void performMutation(VoidCallback mutation) {
+    if (_isSynchronizing) {
+      mutation();
+      return;
+    }
+
+    final entry = _captureHistoryEntry();
+    if (entry != null) {
+      _undoHistory.add(entry);
+      _redoHistory.clear();
+    }
+
+    mutation();
+    synchronizeGraph(currentDomainData);
+  }
+
+  /// Restores the previous canvas snapshot if available.
+  bool undo() {
+    if (_undoHistory.isEmpty) {
+      return false;
+    }
+
+    final currentEntry = _captureHistoryEntry();
+    if (currentEntry != null) {
+      _redoHistory.add(currentEntry);
+    }
+
+    final entry = _undoHistory.removeLast();
+    _applyHistoryEntry(entry);
+    return true;
+  }
+
+  /// Reapplies the most recently undone canvas snapshot if available.
+  bool redo() {
+    if (_redoHistory.isEmpty) {
+      return false;
+    }
+
+    final currentEntry = _captureHistoryEntry();
+    if (currentEntry != null) {
+      _undoHistory.add(currentEntry);
+    }
+
+    final entry = _redoHistory.removeLast();
+    _applyHistoryEntry(entry);
+    return true;
+  }
+
+  /// Synchronises the canvas with the provided domain [data].
+  @protected
+  void synchronizeGraph(TSnapshot? data) {
+    final snapshot = toSnapshot(data);
+    final incomingNodes = {for (final node in snapshot.nodes) node.id: node};
+    final incomingEdges = {for (final edge in snapshot.edges) edge.id: edge};
+
+    final previousHighlight = SimulationHighlight(
+      stateIds: Set<String>.from(highlightNotifier.value.stateIds),
+      transitionIds: Set<String>.from(highlightNotifier.value.transitionIds),
+    );
+
+    _isSynchronizing = true;
+
+    var nodesDirty = false;
+    var edgesDirty = false;
+
+    try {
+      final removedNodeIds =
+          _nodes.keys.where((id) => !incomingNodes.containsKey(id)).toList();
+      for (final nodeId in removedNodeIds) {
+        _nodes.remove(nodeId);
+        final nodeInstance = _graphNodes.remove(nodeId);
+        if (nodeInstance != null) {
+          graph.removeNode(nodeInstance);
+          nodesDirty = true;
+        }
+
+        final affectedEdges = _edges.values
+            .where((edge) =>
+                edge.fromStateId == nodeId || edge.toStateId == nodeId)
+            .map((edge) => edge.id)
+            .toList();
+        for (final edgeId in affectedEdges) {
+          _edges.remove(edgeId);
+          final edgeInstance = _graphEdges.remove(edgeId);
+          if (edgeInstance != null) {
+            graph.removeEdge(edgeInstance);
+            edgesDirty = true;
+          }
+          pruneLinkHighlight(edgeId);
+        }
+      }
+
+      final removedEdgeIds =
+          _edges.keys.where((id) => !incomingEdges.containsKey(id)).toList();
+      for (final edgeId in removedEdgeIds) {
+        _edges.remove(edgeId);
+        final edgeInstance = _graphEdges.remove(edgeId);
+        if (edgeInstance != null) {
+          graph.removeEdge(edgeInstance);
+          edgesDirty = true;
+        }
+        pruneLinkHighlight(edgeId);
+      }
+
+      for (final entry in incomingNodes.entries) {
+        final nodeId = entry.key;
+        final incomingNode = entry.value;
+        final existingNode = _nodes[nodeId];
+        final nodeInstance = _graphNodes[nodeId];
+
+        if (existingNode == null || nodeInstance == null) {
+          final createdNode = buildGraphNode(incomingNode);
+          _nodes[nodeId] = incomingNode;
+          _graphNodes[nodeId] = createdNode;
+          graph.addNode(createdNode);
+          nodesDirty = true;
+          continue;
+        }
+
+        final hasPositionChanged =
+            existingNode.x != incomingNode.x || existingNode.y != incomingNode.y;
+        final hasMetadataChanged = existingNode.label != incomingNode.label ||
+            existingNode.isInitial != incomingNode.isInitial ||
+            existingNode.isAccepting != incomingNode.isAccepting;
+
+        if (hasPositionChanged || hasMetadataChanged) {
+          nodeInstance.position = Offset(incomingNode.x, incomingNode.y);
+          nodesDirty = true;
+        }
+
+        _nodes[nodeId] = incomingNode;
+      }
+
+      for (final entry in incomingEdges.entries) {
+        final edgeId = entry.key;
+        final incomingEdge = entry.value;
+        final existingEdge = _edges[edgeId];
+        final edgeInstance = _graphEdges[edgeId];
+
+        if (existingEdge == null || edgeInstance == null) {
+          final fromNode = _graphNodes[incomingEdge.fromStateId];
+          final toNode = _graphNodes[incomingEdge.toStateId];
+          if (fromNode == null || toNode == null) {
+            continue;
+          }
+          final createdEdge = buildGraphEdge(incomingEdge, fromNode, toNode);
+          _edges[edgeId] = incomingEdge;
+          _graphEdges[edgeId] = createdEdge;
+          graph.addEdgeS(createdEdge);
+          edgesDirty = true;
+          continue;
+        }
+
+        if (existingEdge != incomingEdge) {
+          _edges[edgeId] = incomingEdge;
+          edgesDirty = true;
+        }
+      }
+
+      final sanitizedHighlight = SimulationHighlight(
+        stateIds: previousHighlight.stateIds
+            .where((id) => incomingNodes.containsKey(id))
+            .toSet(),
+        transitionIds: previousHighlight.transitionIds
+            .where((id) => incomingEdges.containsKey(id))
+            .toSet(),
+      );
+
+      updateLinkHighlights(sanitizedHighlight.transitionIds);
+      highlightNotifier.value = sanitizedHighlight;
+
+      if (nodesDirty || edgesDirty) {
+        graph.notifyGraphObserver();
+        graphRevision.value++;
+      }
+    } finally {
+      _isSynchronizing = false;
+    }
+  }
+
+  @visibleForTesting
+  void pruneLinkHighlight(String edgeId) {
+    if (!highlightedTransitionIds.contains(edgeId)) {
+      return;
+    }
+
+    final updatedHighlighted = Set<String>.from(highlightedTransitionIds)
+      ..remove(edgeId);
+    updateLinkHighlights(updatedHighlighted);
+
+    final currentHighlight = highlightNotifier.value;
+    if (currentHighlight.transitionIds.contains(edgeId)) {
+      final remaining = Set<String>.from(currentHighlight.transitionIds)
+        ..remove(edgeId);
+      if (remaining.isEmpty && currentHighlight.stateIds.isEmpty) {
+        highlightNotifier.value = SimulationHighlight.empty;
+      } else {
+        highlightNotifier.value = currentHighlight.copyWith(
+          transitionIds: remaining,
+        );
+      }
+    } else if (updatedHighlighted.isEmpty &&
+        currentHighlight.transitionIds.isEmpty &&
+        currentHighlight.stateIds.isEmpty) {
+      highlightNotifier.value = SimulationHighlight.empty;
+    }
+  }
+
+  _GraphHistoryEntry? _captureHistoryEntry() {
+    try {
+      final snapshot = toSnapshot(currentDomainData);
+      final encoded =
+          GraphViewAutomatonSnapshot.fromJson(snapshot.toJson());
+      final highlight = SimulationHighlight(
+        stateIds: Set<String>.from(highlightNotifier.value.stateIds),
+        transitionIds: Set<String>.from(highlightNotifier.value.transitionIds),
+      );
+      return _GraphHistoryEntry(snapshot: encoded, highlight: highlight);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  void _applyHistoryEntry(_GraphHistoryEntry entry) {
+    applySnapshotToDomain(entry.snapshot);
+
+    final highlight = SimulationHighlight(
+      stateIds: Set<String>.from(entry.highlight.stateIds),
+      transitionIds: Set<String>.from(entry.highlight.transitionIds),
+    );
+
+    updateLinkHighlights(highlight.transitionIds);
+    highlightNotifier.value = highlight;
+  }
+}

--- a/lib/features/canvas/graphview/graphview_automaton_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_automaton_mapper.dart
@@ -1,0 +1,124 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/fsa.dart';
+import '../../../core/models/fsa_transition.dart';
+import '../../../core/models/state.dart';
+import 'graphview_canvas_models.dart';
+
+/// Utility helpers to convert between [FSA] instances and GraphView snapshots.
+class GraphViewAutomatonMapper {
+  const GraphViewAutomatonMapper._();
+
+  /// Converts the provided [automaton] into a snapshot consumed by the
+  /// [GraphViewCanvasController].
+  static GraphViewAutomatonSnapshot toSnapshot(FSA? automaton) {
+    if (automaton == null) {
+      return const GraphViewAutomatonSnapshot.empty();
+    }
+
+    final nodes = automaton.states.map((state) {
+      return GraphViewCanvasNode(
+        id: state.id,
+        label: state.label,
+        x: state.position.x,
+        y: state.position.y,
+        isInitial: automaton.initialState?.id == state.id,
+        isAccepting: automaton.acceptingStates.any(
+          (candidate) => candidate.id == state.id,
+        ),
+      );
+    }).toList();
+
+    final edges = automaton.fsaTransitions.map((transition) {
+      return GraphViewCanvasEdge(
+        id: transition.id,
+        fromStateId: transition.fromState.id,
+        toStateId: transition.toState.id,
+        symbols: transition.inputSymbols.toList(),
+        lambdaSymbol: transition.lambdaSymbol,
+        controlPointX: transition.controlPoint.x,
+        controlPointY: transition.controlPoint.y,
+      );
+    }).toList();
+
+    final metadata = GraphViewAutomatonMetadata(
+      id: automaton.id,
+      name: automaton.name,
+      alphabet: automaton.alphabet.toList(),
+    );
+
+    return GraphViewAutomatonSnapshot(
+      nodes: nodes,
+      edges: edges,
+      metadata: metadata,
+    );
+  }
+
+  /// Rebuilds an [FSA] template with the snapshot produced by the canvas.
+  static FSA mergeIntoTemplate(
+    GraphViewAutomatonSnapshot snapshot,
+    FSA template,
+  ) {
+    final states = snapshot.nodes
+        .map(
+          (node) => State(
+            id: node.id,
+            label: node.label,
+            position: Vector2(node.x, node.y),
+            isInitial: node.isInitial,
+            isAccepting: node.isAccepting,
+          ),
+        )
+        .toSet();
+
+    final stateMap = {for (final state in states) state.id: state};
+
+    final transitions = snapshot.edges.map((edge) {
+      final fromState = stateMap[edge.fromStateId];
+      final toState = stateMap[edge.toStateId];
+      if (fromState == null || toState == null) {
+        throw StateError('Edge references missing state: ${edge.toJson()}');
+      }
+      return FSATransition(
+        id: edge.id,
+        fromState: fromState,
+        toState: toState,
+        inputSymbols: edge.symbols.toSet(),
+        lambdaSymbol: edge.lambdaSymbol,
+        label: edge.label,
+        controlPoint: edge.controlPointX != null && edge.controlPointY != null
+            ? Vector2(edge.controlPointX!, edge.controlPointY!)
+            : null,
+      );
+    }).toSet();
+
+    final acceptingStates = {
+      for (final node in snapshot.nodes.where((node) => node.isAccepting))
+        stateMap[node.id]!,
+    };
+
+    GraphViewCanvasNode? initialNode;
+    for (final node in snapshot.nodes) {
+      if (node.isInitial) {
+        initialNode = node;
+        break;
+      }
+    }
+
+    final alphabet = <String>{
+      ...template.alphabet,
+      for (final edge in snapshot.edges) ...edge.symbols,
+    }..removeWhere((symbol) => symbol.isEmpty);
+
+    final initialState =
+        initialNode != null ? stateMap[initialNode.id] : template.initialState;
+
+    return template.copyWith(
+      states: states,
+      transitions: transitions.map<Transition>((t) => t).toSet(),
+      acceptingStates: acceptingStates,
+      initialState: initialState,
+      alphabet: alphabet,
+    );
+  }
+}

--- a/lib/features/canvas/graphview/graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_controller.dart
@@ -1,0 +1,220 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/fsa.dart';
+import '../../../presentation/providers/automaton_provider.dart';
+import 'base_graphview_canvas_controller.dart';
+import 'graphview_automaton_mapper.dart';
+import 'graphview_canvas_models.dart';
+
+/// Controller that keeps the [Graph] in sync with the [AutomatonProvider].
+class GraphViewCanvasController
+    extends BaseGraphViewCanvasController<AutomatonProvider, FSA> {
+  GraphViewCanvasController({
+    required AutomatonProvider automatonProvider,
+    Graph? graph,
+    GraphViewController? viewController,
+    TransformationController? transformationController,
+  }) : super(
+          notifier: automatonProvider,
+          graph: graph,
+          viewController: viewController,
+          transformationController: transformationController,
+        );
+
+  AutomatonProvider get _provider => notifier;
+
+  @override
+  FSA? get currentDomainData => _provider.state.currentAutomaton;
+
+  @override
+  GraphViewAutomatonSnapshot toSnapshot(FSA? automaton) {
+    return GraphViewAutomatonMapper.toSnapshot(automaton);
+  }
+
+  /// Synchronises the GraphView controller with the latest [automaton].
+  void synchronize(FSA? automaton) {
+    synchronizeGraph(automaton);
+  }
+
+  String _generateNodeId() {
+    final reservedIds = <String>{...nodesCache.keys};
+    final automaton = _provider.state.currentAutomaton;
+    if (automaton != null) {
+      for (final state in automaton.states) {
+        reservedIds.add(state.id);
+      }
+    }
+    var index = 0;
+    while (true) {
+      final candidate = 'state_$index';
+      if (!reservedIds.contains(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+  }
+
+  String _generateEdgeId() {
+    final reservedIds = <String>{...edgesCache.keys};
+    final automaton = _provider.state.currentAutomaton;
+    if (automaton != null) {
+      for (final transition in automaton.transitions) {
+        reservedIds.add(transition.id);
+      }
+    }
+    var index = 0;
+    while (true) {
+      final candidate = 'transition_$index';
+      if (!reservedIds.contains(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+  }
+
+  String _nextAvailableStateLabel() {
+    final reservedLabels = <String>{};
+
+    final automaton = _provider.state.currentAutomaton;
+    if (automaton != null) {
+      for (final state in automaton.states) {
+        final label = state.label.trim();
+        if (label.isNotEmpty) {
+          reservedLabels.add(label);
+        }
+      }
+    }
+
+    for (final node in nodesCache.values) {
+      final label = node.label.trim();
+      if (label.isNotEmpty) {
+        reservedLabels.add(label);
+      }
+    }
+
+    var index = 0;
+    while (reservedLabels.contains('q$index')) {
+      index++;
+    }
+    return 'q$index';
+  }
+
+  /// Adds a new state centred in the current viewport.
+  void addStateAtCenter() {
+    addStateAt(Offset.zero);
+  }
+
+  /// Adds a new state at the provided [worldPosition].
+  void addStateAt(Offset worldPosition) {
+    final nodeId = _generateNodeId();
+    final label = _nextAvailableStateLabel();
+    final isFirstState = nodesCache.isEmpty &&
+        (_provider.state.currentAutomaton?.states.isEmpty ?? true);
+
+    performMutation(() {
+      _provider.addState(
+        id: nodeId,
+        label: label,
+        x: worldPosition.dx,
+        y: worldPosition.dy,
+        isInitial: isFirstState ? true : null,
+        isAccepting: false,
+      );
+    });
+  }
+
+  /// Moves an existing state to a new [position].
+  void moveState(String id, Offset position) {
+    performMutation(() {
+      _provider.moveState(
+        id: id,
+        x: position.dx,
+        y: position.dy,
+      );
+    });
+  }
+
+  /// Updates the label displayed for the state identified by [id].
+  void updateStateLabel(String id, String label) {
+    final resolvedLabel = label.isEmpty ? id : label;
+    performMutation(() {
+      _provider.updateStateLabel(
+        id: id,
+        label: resolvedLabel,
+      );
+    });
+  }
+
+  /// Removes the state identified by [id] from the automaton.
+  void removeState(String id) {
+    performMutation(() {
+      _provider.removeState(id: id);
+    });
+  }
+
+  /// Adds or updates a transition between [fromStateId] and [toStateId].
+  void addOrUpdateTransition({
+    required String fromStateId,
+    required String toStateId,
+    required String label,
+    String? transitionId,
+    double? controlPointX,
+    double? controlPointY,
+  }) {
+    final edgeId = transitionId ?? _generateEdgeId();
+    performMutation(() {
+      _provider.addOrUpdateTransition(
+        id: edgeId,
+        fromStateId: fromStateId,
+        toStateId: toStateId,
+        label: label,
+        controlPointX: controlPointX,
+        controlPointY: controlPointY,
+      );
+    });
+  }
+
+  /// Removes the transition identified by [id] from the automaton.
+  void removeTransition(String id) {
+    performMutation(() {
+      _provider.removeTransition(id: id);
+    });
+  }
+
+  @override
+  void applySnapshotToDomain(GraphViewAutomatonSnapshot snapshot) {
+    final template = _provider.state.currentAutomaton ??
+        FSA(
+          id: snapshot.metadata.id ??
+              'automaton_${DateTime.now().microsecondsSinceEpoch}',
+          name: snapshot.metadata.name ?? 'Untitled Automaton',
+          states: const {},
+          transitions: const {},
+          alphabet: snapshot.metadata.alphabet.toSet(),
+          initialState: null,
+          acceptingStates: const {},
+          created: DateTime.now(),
+          modified: DateTime.now(),
+          bounds: const math.Rectangle<double>(0, 0, 800, 600),
+          panOffset: Vector2.zero(),
+          zoomLevel: 1.0,
+        );
+
+    final merged = GraphViewAutomatonMapper.mergeIntoTemplate(snapshot, template)
+        .copyWith(
+      id: snapshot.metadata.id ?? template.id,
+      name: snapshot.metadata.name ?? template.name,
+      alphabet: snapshot.metadata.alphabet.isNotEmpty
+          ? snapshot.metadata.alphabet.toSet()
+          : template.alphabet,
+      modified: DateTime.now(),
+    );
+
+    _provider.updateAutomaton(merged);
+    synchronize(merged);
+  }
+}

--- a/lib/features/canvas/graphview/graphview_canvas_models.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_models.dart
@@ -1,0 +1,419 @@
+import 'package:collection/collection.dart';
+
+import '../../../core/models/tm_transition.dart';
+
+/// Metadata describing the current automaton rendered in the GraphView canvas.
+class GraphViewAutomatonMetadata {
+  const GraphViewAutomatonMetadata({
+    required this.id,
+    required this.name,
+    required this.alphabet,
+  });
+
+  const GraphViewAutomatonMetadata.empty()
+      : id = null,
+        name = null,
+        alphabet = const <String>[];
+
+  final String? id;
+  final String? name;
+  final List<String> alphabet;
+
+  GraphViewAutomatonMetadata copyWith({
+    String? id,
+    String? name,
+    List<String>? alphabet,
+  }) {
+    return GraphViewAutomatonMetadata(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      alphabet: alphabet ?? this.alphabet,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'alphabet': alphabet,
+    };
+  }
+
+  factory GraphViewAutomatonMetadata.fromJson(Map<String, dynamic>? json) {
+    if (json == null) {
+      return const GraphViewAutomatonMetadata.empty();
+    }
+    final rawAlphabet = json['alphabet'];
+    final alphabet = rawAlphabet is List
+        ? rawAlphabet.cast<String>()
+        : const <String>[];
+    return GraphViewAutomatonMetadata(
+      id: json['id'] as String?,
+      name: json['name'] as String?,
+      alphabet: alphabet,
+    );
+  }
+}
+
+/// Node rendered inside the GraphView canvas.
+class GraphViewCanvasNode {
+  const GraphViewCanvasNode({
+    required this.id,
+    required this.label,
+    required this.x,
+    required this.y,
+    required this.isInitial,
+    required this.isAccepting,
+  });
+
+  final String id;
+  final String label;
+  final double x;
+  final double y;
+  final bool isInitial;
+  final bool isAccepting;
+
+  GraphViewCanvasNode copyWith({
+    String? id,
+    String? label,
+    double? x,
+    double? y,
+    bool? isInitial,
+    bool? isAccepting,
+  }) {
+    return GraphViewCanvasNode(
+      id: id ?? this.id,
+      label: label ?? this.label,
+      x: x ?? this.x,
+      y: y ?? this.y,
+      isInitial: isInitial ?? this.isInitial,
+      isAccepting: isAccepting ?? this.isAccepting,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'label': label,
+      'x': x,
+      'y': y,
+      'isInitial': isInitial,
+      'isAccepting': isAccepting,
+    };
+  }
+
+  factory GraphViewCanvasNode.fromJson(Map<String, dynamic> json) {
+    return GraphViewCanvasNode(
+      id: json['id'] as String,
+      label: (json['label'] as String?) ?? json['id'] as String,
+      x: (json['x'] as num?)?.toDouble() ?? 0,
+      y: (json['y'] as num?)?.toDouble() ?? 0,
+      isInitial: json['isInitial'] as bool? ?? false,
+      isAccepting: json['isAccepting'] as bool? ?? false,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GraphViewCanvasNode &&
+        other.id == id &&
+        other.label == label &&
+        other.x == x &&
+        other.y == y &&
+        other.isInitial == isInitial &&
+        other.isAccepting == isAccepting;
+  }
+
+  @override
+  int get hashCode => Object.hash(id, label, x, y, isInitial, isAccepting);
+}
+
+/// Directed edge rendered inside the GraphView canvas.
+class GraphViewCanvasEdge {
+  static const Object _unset = Object();
+
+  const GraphViewCanvasEdge({
+    required this.id,
+    required this.fromStateId,
+    required this.toStateId,
+    required this.symbols,
+    this.lambdaSymbol,
+    this.controlPointX,
+    this.controlPointY,
+    this.readSymbol,
+    this.writeSymbol,
+    this.direction,
+    this.tapeNumber,
+    this.popSymbol,
+    this.pushSymbol,
+    this.isLambdaInput,
+    this.isLambdaPop,
+    this.isLambdaPush,
+  });
+
+  final String id;
+  final String fromStateId;
+  final String toStateId;
+  final List<String> symbols;
+  final String? lambdaSymbol;
+  final double? controlPointX;
+  final double? controlPointY;
+  final String? readSymbol;
+  final String? writeSymbol;
+  final TapeDirection? direction;
+  final int? tapeNumber;
+  final String? popSymbol;
+  final String? pushSymbol;
+  final bool? isLambdaInput;
+  final bool? isLambdaPop;
+  final bool? isLambdaPush;
+
+  String get label {
+    final hasPdaMetadata = popSymbol != null ||
+        pushSymbol != null ||
+        isLambdaInput != null ||
+        isLambdaPop != null ||
+        isLambdaPush != null;
+    if (hasPdaMetadata) {
+      final lambdaInput = isLambdaInput ?? (readSymbol == null || readSymbol!.isEmpty);
+      final lambdaPop = isLambdaPop ?? (popSymbol == null || popSymbol!.isEmpty);
+      final lambdaPush = isLambdaPush ?? (pushSymbol == null || pushSymbol!.isEmpty);
+      final read = lambdaInput ? 'λ' : (readSymbol ?? '');
+      final pop = lambdaPop ? 'λ' : (popSymbol ?? '');
+      final push = lambdaPush ? 'λ' : (pushSymbol ?? '');
+      return '$read, $pop/$push';
+    }
+    if (lambdaSymbol != null && lambdaSymbol!.isNotEmpty) {
+      return lambdaSymbol!;
+    }
+    if (readSymbol != null || writeSymbol != null || direction != null) {
+      final read = (readSymbol ?? '').isEmpty ? '∅' : readSymbol!;
+      final write = (writeSymbol ?? '').isEmpty ? '∅' : writeSymbol!;
+      final resolvedDirection = direction;
+      final directionSymbol = switch (resolvedDirection) {
+        TapeDirection.left => 'L',
+        TapeDirection.right => 'R',
+        TapeDirection.stay => 'S',
+        null => '',
+      };
+      final suffix = directionSymbol.isEmpty ? '' : ',$directionSymbol';
+      return '$read/$write$suffix';
+    }
+    final filtered = symbols.where((symbol) => symbol.isNotEmpty).toList();
+    return filtered.join(',');
+  }
+
+  GraphViewCanvasEdge copyWith({
+    String? id,
+    String? fromStateId,
+    String? toStateId,
+    List<String>? symbols,
+    String? lambdaSymbol,
+    Object? controlPointX = _unset,
+    Object? controlPointY = _unset,
+    String? readSymbol,
+    String? writeSymbol,
+    TapeDirection? direction,
+    int? tapeNumber,
+    String? popSymbol,
+    String? pushSymbol,
+    bool? isLambdaInput,
+    bool? isLambdaPop,
+    bool? isLambdaPush,
+  }) {
+    return GraphViewCanvasEdge(
+      id: id ?? this.id,
+      fromStateId: fromStateId ?? this.fromStateId,
+      toStateId: toStateId ?? this.toStateId,
+      symbols: symbols ?? this.symbols,
+      lambdaSymbol: lambdaSymbol ?? this.lambdaSymbol,
+      controlPointX: controlPointX == _unset
+          ? this.controlPointX
+          : controlPointX as double?,
+      controlPointY: controlPointY == _unset
+          ? this.controlPointY
+          : controlPointY as double?,
+      readSymbol: readSymbol ?? this.readSymbol,
+      writeSymbol: writeSymbol ?? this.writeSymbol,
+      direction: direction ?? this.direction,
+      tapeNumber: tapeNumber ?? this.tapeNumber,
+      popSymbol: popSymbol ?? this.popSymbol,
+      pushSymbol: pushSymbol ?? this.pushSymbol,
+      isLambdaInput: isLambdaInput ?? this.isLambdaInput,
+      isLambdaPop: isLambdaPop ?? this.isLambdaPop,
+      isLambdaPush: isLambdaPush ?? this.isLambdaPush,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'from': fromStateId,
+      'to': toStateId,
+      'symbols': symbols.join(','),
+      'lambdaSymbol': lambdaSymbol,
+      'controlPointX': controlPointX,
+      'controlPointY': controlPointY,
+      'readSymbol': readSymbol,
+      'writeSymbol': writeSymbol,
+      'direction': direction?.name,
+      'tapeNumber': tapeNumber,
+      'popSymbol': popSymbol,
+      'pushSymbol': pushSymbol,
+      'isLambdaInput': isLambdaInput,
+      'isLambdaPop': isLambdaPop,
+      'isLambdaPush': isLambdaPush,
+    };
+  }
+
+  factory GraphViewCanvasEdge.fromJson(Map<String, dynamic> json) {
+    final rawSymbols = json['symbols'];
+    final symbols = rawSymbols is String
+        ? rawSymbols.split(',')
+        : const <String>[];
+    return GraphViewCanvasEdge(
+      id: json['id'] as String,
+      fromStateId: json['from'] as String,
+      toStateId: json['to'] as String,
+      symbols: symbols,
+      lambdaSymbol: json['lambdaSymbol'] as String?,
+      controlPointX: (json['controlPointX'] as num?)?.toDouble(),
+      controlPointY: (json['controlPointY'] as num?)?.toDouble(),
+      readSymbol: json['readSymbol'] as String?,
+      writeSymbol: json['writeSymbol'] as String?,
+      direction: (json['direction'] as String?) != null
+          ? TapeDirection.values.firstWhere(
+              (value) => value.name == json['direction'],
+              orElse: () => TapeDirection.right,
+            )
+          : null,
+      tapeNumber: json['tapeNumber'] as int?,
+      popSymbol: json['popSymbol'] as String?,
+      pushSymbol: json['pushSymbol'] as String?,
+      isLambdaInput: json['isLambdaInput'] as bool?,
+      isLambdaPop: json['isLambdaPop'] as bool?,
+      isLambdaPush: json['isLambdaPush'] as bool?,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GraphViewCanvasEdge &&
+        other.id == id &&
+        other.fromStateId == fromStateId &&
+        other.toStateId == toStateId &&
+        const ListEquality<String>().equals(other.symbols, symbols) &&
+        other.lambdaSymbol == lambdaSymbol &&
+        other.controlPointX == controlPointX &&
+        other.controlPointY == controlPointY &&
+        other.readSymbol == readSymbol &&
+        other.writeSymbol == writeSymbol &&
+        other.direction == direction &&
+        other.tapeNumber == tapeNumber &&
+        other.popSymbol == popSymbol &&
+        other.pushSymbol == pushSymbol &&
+        other.isLambdaInput == isLambdaInput &&
+        other.isLambdaPop == isLambdaPop &&
+        other.isLambdaPush == isLambdaPush;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        id,
+        fromStateId,
+        toStateId,
+        const ListEquality<String>().hash(symbols),
+        lambdaSymbol,
+        controlPointX,
+        controlPointY,
+        readSymbol,
+        writeSymbol,
+        direction,
+        tapeNumber,
+        popSymbol,
+        pushSymbol,
+        isLambdaInput,
+        isLambdaPop,
+        isLambdaPush,
+      );
+}
+
+/// Snapshot of nodes, edges and metadata rendered in the GraphView canvas.
+class GraphViewAutomatonSnapshot {
+  const GraphViewAutomatonSnapshot({
+    required this.nodes,
+    required this.edges,
+    required this.metadata,
+  });
+
+  const GraphViewAutomatonSnapshot.empty()
+      : nodes = const <GraphViewCanvasNode>[],
+        edges = const <GraphViewCanvasEdge>[],
+        metadata = const GraphViewAutomatonMetadata.empty();
+
+  final List<GraphViewCanvasNode> nodes;
+  final List<GraphViewCanvasEdge> edges;
+  final GraphViewAutomatonMetadata metadata;
+
+  GraphViewAutomatonSnapshot copyWith({
+    List<GraphViewCanvasNode>? nodes,
+    List<GraphViewCanvasEdge>? edges,
+    GraphViewAutomatonMetadata? metadata,
+  }) {
+    return GraphViewAutomatonSnapshot(
+      nodes: nodes ?? this.nodes,
+      edges: edges ?? this.edges,
+      metadata: metadata ?? this.metadata,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'nodes': nodes.map((node) => node.toJson()).toList(),
+      'edges': edges.map((edge) => edge.toJson()).toList(),
+      'metadata': metadata.toJson(),
+    };
+  }
+
+  factory GraphViewAutomatonSnapshot.fromJson(Map<String, dynamic> json) {
+    final rawNodes = (json['nodes'] as List?)?.cast<Map>() ?? const [];
+    final rawEdges = (json['edges'] as List?)?.cast<Map>() ?? const [];
+    return GraphViewAutomatonSnapshot(
+      nodes: rawNodes
+          .map((node) => GraphViewCanvasNode.fromJson(
+                node.cast<String, dynamic>(),
+              ))
+          .toList(),
+      edges: rawEdges
+          .map((edge) => GraphViewCanvasEdge.fromJson(
+                edge.cast<String, dynamic>(),
+              ))
+          .toList(),
+      metadata: GraphViewAutomatonMetadata.fromJson(
+        (json['metadata'] as Map?)?.cast<String, dynamic>(),
+      ),
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is GraphViewAutomatonSnapshot &&
+        const ListEquality<GraphViewCanvasNode>().equals(nodes, other.nodes) &&
+        const ListEquality<GraphViewCanvasEdge>().equals(edges, other.edges) &&
+        metadata.id == other.metadata.id &&
+        metadata.name == other.metadata.name &&
+        const ListEquality<String>().equals(
+          metadata.alphabet,
+          other.metadata.alphabet,
+        );
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        const ListEquality<GraphViewCanvasNode>().hash(nodes),
+        const ListEquality<GraphViewCanvasEdge>().hash(edges),
+        metadata.id,
+        metadata.name,
+        const ListEquality<String>().hash(metadata.alphabet),
+      );
+}

--- a/lib/features/canvas/graphview/graphview_highlight_channel.dart
+++ b/lib/features/canvas/graphview/graphview_highlight_channel.dart
@@ -1,0 +1,21 @@
+import '../../../core/models/simulation_highlight.dart';
+import '../../../core/services/simulation_highlight_service.dart';
+import 'graphview_highlight_controller.dart';
+
+/// Highlight channel that bridges [SimulationHighlightService] payloads to a
+/// GraphView canvas controller.
+class GraphViewSimulationHighlightChannel implements SimulationHighlightChannel {
+  GraphViewSimulationHighlightChannel(this._controller);
+
+  final GraphViewHighlightController _controller;
+
+  @override
+  void clear() {
+    _controller.clearHighlight();
+  }
+
+  @override
+  void send(SimulationHighlight highlight) {
+    _controller.applyHighlight(highlight);
+  }
+}

--- a/lib/features/canvas/graphview/graphview_highlight_controller.dart
+++ b/lib/features/canvas/graphview/graphview_highlight_controller.dart
@@ -1,0 +1,11 @@
+import '../../../core/models/simulation_highlight.dart';
+
+/// Common contract exposed by GraphView canvas controllers that support
+/// simulation highlights.
+abstract class GraphViewHighlightController {
+  /// Applies the provided [highlight] to the canvas.
+  void applyHighlight(SimulationHighlight highlight);
+
+  /// Clears any active highlight from the canvas.
+  void clearHighlight();
+}

--- a/lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
+++ b/lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
@@ -1,0 +1,134 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+
+import '../../../core/models/simulation_highlight.dart';
+import 'graphview_canvas_models.dart';
+import 'graphview_highlight_controller.dart';
+
+/// Shared viewport and highlight helpers for GraphView canvas controllers.
+mixin GraphViewViewportHighlightMixin on GraphViewHighlightController {
+  /// Exposes the underlying graph structure managed by the controller.
+  Graph get graph;
+
+  /// Provides access to the GraphView controller responsible for viewport
+  /// operations.
+  GraphViewController get graphController;
+
+  /// Provides access to the cached canvas nodes.
+  Map<String, GraphViewCanvasNode> get nodesCache;
+
+  /// Provides access to the cached canvas edges.
+  Map<String, GraphViewCanvasEdge> get edgesCache;
+
+  /// Notifier used to broadcast highlight updates to listeners.
+  final ValueNotifier<SimulationHighlight> highlightNotifier = ValueNotifier(
+    SimulationHighlight.empty,
+  );
+
+  /// Notifier that indicates when the rendered graph should be repainted.
+  final ValueNotifier<int> graphRevision = ValueNotifier<int>(0);
+
+  /// Tracks the ids of the transitions currently highlighted.
+  final Set<String> highlightedTransitionIds = <String>{};
+
+  /// Releases the resources owned by the mixin.
+  void disposeViewportHighlight() {
+    highlightNotifier.dispose();
+    graphRevision.dispose();
+  }
+
+  /// Hook invoked whenever the highlighted transitions change.
+  @protected
+  void onHighlightedTransitionsChanged(Set<String> transitionIds) {}
+
+  double _extractScale(Matrix4 matrix) {
+    final storage = matrix.storage;
+    final scaleX = math.sqrt(storage[0] * storage[0] +
+        storage[1] * storage[1] +
+        storage[2] * storage[2]);
+    final scaleY = math.sqrt(storage[4] * storage[4] +
+        storage[5] * storage[5] +
+        storage[6] * storage[6]);
+    if (scaleX == 0 && scaleY == 0) {
+      return 1.0;
+    }
+    if (scaleX == 0) {
+      return scaleY.abs();
+    }
+    if (scaleY == 0) {
+      return scaleX.abs();
+    }
+    return (scaleX.abs() + scaleY.abs()) / 2;
+  }
+
+  void _applyScale(double factor) {
+    final transformation = graphController.transformationController;
+    if (transformation == null) {
+      return;
+    }
+
+    final matrix = Matrix4.copy(transformation.value);
+    final currentScale = _extractScale(matrix);
+    final safeCurrent = currentScale == 0 ? 1.0 : currentScale;
+    final targetScale = (safeCurrent * factor).clamp(0.05, 10.0);
+    final relativeScale = targetScale / safeCurrent;
+    matrix.scale(relativeScale);
+    transformation.value = matrix;
+  }
+
+  /// Increases the viewport zoom while respecting reasonable bounds.
+  void zoomIn() {
+    _applyScale(1.2);
+  }
+
+  /// Decreases the viewport zoom while respecting reasonable bounds.
+  void zoomOut() {
+    _applyScale(1 / 1.2);
+  }
+
+  /// Resets the viewport offset and zoom to their defaults.
+  void resetView() {
+    final transformation = graphController.transformationController;
+    transformation?.value = Matrix4.identity();
+    graphController.resetView();
+  }
+
+  /// Adjusts the viewport to focus on the available nodes.
+  void fitToContent() {
+    if (graph.nodes.isEmpty) {
+      resetView();
+      return;
+    }
+    graphController.zoomToFit();
+  }
+
+  @override
+  void applyHighlight(SimulationHighlight highlight) {
+    updateLinkHighlights(highlight.transitionIds);
+    highlightNotifier.value = highlight;
+  }
+
+  @override
+  void clearHighlight() {
+    updateLinkHighlights(const <String>{});
+    highlightNotifier.value = SimulationHighlight.empty;
+  }
+
+  /// Updates the edge highlight set to match the provided ids.
+  void updateLinkHighlights(Set<String> transitionIds) {
+    final desiredIds = Set<String>.from(transitionIds);
+    if (setEquals(desiredIds, highlightedTransitionIds)) {
+      return;
+    }
+
+    highlightedTransitionIds
+      ..clear()
+      ..addAll(desiredIds);
+
+    onHighlightedTransitionsChanged(highlightedTransitionIds);
+    graphRevision.value++;
+  }
+}

--- a/lib/presentation/providers/automaton_provider.dart
+++ b/lib/presentation/providers/automaton_provider.dart
@@ -22,6 +22,7 @@ import '../../data/services/automaton_service.dart';
 import '../../core/repositories/automaton_repository.dart';
 import '../../core/services/trace_persistence_service.dart';
 import '../../features/layout/layout_repository_impl.dart';
+import '../../features/canvas/graphview/graphview_canvas_controller.dart';
 
 /// Provider for automaton state management
 class AutomatonProvider extends StateNotifier<AutomatonState> {
@@ -1138,3 +1139,15 @@ final automatonProvider =
         layoutRepository: LayoutRepositoryImpl(),
       );
     });
+
+/// Provides a lazily constructed GraphView canvas controller for automata.
+final graphViewCanvasControllerProvider =
+    Provider<GraphViewCanvasController>((ref) {
+  final automatonNotifier = ref.read(automatonProvider.notifier);
+  final controller = GraphViewCanvasController(
+    automatonProvider: automatonNotifier,
+  );
+  ref.onDispose(controller.dispose);
+  controller.synchronize(automatonNotifier.state.currentAutomaton);
+  return controller;
+});

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.4.0+1"
+  graphview:
+    dependency: "direct main"
+    description:
+      name: graphview
+      sha256: "371fc1718cb99a12238e8e759457085619026b38b7e90bc5f9d9916e70b10899"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   flutter:
     dependency: "direct main"
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -52,6 +52,7 @@ dependencies:
 
   # Node-based canvas primitives
   fl_nodes: ^0.4.0+1
+  graphview: ^1.5.0
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- add the graphview dependency to support a new canvas implementation
- introduce GraphView canvas models, controller scaffolding, and highlight utilities mirroring the existing fl_nodes flow
- expose a provider to construct the GraphView canvas controller without removing the legacy controller

## Testing
- flutter pub get *(fails: flutter not available in the execution environment)*
- dart format lib/features/canvas/graphview lib/presentation/providers/automaton_provider.dart pubspec.yaml *(fails: dart not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1b2b84dc8832e954c1e3edbf4d82c