### PR TITLE
graphview: add toolbar and overlays for inline editing

### DIFF
--- a/lib/features/canvas/graphview/graphview_label_field_editor.dart
+++ b/lib/features/canvas/graphview/graphview_label_field_editor.dart
@@ -1,0 +1,86 @@
+import 'package:flutter/material.dart';
+
+import '../../../presentation/widgets/transition_editors/transition_label_editor.dart';
+
+/// Overlay editor used by the GraphView canvas to update transition labels.
+class GraphViewLabelFieldEditor extends StatefulWidget {
+  const GraphViewLabelFieldEditor({
+    super.key,
+    required this.initialValue,
+    required this.onSubmit,
+    required this.onCancel,
+  });
+
+  final String initialValue;
+  final ValueChanged<String> onSubmit;
+  final VoidCallback onCancel;
+
+  @override
+  State<GraphViewLabelFieldEditor> createState() =>
+      _GraphViewLabelFieldEditorState();
+}
+
+class _GraphViewLabelFieldEditorState
+    extends State<GraphViewLabelFieldEditor> {
+  late final FocusScopeNode _focusScopeNode;
+  late final FocusNode _focusNode;
+
+  @override
+  void initState() {
+    super.initState();
+    _focusScopeNode = FocusScopeNode();
+    _focusNode = FocusNode();
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) {
+        return;
+      }
+      _focusScopeNode.requestFocus(_focusNode);
+    });
+  }
+
+  @override
+  void dispose() {
+    _focusNode.dispose();
+    _focusScopeNode.dispose();
+    super.dispose();
+  }
+
+  void _handleFocusChange(bool focused) {
+    if (!focused) {
+      widget.onCancel();
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return FocusScope(
+      node: _focusScopeNode,
+      child: Focus(
+        focusNode: _focusNode,
+        onFocusChange: _handleFocusChange,
+        child: Material(
+          elevation: 4,
+          borderRadius: BorderRadius.circular(8),
+          child: ConstrainedBox(
+            constraints: const BoxConstraints(minWidth: 200),
+            child: Padding(
+              padding: const EdgeInsets.all(12),
+              child: TransitionLabelEditorForm(
+                initialValue: widget.initialValue,
+                onSubmit: (value) {
+                  widget.onSubmit(value);
+                  _focusScopeNode.unfocus();
+                },
+                onCancel: () {
+                  widget.onCancel();
+                  _focusScopeNode.unfocus();
+                },
+                autofocus: true,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/canvas/graphview/graphview_link_overlay_utils.dart
+++ b/lib/features/canvas/graphview/graphview_link_overlay_utils.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
+
+import '../../../core/constants/automaton_canvas.dart';
+import 'graphview_canvas_controller.dart';
+import 'graphview_canvas_models.dart';
+
+const double _kNodeDiameter = kAutomatonStateDiameter;
+const double _kNodeRadius = _kNodeDiameter / 2;
+
+/// Computes the preferred world anchor for the provided [edge].
+Offset? resolveLinkAnchorWorld(
+  GraphViewCanvasController controller,
+  GraphViewCanvasEdge edge,
+) {
+  final from = controller.nodeById(edge.fromStateId);
+  final to = controller.nodeById(edge.toStateId);
+  if (from == null || to == null) {
+    return null;
+  }
+
+  if (edge.controlPointX != null && edge.controlPointY != null) {
+    return Offset(edge.controlPointX!, edge.controlPointY!);
+  }
+
+  if (edge.fromStateId == edge.toStateId) {
+    return _resolveLoopAnchor(from);
+  }
+
+  final fromCenter = resolveNodeCenter(from);
+  final toCenter = resolveNodeCenter(to);
+  return Offset(
+    (fromCenter.dx + toCenter.dx) / 2,
+    (fromCenter.dy + toCenter.dy) / 2,
+  );
+}
+
+/// Converts a world [offset] into a screen-space position relative to the
+/// overlay associated with [canvasKey].
+Offset? projectWorldPointToOverlay({
+  required GlobalKey canvasKey,
+  required TransformationController transformationController,
+  required Offset worldOffset,
+}) {
+  final renderObject = canvasKey.currentContext?.findRenderObject();
+  if (renderObject is! RenderBox || !renderObject.hasSize) {
+    return null;
+  }
+
+  final matrix = transformationController.value;
+  final projected = MatrixUtils.transformPoint(matrix, worldOffset);
+  if (!projected.dx.isFinite || !projected.dy.isFinite) {
+    return null;
+  }
+
+  return renderObject.localToGlobal(projected);
+}
+
+/// Returns the node center in world coordinates.
+Offset resolveNodeCenter(GraphViewCanvasNode node) {
+  return Offset(node.x, node.y);
+}
+
+Offset _resolveLoopAnchor(GraphViewCanvasNode node) {
+  final center = resolveNodeCenter(node);
+  return center.translate(0, -_kNodeRadius * 2);
+}

--- a/lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
+++ b/lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
@@ -1,0 +1,72 @@
+import 'dart:ui';
+
+/// Lightweight payload describing the result of a drag-selection gesture within
+/// the GraphView canvas.
+class GraphViewDragSelectionEndEventPayload {
+  const GraphViewDragSelectionEndEventPayload({
+    required this.nodeIds,
+    this.position,
+  });
+
+  final Set<String> nodeIds;
+  final Offset? position;
+}
+
+/// Payload describing the selected transitions inside the GraphView canvas.
+class GraphViewLinkSelectionEventPayload {
+  const GraphViewLinkSelectionEventPayload({required this.linkIds});
+
+  final Set<String> linkIds;
+}
+
+/// Payload describing transitions that have been deselected.
+class GraphViewLinkDeselectionEventPayload {
+  const GraphViewLinkDeselectionEventPayload({required this.linkIds});
+
+  final Set<String> linkIds;
+}
+
+/// Payload emitted when a transition is removed from the GraphView canvas.
+class GraphViewRemoveLinkEventPayload {
+  const GraphViewRemoveLinkEventPayload({required this.linkId});
+
+  final String linkId;
+}
+
+/// Utility helpers to standardise payloads emitted by custom interaction
+/// handlers built on top of the GraphView canvas. The helpers accept raw inputs
+/// (such as `Iterable` instances or nullable strings) and coerce them into the
+/// strongly-typed payloads consumed by presentation widgets.
+class GraphViewNodeEditorEventShims {
+  const GraphViewNodeEditorEventShims._();
+
+  static GraphViewDragSelectionEndEventPayload dragSelection({
+    required Iterable<String> nodeIds,
+    Offset? position,
+  }) {
+    return GraphViewDragSelectionEndEventPayload(
+      nodeIds: Set<String>.unmodifiable(nodeIds),
+      position: position,
+    );
+  }
+
+  static GraphViewLinkSelectionEventPayload linkSelection(
+    Iterable<String> linkIds,
+  ) {
+    return GraphViewLinkSelectionEventPayload(
+      linkIds: Set<String>.unmodifiable(linkIds),
+    );
+  }
+
+  static GraphViewLinkDeselectionEventPayload linkDeselection(
+    Iterable<String> linkIds,
+  ) {
+    return GraphViewLinkDeselectionEventPayload(
+      linkIds: Set<String>.unmodifiable(linkIds),
+    );
+  }
+
+  static GraphViewRemoveLinkEventPayload removeLink(String linkId) {
+    return GraphViewRemoveLinkEventPayload(linkId: linkId);
+  }
+}

--- a/lib/presentation/widgets/graphview_canvas_toolbar.dart
+++ b/lib/presentation/widgets/graphview_canvas_toolbar.dart
@@ -1,0 +1,335 @@
+import 'package:flutter/material.dart';
+
+import '../../features/canvas/graphview/graphview_canvas_controller.dart';
+import 'automaton_canvas_tool.dart';
+
+/// Toolbar exposing viewport commands for the GraphView canvas.
+class GraphViewCanvasToolbar extends StatefulWidget {
+  const GraphViewCanvasToolbar({
+    super.key,
+    required this.controller,
+    this.enableToolSelection = false,
+    this.activeTool = AutomatonCanvasTool.selection,
+    this.onSelectTool,
+    required this.onAddState,
+    this.onAddTransition,
+    this.onClear,
+    this.statusMessage,
+    this.layout = GraphViewCanvasToolbarLayout.desktop,
+  }) : assert(
+          !enableToolSelection || onSelectTool != null,
+          'onSelectTool must be provided when tool selection is enabled.',
+        ),
+        assert(
+          !enableToolSelection || onAddTransition != null,
+          'onAddTransition must be provided when tool selection is enabled.',
+        );
+
+  final GraphViewCanvasController controller;
+  final bool enableToolSelection;
+  final AutomatonCanvasTool activeTool;
+  final VoidCallback? onSelectTool;
+  final VoidCallback onAddState;
+  final VoidCallback? onAddTransition;
+  final VoidCallback? onClear;
+  final String? statusMessage;
+  final GraphViewCanvasToolbarLayout layout;
+
+  @override
+  State<GraphViewCanvasToolbar> createState() =>
+      _GraphViewCanvasToolbarState();
+}
+
+class _GraphViewCanvasToolbarState extends State<GraphViewCanvasToolbar> {
+  @override
+  void initState() {
+    super.initState();
+    widget.controller.graphRevision.addListener(_handleControllerChanged);
+  }
+
+  @override
+  void didUpdateWidget(covariant GraphViewCanvasToolbar oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (oldWidget.controller != widget.controller) {
+      oldWidget.controller.graphRevision.removeListener(_handleControllerChanged);
+      widget.controller.graphRevision.addListener(_handleControllerChanged);
+    }
+  }
+
+  @override
+  void dispose() {
+    widget.controller.graphRevision.removeListener(_handleControllerChanged);
+    super.dispose();
+  }
+
+  void _handleControllerChanged() {
+    if (!mounted) {
+      return;
+    }
+    setState(() {});
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final controller = widget.controller;
+    final actions = <_ToolbarButtonConfig>[
+      if (widget.enableToolSelection)
+        _ToolbarButtonConfig(
+          action: _ToolbarAction.selection,
+          handler: widget.onSelectTool,
+          isToggle: true,
+          isSelected: widget.activeTool == AutomatonCanvasTool.selection,
+        ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.addState,
+        handler: widget.onAddState,
+        isToggle: widget.enableToolSelection,
+        isSelected:
+            widget.enableToolSelection &&
+                widget.activeTool == AutomatonCanvasTool.addState,
+      ),
+      if (widget.onAddTransition != null)
+        _ToolbarButtonConfig(
+          action: _ToolbarAction.transition,
+          handler: widget.onAddTransition,
+          isToggle: widget.enableToolSelection,
+          isSelected: widget.enableToolSelection &&
+              widget.activeTool == AutomatonCanvasTool.transition,
+        ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.undo,
+        handler: controller.canUndo ? () => controller.undo() : null,
+      ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.redo,
+        handler: controller.canRedo ? () => controller.redo() : null,
+      ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.zoomIn,
+        handler: controller.zoomIn,
+      ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.zoomOut,
+        handler: controller.zoomOut,
+      ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.fitContent,
+        handler: controller.fitToContent,
+      ),
+      _ToolbarButtonConfig(
+        action: _ToolbarAction.resetView,
+        handler: controller.resetView,
+      ),
+      if (widget.onClear != null)
+        _ToolbarButtonConfig(
+          action: _ToolbarAction.clear,
+          handler: widget.onClear!,
+        ),
+    ];
+
+    switch (widget.layout) {
+      case GraphViewCanvasToolbarLayout.mobile:
+        return _MobileToolbar(
+          actions: actions,
+          statusMessage: widget.statusMessage,
+          theme: theme,
+        );
+      case GraphViewCanvasToolbarLayout.desktop:
+        return _DesktopToolbar(
+          actions: actions,
+          statusMessage: widget.statusMessage,
+          theme: theme,
+        );
+    }
+  }
+}
+
+enum GraphViewCanvasToolbarLayout { desktop, mobile }
+
+class _DesktopToolbar extends StatelessWidget {
+  const _DesktopToolbar({
+    required this.actions,
+    required this.statusMessage,
+    required this.theme,
+  });
+
+  final List<_ToolbarButtonConfig> actions;
+  final String? statusMessage;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Align(
+      alignment: Alignment.topRight,
+      child: Padding(
+        padding: const EdgeInsets.all(12),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: [
+            Container(
+              padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 6),
+              decoration: BoxDecoration(
+                color: colorScheme.surface,
+                borderRadius: BorderRadius.circular(12),
+                boxShadow: [
+                  BoxShadow(
+                    color: Colors.black.withOpacity(0.08),
+                    blurRadius: 12,
+                    offset: const Offset(0, 4),
+                  ),
+                ],
+              ),
+              child: Row(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  for (final entry in actions) ...[
+                    IconButton(
+                      tooltip: entry.action.label,
+                      icon: Icon(entry.action.icon),
+                      onPressed: entry.handler,
+                      style: entry.isToggle
+                          ? IconButton.styleFrom(
+                              backgroundColor: entry.isSelected
+                                  ? colorScheme.secondaryContainer
+                                  : colorScheme.surfaceVariant
+                                      .withOpacity(0.15),
+                              foregroundColor: entry.isSelected
+                                  ? colorScheme.onSecondaryContainer
+                                  : colorScheme.onSurfaceVariant,
+                            )
+                          : null,
+                    ),
+                    if (entry != actions.last)
+                      Container(
+                        width: 1,
+                        height: 24,
+                        margin: const EdgeInsets.symmetric(horizontal: 4),
+                        color:
+                            colorScheme.outlineVariant.withOpacity(0.35),
+                      ),
+                  ],
+                ],
+              ),
+            ),
+            if (statusMessage != null && statusMessage!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(top: 8),
+                child: Text(
+                  statusMessage!,
+                  style: textTheme.bodySmall,
+                ),
+              ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _MobileToolbar extends StatelessWidget {
+  const _MobileToolbar({
+    required this.actions,
+    required this.statusMessage,
+    required this.theme,
+  });
+
+  final List<_ToolbarButtonConfig> actions;
+  final String? statusMessage;
+  final ThemeData theme;
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            if (statusMessage != null && statusMessage!.isNotEmpty)
+              Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: Text(
+                  statusMessage!,
+                  style: textTheme.bodyMedium,
+                ),
+              ),
+            Material(
+              elevation: 6,
+              borderRadius: BorderRadius.circular(16),
+              color: colorScheme.surface,
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Wrap(
+                  spacing: 12,
+                  runSpacing: 12,
+                  alignment: WrapAlignment.center,
+                  children: [
+                    for (final entry in actions)
+                      FilledButton.icon(
+                        onPressed: entry.handler,
+                        style: FilledButton.styleFrom(
+                          padding: const EdgeInsets.symmetric(
+                            horizontal: 16,
+                            vertical: 12,
+                          ),
+                          backgroundColor: entry.isSelected
+                              ? colorScheme.secondaryContainer
+                              : null,
+                          foregroundColor: entry.isSelected
+                              ? colorScheme.onSecondaryContainer
+                              : null,
+                        ),
+                        icon: Icon(entry.action.icon),
+                        label: Text(entry.action.label),
+                      ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _ToolbarButtonConfig {
+  _ToolbarButtonConfig({
+    required this.action,
+    required this.handler,
+    this.isToggle = false,
+    this.isSelected = false,
+  });
+
+  final _ToolbarAction action;
+  final VoidCallback? handler;
+  final bool isToggle;
+  final bool isSelected;
+}
+
+enum _ToolbarAction {
+  selection(icon: Icons.pan_tool, label: 'Select'),
+  addState(icon: Icons.add, label: 'Add state'),
+  transition(icon: Icons.arrow_right_alt, label: 'Add transition'),
+  undo(icon: Icons.undo, label: 'Undo'),
+  redo(icon: Icons.redo, label: 'Redo'),
+  zoomIn(icon: Icons.zoom_in, label: 'Zoom in'),
+  zoomOut(icon: Icons.zoom_out, label: 'Zoom out'),
+  fitContent(icon: Icons.fit_screen, label: 'Fit to content'),
+  resetView(icon: Icons.center_focus_strong, label: 'Reset view'),
+  clear(icon: Icons.delete_outline, label: 'Clear canvas');
+
+  const _ToolbarAction({required this.icon, required this.label});
+
+  final IconData icon;
+  final String label;
+}

--- a/test/widget/presentation/graphview_canvas_toolbar_test.dart
+++ b/test/widget/presentation/graphview_canvas_toolbar_test.dart
@@ -1,0 +1,252 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/data/services/automaton_service.dart';
+import 'package:jflutter/features/layout/layout_repository_impl.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:jflutter/presentation/widgets/automaton_canvas_tool.dart';
+import 'package:jflutter/presentation/widgets/graphview_canvas_toolbar.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_controller.dart';
+
+class _TestGraphViewCanvasController extends GraphViewCanvasController {
+  _TestGraphViewCanvasController({required AutomatonProvider automatonProvider})
+      : super(automatonProvider: automatonProvider);
+
+  int zoomInCount = 0;
+  int zoomOutCount = 0;
+  int fitCount = 0;
+  int resetCount = 0;
+  int undoCount = 0;
+  int redoCount = 0;
+
+  @override
+  void zoomIn() {
+    zoomInCount++;
+    super.zoomIn();
+  }
+
+  @override
+  void zoomOut() {
+    zoomOutCount++;
+    super.zoomOut();
+  }
+
+  @override
+  void fitToContent() {
+    fitCount++;
+    super.fitToContent();
+  }
+
+  @override
+  void resetView() {
+    resetCount++;
+    super.resetView();
+  }
+
+  @override
+  bool undo() {
+    undoCount++;
+    return super.undo();
+  }
+
+  @override
+  bool redo() {
+    redoCount++;
+    return super.redo();
+  }
+}
+
+void main() {
+  late AutomatonProvider provider;
+  late _TestGraphViewCanvasController controller;
+
+  setUp(() {
+    provider = AutomatonProvider(
+      automatonService: AutomatonService(),
+      layoutRepository: LayoutRepositoryImpl(),
+    );
+    controller = _TestGraphViewCanvasController(
+      automatonProvider: provider,
+    )..synchronize(provider.state.currentAutomaton);
+  });
+
+  tearDown(() {
+    controller.dispose();
+  });
+
+  testWidgets('GraphViewCanvasToolbar renders provided status message',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            onAddState: () {},
+            statusMessage: '2 states · 1 transition',
+            layout: GraphViewCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.text('2 states · 1 transition'), findsOneWidget);
+  });
+
+  testWidgets('GraphViewCanvasToolbar hides status message when absent',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            onAddState: () {},
+            layout: GraphViewCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.textContaining('states'), findsNothing);
+    expect(find.textContaining('transition'), findsNothing);
+  });
+
+  testWidgets('Desktop layout renders expected actions', (tester) async {
+    bool addStateInvoked = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            onAddState: () => addStateInvoked = true,
+            layout: GraphViewCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(IconButton), findsNWidgets(7));
+
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.add));
+    await tester.pump();
+
+    expect(addStateInvoked, isTrue);
+  });
+
+  testWidgets('Mobile layout renders filled buttons with labels', (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            onAddState: () {},
+            layout: GraphViewCanvasToolbarLayout.mobile,
+          ),
+        ),
+      ),
+    );
+
+    expect(find.byType(FilledButton), findsNWidgets(7));
+    expect(find.text('Add state'), findsOneWidget);
+    expect(find.text('Zoom in'), findsOneWidget);
+  });
+
+  testWidgets('invokes controller commands when action buttons pressed',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            onAddState: () {},
+            layout: GraphViewCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.zoom_in));
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.zoom_out));
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.fit_screen));
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.center_focus_strong));
+    await tester.pump();
+
+    expect(controller.zoomInCount, 1);
+    expect(controller.zoomOutCount, 1);
+    expect(controller.fitCount, 1);
+    expect(controller.resetCount, 1);
+  });
+
+  testWidgets('renders undo and redo buttons respecting history state',
+      (tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            onAddState: controller.addStateAtCenter,
+            layout: GraphViewCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    final undoFinder =
+        find.widgetWithIcon(IconButton, Icons.undo);
+    final redoFinder =
+        find.widgetWithIcon(IconButton, Icons.redo);
+
+    expect(
+      tester.widget<IconButton>(undoFinder).onPressed,
+      isNull,
+    );
+    expect(
+      tester.widget<IconButton>(redoFinder).onPressed,
+      isNull,
+    );
+
+    controller.addStateAtCenter();
+    await tester.pump();
+
+    expect(
+      tester.widget<IconButton>(undoFinder).onPressed,
+      isNotNull,
+    );
+
+    controller.undo();
+    await tester.pump();
+
+    expect(
+      tester.widget<IconButton>(redoFinder).onPressed,
+      isNotNull,
+    );
+  });
+
+  testWidgets('renders editing tool toggles when enabled', (tester) async {
+    bool selectionInvoked = false;
+    bool transitionInvoked = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewCanvasToolbar(
+            controller: controller,
+            enableToolSelection: true,
+            activeTool: AutomatonCanvasTool.transition,
+            onSelectTool: () => selectionInvoked = true,
+            onAddState: () {},
+            onAddTransition: () => transitionInvoked = true,
+            layout: GraphViewCanvasToolbarLayout.desktop,
+          ),
+        ),
+      ),
+    );
+
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.pan_tool));
+    await tester.tap(find.widgetWithIcon(IconButton, Icons.arrow_right_alt));
+    await tester.pump();
+
+    expect(selectionInvoked, isTrue);
+    expect(transitionInvoked, isTrue);
+  });
+}

--- a/test/widget/presentation/graphview_label_field_editor_test.dart
+++ b/test/widget/presentation/graphview_label_field_editor_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:jflutter/features/canvas/graphview/graphview_label_field_editor.dart';
+
+void main() {
+  testWidgets('GraphViewLabelFieldEditor submits value on Enter',
+      (tester) async {
+    String? submitted;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewLabelFieldEditor(
+            initialValue: 'q0',
+            onSubmit: (value) => submitted = value,
+            onCancel: () {},
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'q1');
+    await tester.sendKeyEvent(LogicalKeyboardKey.enter);
+    await tester.pump();
+
+    expect(submitted, 'q1');
+  });
+
+  testWidgets('GraphViewLabelFieldEditor cancels on Escape',
+      (tester) async {
+    var canceled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: GraphViewLabelFieldEditor(
+            initialValue: 'q0',
+            onSubmit: (_) {},
+            onCancel: () => canceled = true,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.enterText(find.byType(TextField), 'q2');
+    await tester.sendKeyEvent(LogicalKeyboardKey.escape);
+    await tester.pump();
+
+    expect(canceled, isTrue);
+  });
+
+  testWidgets('GraphViewLabelFieldEditor cancels when focus is lost',
+      (tester) async {
+    var canceled = false;
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: Column(
+            children: [
+              GraphViewLabelFieldEditor(
+                initialValue: 'q0',
+                onSubmit: (_) {},
+                onCancel: () => canceled = true,
+              ),
+              const TextField(key: Key('other')),
+            ],
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    await tester.tap(find.byKey(const Key('other')));
+    await tester.pump();
+
+    expect(canceled, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add a GraphView-driven canvas toolbar that mirrors the fl_nodes UI while calling the new controller helpers
- port the inline label editor and link overlay utilities to GraphView and wire them into `AutomatonGraphViewCanvas`
- cover the new toolbar and label editor with widget tests for keyboard shortcuts and focus handling

## Testing
- not run (flutter unavailable in execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68e1b8a072e0832ebd22707b605f77f9