### PR TITLE
Add GraphView automaton canvas and controller tests

### DIFF
--- a/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
@@ -71,6 +71,10 @@ abstract class BaseGraphViewCanvasController<TNotifier, TSnapshot>
   GraphViewCanvasNode? nodeById(String id) => _nodes[id];
   GraphViewCanvasEdge? edgeById(String id) => _edges[id];
 
+  /// Returns the world position of the graph node with the provided [id].
+  @visibleForTesting
+  Offset? nodePosition(String id) => _graphNodes[id]?.position;
+
   bool get canUndo => _undoHistory.isNotEmpty;
   bool get canRedo => _redoHistory.isNotEmpty;
 

--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -1,0 +1,822 @@
+import 'dart:math' as math;
+
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphview/GraphView.dart';
+import 'package:vector_math/vector_math_64.dart' as vmath;
+
+import '../../core/constants/automaton_canvas.dart';
+import '../../core/models/fsa.dart';
+import '../../core/models/simulation_highlight.dart';
+import '../../core/models/simulation_result.dart';
+import '../../core/services/simulation_highlight_service.dart';
+import '../../features/canvas/graphview/graphview_canvas_controller.dart';
+import '../../features/canvas/graphview/graphview_canvas_models.dart';
+import '../../features/canvas/graphview/graphview_highlight_channel.dart';
+import '../providers/automaton_provider.dart';
+import 'automaton_canvas_tool.dart';
+import 'transition_editors/transition_label_editor.dart';
+
+const double _kNodeDiameter = kAutomatonStateDiameter;
+const double _kNodeRadius = _kNodeDiameter / 2;
+
+/// GraphView-based canvas used to render and edit automatons.
+class AutomatonGraphViewCanvas extends ConsumerStatefulWidget {
+  const AutomatonGraphViewCanvas({
+    super.key,
+    required this.automaton,
+    required this.canvasKey,
+    this.simulationResult,
+    this.currentStepIndex,
+    this.showTrace = false,
+    this.controller,
+    this.toolController,
+  });
+
+  final FSA? automaton;
+  final GlobalKey canvasKey;
+  final GraphViewCanvasController? controller;
+  final AutomatonCanvasToolController? toolController;
+  final SimulationResult? simulationResult;
+  final int? currentStepIndex;
+  final bool showTrace;
+
+  @override
+  ConsumerState<AutomatonGraphViewCanvas> createState() =>
+      _AutomatonGraphViewCanvasState();
+}
+
+class _AutomatonGraphViewCanvasState
+    extends ConsumerState<AutomatonGraphViewCanvas> {
+  late GraphViewCanvasController _controller;
+  late bool _ownsController;
+  late AutomatonCanvasToolController _toolController;
+  late bool _ownsToolController;
+  AutomatonCanvasTool _activeTool = AutomatonCanvasTool.selection;
+  SimulationHighlightService? _highlightService;
+  SimulationHighlightChannel? _previousHighlightChannel;
+  GraphViewSimulationHighlightChannel? _highlightChannel;
+  late _AutomatonGraphSugiyamaAlgorithm _algorithm;
+  final Set<String> _selectedTransitions = <String>{};
+  String? _transitionSourceId;
+
+  TransformationController? get _transformationController =>
+      _controller.graphController.transformationController;
+
+  @override
+  void initState() {
+    super.initState();
+    final externalToolController = widget.toolController;
+    if (externalToolController != null) {
+      _toolController = externalToolController;
+      _ownsToolController = false;
+    } else {
+      _toolController = AutomatonCanvasToolController();
+      _ownsToolController = true;
+    }
+    _activeTool = _toolController.activeTool;
+    _toolController.addListener(_handleActiveToolChanged);
+
+    final externalController = widget.controller;
+    if (externalController != null) {
+      _controller = externalController;
+      _ownsController = false;
+    } else {
+      final notifier = ref.read(automatonProvider.notifier);
+      _controller = GraphViewCanvasController(automatonProvider: notifier);
+      _ownsController = true;
+      final highlightService = ref.read(canvasHighlightServiceProvider);
+      _highlightService = highlightService;
+      _previousHighlightChannel = highlightService.channel;
+      final highlightChannel = GraphViewSimulationHighlightChannel(_controller);
+      _highlightChannel = highlightChannel;
+      highlightService.channel = highlightChannel;
+    }
+
+    _algorithm = _AutomatonGraphSugiyamaAlgorithm(
+      controller: _controller,
+      configuration: _buildConfiguration(),
+    );
+
+    _controller.synchronize(widget.automaton);
+    _transformationController?.addListener(_onTransformationChanged);
+
+    if ((widget.automaton?.states.isNotEmpty ?? false)) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _controller.fitToContent();
+      });
+    }
+  }
+
+  @override
+  void didUpdateWidget(covariant AutomatonGraphViewCanvas oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.toolController != widget.toolController) {
+      _toolController.removeListener(_handleActiveToolChanged);
+      if (_ownsToolController) {
+        _toolController.dispose();
+      }
+      final nextController = widget.toolController ?? AutomatonCanvasToolController();
+      _toolController = nextController;
+      _ownsToolController = widget.toolController == null;
+      _toolController.addListener(_handleActiveToolChanged);
+      _activeTool = _toolController.activeTool;
+    }
+
+    if (oldWidget.controller != widget.controller) {
+      _transformationController?.removeListener(_onTransformationChanged);
+      if (_ownsController) {
+        if (_highlightService != null) {
+          _highlightService!.channel = _previousHighlightChannel;
+          _highlightChannel = null;
+        }
+        _controller.dispose();
+      }
+      final externalController = widget.controller;
+      if (externalController != null) {
+        _controller = externalController;
+        _ownsController = false;
+        _highlightService = null;
+        _previousHighlightChannel = null;
+      } else {
+        final notifier = ref.read(automatonProvider.notifier);
+        _controller = GraphViewCanvasController(automatonProvider: notifier);
+        _ownsController = true;
+        final highlightService = ref.read(canvasHighlightServiceProvider);
+        _highlightService = highlightService;
+        _previousHighlightChannel = highlightService.channel;
+        final highlightChannel = GraphViewSimulationHighlightChannel(_controller);
+        _highlightChannel = highlightChannel;
+        highlightService.channel = highlightChannel;
+      }
+      _algorithm = _AutomatonGraphSugiyamaAlgorithm(
+        controller: _controller,
+        configuration: _buildConfiguration(),
+      );
+      _transformationController?.addListener(_onTransformationChanged);
+      _controller.synchronize(widget.automaton);
+    } else if (oldWidget.automaton != widget.automaton) {
+      _controller.synchronize(widget.automaton);
+    }
+  }
+
+  @override
+  void dispose() {
+    _transformationController?.removeListener(_onTransformationChanged);
+    _toolController.removeListener(_handleActiveToolChanged);
+    if (_ownsToolController) {
+      _toolController.dispose();
+    }
+    if (_ownsController) {
+      _controller.dispose();
+    }
+    if (_highlightService != null) {
+      _highlightService!.channel = _previousHighlightChannel;
+      _highlightChannel = null;
+    }
+    super.dispose();
+  }
+
+  void _handleActiveToolChanged() {
+    final nextTool = _toolController.activeTool;
+    if (nextTool == _activeTool) {
+      return;
+    }
+    setState(() {
+      _activeTool = nextTool;
+      if (_activeTool != AutomatonCanvasTool.transition) {
+        _transitionSourceId = null;
+      }
+    });
+  }
+
+  void _onTransformationChanged() {
+    setState(() {});
+  }
+
+  SugiyamaConfiguration _buildConfiguration() {
+    final configuration = SugiyamaConfiguration()
+      ..orientation = SugiyamaConfiguration.ORIENTATION_LEFT_RIGHT
+      ..nodeSeparation = 160
+      ..levelSeparation = 160
+      ..bendPointShape = CurvedBendPointShape(curveLength: 40);
+    return configuration;
+  }
+
+  double _currentScale() {
+    final matrix = _transformationController?.value ?? Matrix4.identity();
+    final storage = matrix.storage;
+    final scaleX = math.sqrt(storage[0] * storage[0] +
+        storage[1] * storage[1] +
+        storage[2] * storage[2]);
+    final scaleY = math.sqrt(storage[4] * storage[4] +
+        storage[5] * storage[5] +
+        storage[6] * storage[6]);
+    if (scaleX == 0 && scaleY == 0) {
+      return 1.0;
+    }
+    if (scaleX == 0) {
+      return scaleY.abs();
+    }
+    if (scaleY == 0) {
+      return scaleX.abs();
+    }
+    return (scaleX.abs() + scaleY.abs()) / 2;
+  }
+
+  Offset _screenToWorld(Offset localPosition) {
+    final controller = _transformationController;
+    if (controller == null) {
+      return localPosition;
+    }
+    final matrix = Matrix4.copy(controller.value);
+    final determinant = matrix.invert();
+    if (determinant == 0) {
+      return localPosition;
+    }
+    final vector = matrix.transform3(vmath.Vector3(
+      localPosition.dx,
+      localPosition.dy,
+      0,
+    ));
+    return Offset(vector.x, vector.y);
+  }
+
+  Future<void> _handleCanvasTap(TapUpDetails details) async {
+    if (_activeTool != AutomatonCanvasTool.addState) {
+      return;
+    }
+    final box = context.findRenderObject() as RenderBox?;
+    if (box == null) {
+      return;
+    }
+    final localPosition = box.globalToLocal(details.globalPosition);
+    final world = _screenToWorld(localPosition);
+    _controller.addStateAt(world);
+  }
+
+  void _handleNodePanStart(String nodeId, DragStartDetails details) {
+    _selectedTransitions.clear();
+  }
+
+  void _handleNodePanUpdate(String nodeId, DragUpdateDetails details) {
+    final scale = _currentScale();
+    final delta = details.delta / scale;
+    final node = _controller.nodeById(nodeId);
+    if (node == null) {
+      return;
+    }
+    final nextPosition = Offset(node.x, node.y) + delta;
+    _controller.moveState(nodeId, nextPosition);
+  }
+
+  void _handleNodeTap(String nodeId) {
+    if (_activeTool != AutomatonCanvasTool.transition) {
+      return;
+    }
+
+    if (_transitionSourceId == null) {
+      setState(() {
+        _transitionSourceId = nodeId;
+      });
+      return;
+    }
+
+    final sourceId = _transitionSourceId!;
+    setState(() {
+      _transitionSourceId = null;
+    });
+    _showTransitionEditor(sourceId, nodeId);
+  }
+
+  GraphViewCanvasEdge? _findExistingEdge(String fromId, String toId) {
+    for (final edge in _controller.edges) {
+      if (edge.fromStateId == fromId && edge.toStateId == toId) {
+        return edge;
+      }
+    }
+    return null;
+  }
+
+  Future<void> _showTransitionEditor(String fromId, String toId) async {
+    final existing = _findExistingEdge(fromId, toId);
+    final initialValue = existing?.label ?? '';
+    final controlPoint = existing != null
+        ? Offset(
+            existing.controlPointX ?? 0,
+            existing.controlPointY ?? 0,
+          )
+        : _deriveControlPoint(fromId, toId);
+
+    final label = await showDialog<String?>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          content: TransitionLabelEditorForm(
+            initialValue: initialValue,
+            autofocus: true,
+            touchOptimized: true,
+            onSubmit: (value) => Navigator.of(context).pop(value),
+            onCancel: () => Navigator.of(context).pop(null),
+          ),
+        );
+      },
+    );
+
+    if (!mounted || label == null) {
+      return;
+    }
+
+    _controller.addOrUpdateTransition(
+      fromStateId: fromId,
+      toStateId: toId,
+      label: label,
+      transitionId: existing?.id,
+      controlPointX: controlPoint.dx,
+      controlPointY: controlPoint.dy,
+    );
+  }
+
+  Offset _deriveControlPoint(String fromId, String toId) {
+    final fromNode = _controller.nodeById(fromId);
+    final toNode = _controller.nodeById(toId);
+    if (fromNode == null || toNode == null) {
+      return Offset.zero;
+    }
+
+    final fromOffset = Offset(fromNode.x, fromNode.y);
+    final toOffset = Offset(toNode.x, toNode.y);
+
+    if (fromId == toId) {
+      return fromOffset.translate(0, -_kNodeDiameter);
+    }
+
+    final midpoint = Offset(
+      (fromOffset.dx + toOffset.dx) / 2,
+      (fromOffset.dy + toOffset.dy) / 2,
+    );
+
+    final dx = toOffset.dx - fromOffset.dx;
+    final dy = toOffset.dy - fromOffset.dy;
+    var normal = Offset(-dy, dx);
+    if (normal.distanceSquared == 0) {
+      normal = const Offset(0, -1);
+    }
+    final existing = _controller.edges.where((edge) {
+      return edge.fromStateId == fromId && edge.toStateId == toId;
+    }).length;
+    final direction = existing.isEven ? 1 : -1;
+    final magnitude = (_kNodeDiameter * 0.8) + existing * 12;
+    final normalized = normal / normal.distance * magnitude * direction;
+    return midpoint + normalized;
+  }
+
+  bool _isNodeHighlighted(
+    GraphViewCanvasNode node,
+    SimulationHighlight highlight,
+  ) {
+    return highlight.stateIds.contains(node.id) ||
+        node.id == _transitionSourceId;
+  }
+
+  Widget _buildEdgeLayer({
+    required List<GraphViewCanvasEdge> edges,
+    required List<GraphViewCanvasNode> nodes,
+    required SimulationHighlight highlight,
+    required ThemeData theme,
+  }) {
+    final painter = _GraphViewEdgePainter(
+      edges: edges,
+      nodes: nodes,
+      highlightedTransitions: highlight.transitionIds,
+      selectedTransitions: _selectedTransitions,
+      theme: theme,
+    );
+
+    final transformation = _transformationController;
+    if (transformation == null) {
+      return CustomPaint(painter: painter);
+    }
+
+    return AnimatedBuilder(
+      animation: transformation,
+      builder: (context, _) {
+        return Transform(
+          alignment: Alignment.topLeft,
+          transform: transformation.value,
+          child: CustomPaint(painter: painter),
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return GestureDetector(
+      key: widget.canvasKey,
+      onTapUp: _handleCanvasTap,
+      child: ValueListenableBuilder<int>(
+        valueListenable: _controller.graphRevision,
+        builder: (context, _, __) {
+          final nodes = _controller.nodes.toList(growable: false);
+          final edges = _controller.edges.toList(growable: false);
+          return ValueListenableBuilder<SimulationHighlight>(
+            valueListenable: _controller.highlightNotifier,
+            builder: (context, highlight, __) {
+              return Stack(
+                children: [
+                  Positioned.fill(
+                    child: GraphView.builder(
+                      graph: _controller.graph,
+                      controller: _controller.graphController,
+                      algorithm: _algorithm,
+                      paint: Paint()..color = Colors.transparent,
+                      builder: (node) {
+                        final nodeId = node.key?.value?.toString();
+                        if (nodeId == null) {
+                          return const SizedBox.shrink();
+                        }
+                        final canvasNode =
+                            _controller.nodeById(nodeId) ??
+                                GraphViewCanvasNode(
+                                  id: nodeId,
+                                  label: nodeId,
+                                  x: node.position.dx,
+                                  y: node.position.dy,
+                                  isInitial: false,
+                                  isAccepting: false,
+                                );
+                        final isHighlighted =
+                            _isNodeHighlighted(canvasNode, highlight);
+                        return _AutomatonGraphNode(
+                          label: canvasNode.label,
+                          isInitial: canvasNode.isInitial,
+                          isAccepting: canvasNode.isAccepting,
+                          isHighlighted: isHighlighted,
+                          onTap: () => _handleNodeTap(canvasNode.id),
+                          onPanStart: (details) =>
+                              _handleNodePanStart(canvasNode.id, details),
+                          onPanUpdate: (details) =>
+                              _handleNodePanUpdate(canvasNode.id, details),
+                        );
+                      },
+                    ),
+                  ),
+                  Positioned.fill(
+                    child: IgnorePointer(
+                      child: _buildEdgeLayer(
+                        edges: edges,
+                        nodes: nodes,
+                        highlight: highlight,
+                        theme: theme,
+                      ),
+                    ),
+                  ),
+                ],
+              );
+            },
+          );
+        },
+      ),
+    );
+  }
+}
+
+class _AutomatonGraphSugiyamaAlgorithm extends SugiyamaAlgorithm {
+  _AutomatonGraphSugiyamaAlgorithm({
+    required this.controller,
+    required SugiyamaConfiguration configuration,
+  }) : super(configuration);
+
+  final GraphViewCanvasController controller;
+
+  @override
+  Size run(Graph? graph, double shiftX, double shiftY) {
+    final size = super.run(graph, shiftX, shiftY);
+    if (graph == null) {
+      return size;
+    }
+
+    for (final node in graph.nodes) {
+      final nodeId = node.key?.value?.toString();
+      if (nodeId == null) {
+        continue;
+      }
+      final cached = controller.nodeById(nodeId);
+      if (cached == null) {
+        continue;
+      }
+      node.position = Offset(cached.x, cached.y);
+    }
+    return size;
+  }
+}
+
+class _AutomatonGraphNode extends StatelessWidget {
+  const _AutomatonGraphNode({
+    required this.label,
+    required this.isInitial,
+    required this.isAccepting,
+    required this.isHighlighted,
+    required this.onTap,
+    required this.onPanStart,
+    required this.onPanUpdate,
+  });
+
+  final String label;
+  final bool isInitial;
+  final bool isAccepting;
+  final bool isHighlighted;
+  final GestureTapCallback onTap;
+  final GestureDragStartCallback onPanStart;
+  final GestureDragUpdateCallback onPanUpdate;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderColor = isHighlighted
+        ? theme.colorScheme.primary
+        : theme.colorScheme.outline;
+    final backgroundColor = isHighlighted
+        ? theme.colorScheme.primaryContainer
+        : theme.colorScheme.surface;
+
+    final badgeColor = theme.colorScheme.primary;
+
+    return GestureDetector(
+      onTap: onTap,
+      onPanStart: onPanStart,
+      onPanUpdate: onPanUpdate,
+      child: SizedBox(
+        width: _kNodeDiameter,
+        height: _kNodeDiameter,
+        child: Stack(
+          clipBehavior: Clip.none,
+          children: [
+            Positioned.fill(
+              child: DecoratedBox(
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: backgroundColor,
+                  border: Border.all(color: borderColor, width: 3),
+                ),
+                child: Center(
+                  child: Text(
+                    label,
+                    style: theme.textTheme.titleMedium,
+                    textAlign: TextAlign.center,
+                  ),
+                ),
+              ),
+            ),
+            if (isInitial)
+              Positioned(
+                left: -16,
+                top: _kNodeRadius - 6,
+                child: CustomPaint(
+                  size: const Size(24, 12),
+                  painter: _InitialStateArrowPainter(color: borderColor),
+                ),
+              ),
+            if (isAccepting)
+              Positioned.fill(
+                child: Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: DecoratedBox(
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      border: Border.all(color: badgeColor, width: 2),
+                    ),
+                  ),
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _InitialStateArrowPainter extends CustomPainter {
+  const _InitialStateArrowPainter({required this.color});
+
+  final Color color;
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..color = color
+      ..style = PaintingStyle.fill;
+
+    final path = Path()
+      ..moveTo(size.width, 0)
+      ..lineTo(0, size.height / 2)
+      ..lineTo(size.width, size.height)
+      ..close();
+    canvas.drawPath(path, paint);
+  }
+
+  @override
+  bool shouldRepaint(covariant _InitialStateArrowPainter oldDelegate) {
+    return oldDelegate.color != color;
+  }
+}
+
+class _GraphViewEdgePainter extends CustomPainter {
+  _GraphViewEdgePainter({
+    required this.edges,
+    required this.nodes,
+    required this.highlightedTransitions,
+    required this.selectedTransitions,
+    required this.theme,
+  });
+
+  final List<GraphViewCanvasEdge> edges;
+  final List<GraphViewCanvasNode> nodes;
+  final Set<String> highlightedTransitions;
+  final Set<String> selectedTransitions;
+  final ThemeData theme;
+
+  GraphViewCanvasNode? _nodeById(String id) {
+    for (final node in nodes) {
+      if (node.id == id) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final baseColor = theme.colorScheme.outline;
+    final highlightColor = theme.colorScheme.primary;
+
+    for (final edge in edges) {
+      final from = _nodeById(edge.fromStateId);
+      final to = _nodeById(edge.toStateId);
+      if (from == null || to == null) {
+        continue;
+      }
+
+      final fromCenter = Offset(from.x, from.y);
+      final toCenter = Offset(to.x, to.y);
+      final controlPoint = (edge.controlPointX != null &&
+              edge.controlPointY != null)
+          ? Offset(edge.controlPointX!, edge.controlPointY!)
+          : null;
+
+      final isHighlighted = highlightedTransitions.contains(edge.id);
+      final isSelected = selectedTransitions.contains(edge.id);
+      final color = isHighlighted ? highlightColor : baseColor;
+      final strokeWidth = isSelected ? 4.0 : 2.0;
+      final paint = Paint()
+        ..color = color
+        ..style = PaintingStyle.stroke
+        ..strokeWidth = strokeWidth
+        ..strokeCap = StrokeCap.round;
+
+      if (edge.fromStateId == edge.toStateId) {
+        final loopPoint = controlPoint ??
+            fromCenter.translate(0, -_kNodeDiameter);
+        final loopPath = _buildLoopPath(fromCenter, loopPoint);
+        canvas.drawPath(loopPath.path, paint);
+        _drawArrowHead(
+          canvas,
+          loopPath.tip,
+          loopPath.direction,
+          color,
+        );
+        _drawEdgeLabel(canvas, loopPath.labelAnchor, edge.label, color);
+        continue;
+      }
+
+      final start = _projectFromCenter(
+        fromCenter,
+        controlPoint ?? toCenter,
+        _kNodeRadius,
+      );
+      final end = _projectFromCenter(
+        toCenter,
+        controlPoint ?? fromCenter,
+        _kNodeRadius,
+      );
+
+      final path = Path()..moveTo(start.dx, start.dy);
+      Offset direction;
+      if (controlPoint != null) {
+        path.quadraticBezierTo(
+          controlPoint.dx,
+          controlPoint.dy,
+          end.dx,
+          end.dy,
+        );
+        direction = end - controlPoint;
+      } else {
+        path.lineTo(end.dx, end.dy);
+        direction = end - start;
+      }
+      canvas.drawPath(path, paint);
+      _drawArrowHead(canvas, end, direction, color);
+
+      final labelAnchor = controlPoint ?? Offset(
+        (start.dx + end.dx) / 2,
+        (start.dy + end.dy) / 2,
+      );
+      _drawEdgeLabel(canvas, labelAnchor, edge.label, color);
+    }
+  }
+
+  ({Path path, Offset tip, Offset direction, Offset labelAnchor}) _buildLoopPath(
+    Offset center,
+    Offset anchor,
+  ) {
+    final path = Path();
+    final start = center + Offset(0, -_kNodeRadius);
+    final end = center + Offset(_kNodeRadius * 0.7, -_kNodeRadius * 0.2);
+    path.moveTo(start.dx, start.dy);
+    path.quadraticBezierTo(anchor.dx, anchor.dy, end.dx, end.dy);
+    final labelAnchor = Offset(
+      (start.dx + anchor.dx) / 2,
+      math.min(start.dy, anchor.dy) - 12,
+    );
+    return (
+      path: path,
+      tip: end,
+      direction: end - anchor,
+      labelAnchor: labelAnchor,
+    );
+  }
+
+  Offset _projectFromCenter(Offset center, Offset target, double radius) {
+    final vector = target - center;
+    if (vector.distance == 0) {
+      return center;
+    }
+    final normalized = vector / vector.distance;
+    return center + normalized * radius;
+  }
+
+  void _drawArrowHead(
+    Canvas canvas,
+    Offset position,
+    Offset direction,
+    Color color,
+  ) {
+    if (direction.distance == 0) {
+      return;
+    }
+    final normalized = direction / direction.distance;
+    final normal = Offset(-normalized.dy, normalized.dx);
+    const arrowLength = 12.0;
+    const arrowWidth = 6.0;
+    final tip = position;
+    final base = tip - normalized * arrowLength;
+    final left = base + normal * arrowWidth;
+    final right = base - normal * arrowWidth;
+    final path = Path()
+      ..moveTo(tip.dx, tip.dy)
+      ..lineTo(left.dx, left.dy)
+      ..lineTo(right.dx, right.dy)
+      ..close();
+    canvas.drawPath(path, Paint()..color = color);
+  }
+
+  void _drawEdgeLabel(
+    Canvas canvas,
+    Offset position,
+    String label,
+    Color color,
+  ) {
+    if (label.isEmpty) {
+      return;
+    }
+    final textPainter = TextPainter(
+      text: TextSpan(
+        text: label,
+        style: TextStyle(
+          color: color,
+          fontSize: 14,
+        ),
+      ),
+      textDirection: TextDirection.ltr,
+    )..layout();
+    final offset = position -
+        Offset(textPainter.width / 2, textPainter.height / 2 + 4);
+    textPainter.paint(canvas, offset);
+  }
+
+  @override
+  bool shouldRepaint(covariant _GraphViewEdgePainter oldDelegate) {
+    return !listEquals(oldDelegate.edges, edges) ||
+        !listEquals(oldDelegate.nodes, nodes) ||
+        !setEquals(
+          oldDelegate.highlightedTransitions,
+          highlightedTransitions,
+        ) ||
+        !setEquals(oldDelegate.selectedTransitions, selectedTransitions) ||
+        oldDelegate.theme != theme;
+  }
+}

--- a/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
@@ -1,0 +1,139 @@
+import 'dart:math' as math;
+
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_automaton_mapper.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';
+
+void main() {
+  group('GraphViewAutomatonMapper', () {
+    late FSA baseAutomaton;
+    late State initialState;
+    late State acceptingState;
+    late FSATransition transition;
+
+    setUp(() {
+      initialState = State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      acceptingState = State(
+        id: 'q1',
+        label: 'q1',
+        position: Vector2(160, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      transition = FSATransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        inputSymbols: {'a'},
+        label: 'a',
+        controlPoint: Vector2(12, 18),
+      );
+
+      baseAutomaton = FSA(
+        id: 'auto',
+        name: 'Automaton',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+      );
+    });
+
+    test('toSnapshot captures nodes, edges and metadata', () {
+      final snapshot = GraphViewAutomatonMapper.toSnapshot(baseAutomaton);
+
+      expect(snapshot.metadata.id, equals('auto'));
+      expect(snapshot.metadata.name, equals('Automaton'));
+      expect(snapshot.metadata.alphabet, containsAll(['a']));
+
+      expect(snapshot.nodes, hasLength(2));
+      final nodeIds = snapshot.nodes.map((node) => node.id).toSet();
+      expect(nodeIds, containsAll({'q0', 'q1'}));
+
+      final acceptingNode =
+          snapshot.nodes.firstWhere((node) => node.id == 'q1');
+      expect(acceptingNode.isAccepting, isTrue);
+      expect(acceptingNode.x, closeTo(160, 0.0001));
+      expect(acceptingNode.y, closeTo(120, 0.0001));
+
+      expect(snapshot.edges, hasLength(1));
+      final edge = snapshot.edges.single;
+      expect(edge.id, equals('t0'));
+      expect(edge.fromStateId, equals('q0'));
+      expect(edge.toStateId, equals('q1'));
+      expect(edge.symbols, equals(['a']));
+      expect(edge.controlPointX, closeTo(12, 0.0001));
+      expect(edge.controlPointY, closeTo(18, 0.0001));
+    });
+
+    test('mergeIntoTemplate rebuilds automaton from snapshot', () {
+      final snapshot = GraphViewAutomatonSnapshot(
+        nodes: const [
+          GraphViewCanvasNode(
+            id: 'q0',
+            label: 'Start',
+            x: 40,
+            y: 60,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          GraphViewCanvasNode(
+            id: 'q1',
+            label: 'End',
+            x: 220,
+            y: 240,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          GraphViewCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: ['b'],
+            lambdaSymbol: null,
+            controlPointX: 8,
+            controlPointY: 12,
+          ),
+        ],
+        metadata: const GraphViewAutomatonMetadata(
+          id: 'auto',
+          name: 'Automaton',
+          alphabet: ['b'],
+        ),
+      );
+
+      final merged =
+          GraphViewAutomatonMapper.mergeIntoTemplate(snapshot, baseAutomaton);
+
+      expect(merged.states, hasLength(2));
+      expect(merged.transitions, hasLength(1));
+      expect(merged.acceptingStates.map((state) => state.id), contains('q1'));
+      expect(merged.initialState?.id, equals('q0'));
+
+      final mergedTransition =
+          merged.fsaTransitions.firstWhere((transition) => transition.id == 't0');
+      expect(mergedTransition.fromState.id, equals('q0'));
+      expect(mergedTransition.toState.id, equals('q1'));
+      expect(mergedTransition.inputSymbols, equals({'b'}));
+      expect(mergedTransition.controlPoint.x, closeTo(8, 0.0001));
+      expect(mergedTransition.controlPoint.y, closeTo(12, 0.0001));
+    });
+  });
+}

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -1,0 +1,275 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/entities/automaton_entity.dart';
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/repositories/automaton_repository.dart';
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/data/services/automaton_service.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+
+class _FakeLayoutRepository implements LayoutRepository {
+  Future<AutomatonResult> _unsupported() async {
+    return ResultFactory.failure('unsupported');
+  }
+
+  @override
+  Future<AutomatonResult> applyAutoLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applyBalancedLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applyCompactLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applyHierarchicalLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> applySpreadLayout(AutomatonEntity automaton) =>
+      _unsupported();
+
+  @override
+  Future<AutomatonResult> centerAutomaton(AutomatonEntity automaton) =>
+      _unsupported();
+}
+
+class _RecordingAutomatonProvider extends AutomatonProvider {
+  _RecordingAutomatonProvider()
+      : super(
+          automatonService: AutomatonService(),
+          layoutRepository: _FakeLayoutRepository(),
+        );
+
+  final List<Map<String, Object?>> addStateCalls = [];
+  final List<Map<String, Object?>> updateLabelCalls = [];
+  final List<Map<String, Object?>> transitionCalls = [];
+  final List<Map<String, Object?>> moveStateCalls = [];
+
+  @override
+  void addState({
+    required String id,
+    required String label,
+    required double x,
+    required double y,
+    bool? isInitial,
+    bool? isAccepting,
+  }) {
+    addStateCalls.add({
+      'id': id,
+      'label': label,
+      'x': x,
+      'y': y,
+      'isInitial': isInitial,
+      'isAccepting': isAccepting,
+    });
+    super.addState(
+      id: id,
+      label: label,
+      x: x,
+      y: y,
+      isInitial: isInitial,
+      isAccepting: isAccepting,
+    );
+  }
+
+  @override
+  void moveState({
+    required String id,
+    required double x,
+    required double y,
+  }) {
+    moveStateCalls.add({
+      'id': id,
+      'x': x,
+      'y': y,
+    });
+    super.moveState(id: id, x: x, y: y);
+  }
+
+  @override
+  void updateStateLabel({
+    required String id,
+    required String label,
+  }) {
+    updateLabelCalls.add({'id': id, 'label': label});
+    super.updateStateLabel(id: id, label: label);
+  }
+
+  @override
+  void addOrUpdateTransition({
+    required String id,
+    required String fromStateId,
+    required String toStateId,
+    required String label,
+    double? controlPointX,
+    double? controlPointY,
+  }) {
+    transitionCalls.add({
+      'id': id,
+      'fromStateId': fromStateId,
+      'toStateId': toStateId,
+      'label': label,
+      'controlPointX': controlPointX,
+      'controlPointY': controlPointY,
+    });
+    super.addOrUpdateTransition(
+      id: id,
+      fromStateId: fromStateId,
+      toStateId: toStateId,
+      label: label,
+      controlPointX: controlPointX,
+      controlPointY: controlPointY,
+    );
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GraphViewCanvasController', () {
+    late _RecordingAutomatonProvider provider;
+    late GraphViewCanvasController controller;
+
+    setUp(() {
+      provider = _RecordingAutomatonProvider();
+      controller = GraphViewCanvasController(automatonProvider: provider);
+      provider.updateAutomaton(
+        FSA(
+          id: 'auto',
+          name: 'Automaton',
+          states: const {},
+          transitions: const {},
+          alphabet: const {},
+          initialState: null,
+          acceptingStates: const {},
+          created: DateTime.utc(2024, 1, 1),
+          modified: DateTime.utc(2024, 1, 1),
+          bounds: const math.Rectangle<double>(0, 0, 400, 300),
+          panOffset: Vector2.zero(),
+          zoomLevel: 1,
+        ),
+      );
+    });
+
+    test('addStateAt generates id and forwards to provider', () {
+      controller.addStateAt(const Offset(120, 80));
+
+      expect(provider.addStateCalls, hasLength(1));
+      final call = provider.addStateCalls.single;
+      expect(call['id'], isNotEmpty);
+      expect(call['label'], equals('q0'));
+      expect(call['x'], closeTo(120, 0.0001));
+      expect(call['y'], closeTo(80, 0.0001));
+      expect(call['isInitial'], isTrue);
+    });
+
+    test('moveState forwards coordinates to provider', () {
+      controller.addStateAt(const Offset(0, 0));
+      final id = provider.addStateCalls.first['id'] as String;
+
+      controller.moveState(id, const Offset(240, 160));
+
+      expect(provider.moveStateCalls, hasLength(1));
+      final call = provider.moveStateCalls.single;
+      expect(call['id'], equals(id));
+      expect(call['x'], closeTo(240, 0.0001));
+      expect(call['y'], closeTo(160, 0.0001));
+    });
+
+    test('updateStateLabel normalises empty labels', () {
+      controller.addStateAt(const Offset(0, 0));
+      final id = provider.addStateCalls.first['id'] as String;
+
+      controller.updateStateLabel(id, '');
+
+      expect(provider.updateLabelCalls, hasLength(1));
+      expect(provider.updateLabelCalls.single['label'], equals(id));
+    });
+
+    test('addOrUpdateTransition sends payload to provider', () {
+      controller.addStateAt(const Offset(0, 0));
+      controller.addStateAt(const Offset(200, 0));
+      final fromId = provider.addStateCalls[0]['id'] as String;
+      final toId = provider.addStateCalls[1]['id'] as String;
+
+      controller.addOrUpdateTransition(
+        fromStateId: fromId,
+        toStateId: toId,
+        label: 'a',
+        controlPointX: 100,
+        controlPointY: -40,
+      );
+
+      expect(provider.transitionCalls, hasLength(1));
+      final call = provider.transitionCalls.single;
+      expect(call['fromStateId'], equals(fromId));
+      expect(call['toStateId'], equals(toId));
+      expect(call['label'], equals('a'));
+      expect(call['controlPointX'], closeTo(100, 0.0001));
+      expect(call['controlPointY'], closeTo(-40, 0.0001));
+    });
+
+    test('synchronize mirrors provider state into controller caches', () {
+      final stateA = automaton_state.State(
+        id: 'qa',
+        label: 'qa',
+        position: Vector2(32, 64),
+        isInitial: true,
+        isAccepting: false,
+      );
+      final stateB = automaton_state.State(
+        id: 'qb',
+        label: 'qb',
+        position: Vector2(180, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      final transition = FSATransition(
+        id: 't0',
+        fromState: stateA,
+        toState: stateB,
+        inputSymbols: {'a'},
+        label: 'a',
+        controlPoint: Vector2(120, 40),
+      );
+
+      final automaton = FSA(
+        id: 'auto',
+        name: 'Automaton',
+        states: {stateA, stateB},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: stateA,
+        acceptingStates: {stateB},
+        created: DateTime.utc(2024, 1, 1),
+        modified: DateTime.utc(2024, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+      );
+
+      controller.synchronize(automaton);
+
+      final cachedNode = controller.nodeById('qa');
+      expect(cachedNode, isNotNull);
+      expect(cachedNode!.x, closeTo(32, 0.0001));
+      expect(cachedNode.y, closeTo(64, 0.0001));
+
+      final cachedEdge = controller.edgeById('t0');
+      expect(cachedEdge, isNotNull);
+      expect(cachedEdge!.fromStateId, equals('qa'));
+      expect(cachedEdge.toStateId, equals('qb'));
+      expect(cachedEdge.controlPointX, closeTo(120, 0.0001));
+      expect(cachedEdge.controlPointY, closeTo(40, 0.0001));
+    });
+  });
+}

--- a/test/features/canvas/graphview/graphview_canvas_models_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_models_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';
+
+void main() {
+  group('GraphViewCanvasEdge', () {
+    test('copyWith updates PDA metadata fields', () {
+      const baseEdge = GraphViewCanvasEdge(
+        id: 'edge-1',
+        fromStateId: 'q0',
+        toStateId: 'q1',
+        symbols: ['a'],
+        popSymbol: 'A',
+        pushSymbol: 'B',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+
+      final updated = baseEdge.copyWith(
+        popSymbol: 'Z',
+        pushSymbol: 'Y',
+        isLambdaInput: true,
+        isLambdaPop: true,
+        isLambdaPush: true,
+      );
+
+      expect(updated.popSymbol, 'Z');
+      expect(updated.pushSymbol, 'Y');
+      expect(updated.isLambdaInput, isTrue);
+      expect(updated.isLambdaPop, isTrue);
+      expect(updated.isLambdaPush, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add a GraphView-based automaton canvas widget with manual interaction helpers and custom edge rendering
- expose node position helpers on the GraphView canvas controller to support the new painter
- port key controller and mapper tests for the GraphView implementation

## Testing
- not run (Flutter/Dart tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1b5946c1c832e8487e93cc13ec3df