### PR TITLE
Add GraphView PDA/TM canvas controllers and widgets

### DIFF
--- a/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
@@ -1,0 +1,253 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/pda.dart';
+import '../../../presentation/providers/pda_editor_provider.dart';
+import 'base_graphview_canvas_controller.dart';
+import 'graphview_canvas_models.dart';
+import 'graphview_pda_mapper.dart';
+
+/// Controller responsible for synchronising GraphView with the
+/// [PDAEditorNotifier].
+class GraphViewPdaCanvasController
+    extends BaseGraphViewCanvasController<PDAEditorNotifier, PDA> {
+  GraphViewPdaCanvasController({
+    required PDAEditorNotifier editorNotifier,
+    Graph? graph,
+    GraphViewController? viewController,
+    TransformationController? transformationController,
+  }) : super(
+          notifier: editorNotifier,
+          graph: graph,
+          viewController: viewController,
+          transformationController: transformationController,
+        );
+
+  PDAEditorNotifier get _notifier => notifier;
+
+  @override
+  PDA? get currentDomainData => _notifier.state.pda;
+
+  @override
+  GraphViewAutomatonSnapshot toSnapshot(PDA? automaton) {
+    return GraphViewPdaMapper.toSnapshot(automaton);
+  }
+
+  /// Synchronises the GraphView controller with the latest [automaton].
+  void synchronize(PDA? automaton) {
+    synchronizeGraph(automaton);
+  }
+
+  String _generateNodeId() {
+    final reservedIds = <String>{...nodesCache.keys};
+    final automaton = _notifier.state.pda;
+    if (automaton != null) {
+      for (final state in automaton.states) {
+        reservedIds.add(state.id);
+      }
+    }
+    var index = 0;
+    while (true) {
+      final candidate = 'state_$index';
+      if (!reservedIds.contains(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+  }
+
+  String _generateEdgeId() {
+    final reservedIds = <String>{...edgesCache.keys};
+    final automaton = _notifier.state.pda;
+    if (automaton != null) {
+      for (final transition in automaton.pdaTransitions) {
+        reservedIds.add(transition.id);
+      }
+    }
+    var index = 0;
+    while (true) {
+      final candidate = 'transition_$index';
+      if (!reservedIds.contains(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+  }
+
+  String _nextAvailableStateLabel() {
+    final reservedLabels = <String>{};
+    final automaton = _notifier.state.pda;
+    if (automaton != null) {
+      for (final state in automaton.states) {
+        final label = state.label.trim();
+        if (label.isNotEmpty) {
+          reservedLabels.add(label);
+        }
+      }
+    }
+    for (final node in nodesCache.values) {
+      final label = node.label.trim();
+      if (label.isNotEmpty) {
+        reservedLabels.add(label);
+      }
+    }
+
+    var index = 0;
+    while (reservedLabels.contains('q$index')) {
+      index++;
+    }
+    return 'q$index';
+  }
+
+  /// Adds a new state centred in the current viewport.
+  void addStateAtCenter() {
+    addStateAt(Offset.zero);
+  }
+
+  /// Adds a new state at the provided [worldPosition].
+  void addStateAt(Offset worldPosition) {
+    final nodeId = _generateNodeId();
+    final label = _nextAvailableStateLabel();
+    performMutation(() {
+      _notifier.addOrUpdateState(
+        id: nodeId,
+        label: label,
+        x: worldPosition.dx,
+        y: worldPosition.dy,
+      );
+    });
+  }
+
+  /// Moves an existing state to a new [position].
+  void moveState(String id, Offset position) {
+    performMutation(() {
+      _notifier.moveState(
+        id: id,
+        x: position.dx,
+        y: position.dy,
+      );
+    });
+  }
+
+  /// Updates the label displayed for the state identified by [id].
+  void updateStateLabel(String id, String label) {
+    final resolvedLabel = label.isEmpty ? id : label;
+    performMutation(() {
+      _notifier.updateStateLabel(
+        id: id,
+        label: resolvedLabel,
+      );
+    });
+  }
+
+  /// Updates the flag metadata for the state identified by [id].
+  void updateStateFlags(String id, {bool? isInitial, bool? isAccepting}) {
+    performMutation(() {
+      _notifier.updateStateFlags(
+        id: id,
+        isInitial: isInitial,
+        isAccepting: isAccepting,
+      );
+    });
+  }
+
+  /// Removes the state identified by [id] from the automaton.
+  void removeState(String id) {
+    performMutation(() {
+      _notifier.removeState(id: id);
+    });
+  }
+
+  /// Adds or updates a transition between [fromStateId] and [toStateId].
+  void addOrUpdateTransition({
+    required String fromStateId,
+    required String toStateId,
+    String? readSymbol,
+    String? popSymbol,
+    String? pushSymbol,
+    bool? isLambdaInput,
+    bool? isLambdaPop,
+    bool? isLambdaPush,
+    String? transitionId,
+    double? controlPointX,
+    double? controlPointY,
+  }) {
+    final edgeId = transitionId ?? _generateEdgeId();
+    final controlPoint = (controlPointX != null && controlPointY != null)
+        ? Vector2(controlPointX, controlPointY)
+        : null;
+    performMutation(() {
+      _notifier.upsertTransition(
+        id: edgeId,
+        fromStateId: fromStateId,
+        toStateId: toStateId,
+        readSymbol: readSymbol,
+        popSymbol: popSymbol,
+        pushSymbol: pushSymbol,
+        isLambdaInput: isLambdaInput,
+        isLambdaPop: isLambdaPop,
+        isLambdaPush: isLambdaPush,
+        controlPoint: controlPoint,
+      );
+    });
+  }
+
+  /// Updates only the geometry of the transition identified by [id].
+  void updateTransitionControlPoint(
+    String id,
+    double controlPointX,
+    double controlPointY,
+  ) {
+    performMutation(() {
+      _notifier.upsertTransition(
+        id: id,
+        controlPoint: Vector2(controlPointX, controlPointY),
+      );
+    });
+  }
+
+  /// Removes the transition identified by [id] from the automaton.
+  void removeTransition(String id) {
+    performMutation(() {
+      _notifier.removeTransition(id: id);
+    });
+  }
+
+  @override
+  void applySnapshotToDomain(GraphViewAutomatonSnapshot snapshot) {
+    final template = _notifier.state.pda ??
+        PDA(
+          id: snapshot.metadata.id ??
+              'pda_${DateTime.now().microsecondsSinceEpoch}',
+          name: snapshot.metadata.name ?? 'Canvas PDA',
+          states: const {},
+          transitions: const {},
+          alphabet: snapshot.metadata.alphabet.toSet(),
+          initialState: null,
+          acceptingStates: const {},
+          created: DateTime.now(),
+          modified: DateTime.now(),
+          bounds: const math.Rectangle<double>(0, 0, 800, 600),
+          stackAlphabet: const {'Z'},
+          initialStackSymbol: 'Z',
+          panOffset: Vector2.zero(),
+          zoomLevel: 1.0,
+        );
+
+    final merged = GraphViewPdaMapper.mergeIntoTemplate(snapshot, template)
+        .copyWith(
+      id: snapshot.metadata.id ?? template.id,
+      name: snapshot.metadata.name ?? template.name,
+      alphabet: snapshot.metadata.alphabet.isNotEmpty
+          ? snapshot.metadata.alphabet.toSet()
+          : template.alphabet,
+      modified: DateTime.now(),
+    );
+
+    _notifier.setPda(merged);
+    synchronize(merged);
+  }
+}

--- a/lib/features/canvas/graphview/graphview_pda_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_pda_mapper.dart
@@ -1,0 +1,162 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/pda.dart';
+import '../../../core/models/pda_transition.dart';
+import '../../../core/models/state.dart';
+import '../../../core/models/transition.dart';
+import 'graphview_canvas_models.dart';
+
+/// Converts between [PDA] instances and GraphView snapshots consumed by the PDA
+/// canvas controller.
+class GraphViewPdaMapper {
+  const GraphViewPdaMapper._();
+
+  /// Converts the provided [automaton] into a GraphView snapshot.
+  static GraphViewAutomatonSnapshot toSnapshot(PDA? automaton) {
+    if (automaton == null) {
+      return const GraphViewAutomatonSnapshot.empty();
+    }
+
+    final nodes = automaton.states.map((state) {
+      return GraphViewCanvasNode(
+        id: state.id,
+        label: state.label,
+        x: state.position.x,
+        y: state.position.y,
+        isInitial: automaton.initialState?.id == state.id,
+        isAccepting: automaton.acceptingStates.any(
+          (candidate) => candidate.id == state.id,
+        ),
+      );
+    }).toList();
+
+    final edges = automaton.pdaTransitions.map((transition) {
+      return GraphViewCanvasEdge(
+        id: transition.id,
+        fromStateId: transition.fromState.id,
+        toStateId: transition.toState.id,
+        symbols: const <String>[],
+        controlPointX: transition.controlPoint.x,
+        controlPointY: transition.controlPoint.y,
+        readSymbol: transition.inputSymbol,
+        popSymbol: transition.popSymbol,
+        pushSymbol: transition.pushSymbol,
+        isLambdaInput: transition.isLambdaInput,
+        isLambdaPop: transition.isLambdaPop,
+        isLambdaPush: transition.isLambdaPush,
+      );
+    }).toList();
+
+    final metadata = GraphViewAutomatonMetadata(
+      id: automaton.id,
+      name: automaton.name,
+      alphabet: automaton.alphabet.toList(),
+    );
+
+    return GraphViewAutomatonSnapshot(
+      nodes: nodes,
+      edges: edges,
+      metadata: metadata,
+    );
+  }
+
+  /// Rebuilds a [PDA] template with the data contained in [snapshot].
+  static PDA mergeIntoTemplate(
+    GraphViewAutomatonSnapshot snapshot,
+    PDA template,
+  ) {
+    final states = snapshot.nodes
+        .map(
+          (node) => State(
+            id: node.id,
+            label: node.label,
+            position: Vector2(node.x, node.y),
+            isInitial: node.isInitial,
+            isAccepting: node.isAccepting,
+          ),
+        )
+        .toSet();
+
+    final stateMap = {for (final state in states) state.id: state};
+
+    final transitions = snapshot.edges.map((edge) {
+      final fromState = stateMap[edge.fromStateId];
+      final toState = stateMap[edge.toStateId];
+      if (fromState == null || toState == null) {
+        throw StateError('Edge references missing state: ${edge.toJson()}');
+      }
+
+      final controlPoint =
+          (edge.controlPointX != null && edge.controlPointY != null)
+              ? Vector2(edge.controlPointX!, edge.controlPointY!)
+              : Vector2.zero();
+
+      final isLambdaInput =
+          edge.isLambdaInput ?? (edge.readSymbol?.isEmpty ?? true);
+      final isLambdaPop =
+          edge.isLambdaPop ?? (edge.popSymbol?.isEmpty ?? true);
+      final isLambdaPush =
+          edge.isLambdaPush ?? (edge.pushSymbol?.isEmpty ?? true);
+
+      return PDATransition(
+        id: edge.id,
+        fromState: fromState,
+        toState: toState,
+        label: edge.label,
+        controlPoint: controlPoint,
+        type: TransitionType.deterministic,
+        inputSymbol: edge.readSymbol ?? '',
+        popSymbol: edge.popSymbol ?? '',
+        pushSymbol: edge.pushSymbol ?? '',
+        isLambdaInput: isLambdaInput,
+        isLambdaPop: isLambdaPop,
+        isLambdaPush: isLambdaPush,
+      );
+    }).toSet();
+
+    final acceptingStates = {
+      for (final node in snapshot.nodes.where((node) => node.isAccepting))
+        stateMap[node.id]!,
+    };
+
+    GraphViewCanvasNode? initialNode;
+    for (final node in snapshot.nodes) {
+      if (node.isInitial) {
+        initialNode = node;
+        break;
+      }
+    }
+
+    final alphabet = <String>{
+      ...template.alphabet,
+      for (final edge in snapshot.edges)
+        if (!(edge.isLambdaInput ?? false) &&
+            (edge.readSymbol != null && edge.readSymbol!.isNotEmpty))
+          edge.readSymbol!,
+    };
+
+    final stackAlphabet = <String>{
+      ...template.stackAlphabet,
+      for (final edge in snapshot.edges)
+        if (!(edge.isLambdaPop ?? false) &&
+            (edge.popSymbol != null && edge.popSymbol!.isNotEmpty))
+          edge.popSymbol!,
+      for (final edge in snapshot.edges)
+        if (!(edge.isLambdaPush ?? false) &&
+            (edge.pushSymbol != null && edge.pushSymbol!.isNotEmpty))
+          edge.pushSymbol!,
+    };
+
+    final initialState =
+        initialNode != null ? stateMap[initialNode.id] : template.initialState;
+
+    return template.copyWith(
+      states: states,
+      transitions: transitions.map<Transition>((t) => t).toSet(),
+      acceptingStates: acceptingStates,
+      initialState: initialState,
+      alphabet: alphabet,
+      stackAlphabet: stackAlphabet,
+    );
+  }
+}

--- a/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
@@ -1,0 +1,260 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:graphview/GraphView.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/tm.dart';
+import '../../../core/models/tm_transition.dart';
+import '../../../presentation/providers/tm_editor_provider.dart';
+import 'base_graphview_canvas_controller.dart';
+import 'graphview_canvas_models.dart';
+import 'graphview_tm_mapper.dart';
+
+/// Controller responsible for synchronising GraphView with the
+/// [TMEditorNotifier].
+class GraphViewTmCanvasController
+    extends BaseGraphViewCanvasController<TMEditorNotifier, TM> {
+  GraphViewTmCanvasController({
+    required TMEditorNotifier editorNotifier,
+    Graph? graph,
+    GraphViewController? viewController,
+    TransformationController? transformationController,
+  }) : super(
+          notifier: editorNotifier,
+          graph: graph,
+          viewController: viewController,
+          transformationController: transformationController,
+        );
+
+  TMEditorNotifier get _notifier => notifier;
+
+  @override
+  TM? get currentDomainData => _notifier.state.tm;
+
+  @override
+  GraphViewAutomatonSnapshot toSnapshot(TM? machine) {
+    return GraphViewTmMapper.toSnapshot(machine);
+  }
+
+  /// Synchronises the GraphView controller with the latest [machine].
+  void synchronize(TM? machine) {
+    synchronizeGraph(machine);
+  }
+
+  String _generateNodeId() {
+    final reservedIds = <String>{...nodesCache.keys};
+    final machine = _notifier.state.tm;
+    if (machine != null) {
+      for (final state in machine.states) {
+        reservedIds.add(state.id);
+      }
+    }
+    var index = 0;
+    while (true) {
+      final candidate = 'state_$index';
+      if (!reservedIds.contains(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+  }
+
+  String _generateEdgeId() {
+    final reservedIds = <String>{...edgesCache.keys};
+    final machine = _notifier.state.tm;
+    if (machine != null) {
+      for (final transition in machine.tmTransitions) {
+        reservedIds.add(transition.id);
+      }
+    }
+    var index = 0;
+    while (true) {
+      final candidate = 'transition_$index';
+      if (!reservedIds.contains(candidate)) {
+        return candidate;
+      }
+      index++;
+    }
+  }
+
+  String _nextAvailableStateLabel() {
+    final reservedLabels = <String>{};
+    final machine = _notifier.state.tm;
+    if (machine != null) {
+      for (final state in machine.states) {
+        final label = state.label.trim();
+        if (label.isNotEmpty) {
+          reservedLabels.add(label);
+        }
+      }
+    }
+    for (final node in nodesCache.values) {
+      final label = node.label.trim();
+      if (label.isNotEmpty) {
+        reservedLabels.add(label);
+      }
+    }
+
+    var index = 0;
+    while (reservedLabels.contains('q$index')) {
+      index++;
+    }
+    return 'q$index';
+  }
+
+  /// Adds a new state centred in the current viewport.
+  void addStateAtCenter() {
+    addStateAt(Offset.zero);
+  }
+
+  /// Adds a new state at the provided [worldPosition].
+  void addStateAt(Offset worldPosition) {
+    final nodeId = _generateNodeId();
+    final label = _nextAvailableStateLabel();
+    performMutation(() {
+      _notifier.upsertState(
+        id: nodeId,
+        label: label,
+        x: worldPosition.dx,
+        y: worldPosition.dy,
+      );
+    });
+  }
+
+  /// Moves an existing state to a new [position].
+  void moveState(String id, Offset position) {
+    performMutation(() {
+      _notifier.moveState(
+        id: id,
+        x: position.dx,
+        y: position.dy,
+      );
+    });
+  }
+
+  /// Updates the label displayed for the state identified by [id].
+  void updateStateLabel(String id, String label) {
+    final resolvedLabel = label.isEmpty ? id : label;
+    performMutation(() {
+      _notifier.updateStateLabel(
+        id: id,
+        label: resolvedLabel,
+      );
+    });
+  }
+
+  /// Updates the flag metadata for the state identified by [id].
+  void updateStateFlags(String id, {bool? isInitial, bool? isAccepting}) {
+    performMutation(() {
+      _notifier.updateStateFlags(
+        id: id,
+        isInitial: isInitial,
+        isAccepting: isAccepting,
+      );
+    });
+  }
+
+  /// Removes the state identified by [id] from the machine.
+  void removeState(String id) {
+    performMutation(() {
+      _notifier.removeState(id: id);
+    });
+  }
+
+  /// Adds or updates a TM transition between [fromStateId] and [toStateId].
+  void addOrUpdateTransition({
+    required String fromStateId,
+    required String toStateId,
+    String? readSymbol,
+    String? writeSymbol,
+    TapeDirection? direction,
+    String? transitionId,
+    double? controlPointX,
+    double? controlPointY,
+  }) {
+    final edgeId = transitionId ?? _generateEdgeId();
+    final controlPoint = (controlPointX != null && controlPointY != null)
+        ? Vector2(controlPointX, controlPointY)
+        : null;
+    performMutation(() {
+      _notifier.addOrUpdateTransition(
+        id: edgeId,
+        fromStateId: fromStateId,
+        toStateId: toStateId,
+        readSymbol: readSymbol,
+        writeSymbol: writeSymbol,
+        direction: direction,
+        controlPoint: controlPoint,
+      );
+    });
+  }
+
+  /// Updates the control point for the transition identified by [id].
+  void updateTransitionControlPoint(
+    String id,
+    double controlPointX,
+    double controlPointY,
+  ) {
+    final edge = edgeById(id);
+    if (edge == null) {
+      return;
+    }
+
+    addOrUpdateTransition(
+      fromStateId: edge.fromStateId,
+      toStateId: edge.toStateId,
+      readSymbol: edge.readSymbol,
+      writeSymbol: edge.writeSymbol,
+      direction: edge.direction,
+      transitionId: id,
+      controlPointX: controlPointX,
+      controlPointY: controlPointY,
+    );
+  }
+
+  /// Removes the transition identified by [id] from the machine.
+  void removeTransition(String id) {
+    performMutation(() {
+      _notifier.removeTransition(id: id);
+    });
+  }
+
+  @override
+  void applySnapshotToDomain(GraphViewAutomatonSnapshot snapshot) {
+    final template = _notifier.state.tm ??
+        TM(
+          id: snapshot.metadata.id ??
+              'tm_${DateTime.now().microsecondsSinceEpoch}',
+          name: snapshot.metadata.name ?? 'Canvas TM',
+          states: const {},
+          transitions: const {},
+          alphabet: snapshot.metadata.alphabet.toSet(),
+          initialState: null,
+          acceptingStates: const {},
+          created: DateTime.now(),
+          modified: DateTime.now(),
+          bounds: const math.Rectangle<double>(0, 0, 800, 600),
+          tapeAlphabet: snapshot.metadata.alphabet.toSet().isEmpty
+              ? const {'B'}
+              : snapshot.metadata.alphabet.toSet(),
+          blankSymbol: 'B',
+          tapeCount: 1,
+          panOffset: Vector2.zero(),
+          zoomLevel: 1.0,
+        );
+
+    final merged = GraphViewTmMapper.mergeIntoTemplate(snapshot, template)
+        .copyWith(
+      id: snapshot.metadata.id ?? template.id,
+      name: snapshot.metadata.name ?? template.name,
+      tapeAlphabet: snapshot.metadata.alphabet.isNotEmpty
+          ? snapshot.metadata.alphabet.toSet()
+          : template.tapeAlphabet,
+      modified: DateTime.now(),
+    );
+
+    _notifier.setTm(merged);
+    synchronize(merged);
+  }
+}

--- a/lib/features/canvas/graphview/graphview_tm_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_tm_mapper.dart
@@ -1,0 +1,141 @@
+import 'package:vector_math/vector_math_64.dart';
+
+import '../../../core/models/state.dart';
+import '../../../core/models/tm.dart';
+import '../../../core/models/tm_transition.dart';
+import '../../../core/models/transition.dart';
+import 'graphview_canvas_models.dart';
+
+/// Converts between [TM] instances and GraphView snapshots consumed by the TM
+/// canvas controller.
+class GraphViewTmMapper {
+  const GraphViewTmMapper._();
+
+  /// Converts the provided Turing Machine into a GraphView snapshot.
+  static GraphViewAutomatonSnapshot toSnapshot(TM? machine) {
+    if (machine == null) {
+      return const GraphViewAutomatonSnapshot.empty();
+    }
+
+    final nodes = machine.states.map((state) {
+      return GraphViewCanvasNode(
+        id: state.id,
+        label: state.label,
+        x: state.position.x,
+        y: state.position.y,
+        isInitial: machine.initialState?.id == state.id,
+        isAccepting: machine.acceptingStates.any(
+          (candidate) => candidate.id == state.id,
+        ),
+      );
+    }).toList();
+
+    final edges = machine.tmTransitions.map((transition) {
+      return GraphViewCanvasEdge(
+        id: transition.id,
+        fromStateId: transition.fromState.id,
+        toStateId: transition.toState.id,
+        symbols: const <String>[],
+        controlPointX: transition.controlPoint.x,
+        controlPointY: transition.controlPoint.y,
+        readSymbol: transition.readSymbol,
+        writeSymbol: transition.writeSymbol,
+        direction: transition.direction,
+        tapeNumber: transition.tapeNumber,
+      );
+    }).toList();
+
+    final metadata = GraphViewAutomatonMetadata(
+      id: machine.id,
+      name: machine.name,
+      alphabet: machine.alphabet.toList(),
+    );
+
+    return GraphViewAutomatonSnapshot(
+      nodes: nodes,
+      edges: edges,
+      metadata: metadata,
+    );
+  }
+
+  /// Rebuilds a [TM] template using the data contained in [snapshot].
+  static TM mergeIntoTemplate(
+    GraphViewAutomatonSnapshot snapshot,
+    TM template,
+  ) {
+    final states = snapshot.nodes
+        .map(
+          (node) => State(
+            id: node.id,
+            label: node.label,
+            position: Vector2(node.x, node.y),
+            isInitial: node.isInitial,
+            isAccepting: node.isAccepting,
+          ),
+        )
+        .toSet();
+
+    final stateMap = {for (final state in states) state.id: state};
+
+    final transitions = snapshot.edges.map((edge) {
+      final fromState = stateMap[edge.fromStateId];
+      final toState = stateMap[edge.toStateId];
+      if (fromState == null || toState == null) {
+        throw StateError('Edge references missing state: ${edge.toJson()}');
+      }
+
+      final controlPoint =
+          (edge.controlPointX != null && edge.controlPointY != null)
+              ? Vector2(edge.controlPointX!, edge.controlPointY!)
+              : Vector2.zero();
+
+      final direction = edge.direction ?? TapeDirection.right;
+
+      return TMTransition(
+        id: edge.id,
+        fromState: fromState,
+        toState: toState,
+        label: edge.label,
+        controlPoint: controlPoint,
+        readSymbol: edge.readSymbol ?? '',
+        writeSymbol: edge.writeSymbol ?? '',
+        direction: direction,
+        tapeNumber: edge.tapeNumber ?? 0,
+      );
+    }).toSet();
+
+    final acceptingStates = {
+      for (final node in snapshot.nodes.where((node) => node.isAccepting))
+        stateMap[node.id]!,
+    };
+
+    GraphViewCanvasNode? initialNode;
+    for (final node in snapshot.nodes) {
+      if (node.isInitial) {
+        initialNode = node;
+        break;
+      }
+    }
+
+    final alphabet = <String>{
+      ...template.alphabet,
+      for (final edge in snapshot.edges)
+        if (edge.readSymbol != null && edge.readSymbol!.isNotEmpty)
+          edge.readSymbol!,
+      for (final edge in snapshot.edges)
+        if (edge.writeSymbol != null && edge.writeSymbol!.isNotEmpty)
+          edge.writeSymbol!,
+    };
+
+    final initialState =
+        initialNode != null ? stateMap[initialNode.id] : template.initialState;
+
+    return template.copyWith(
+      states: states,
+      transitions: transitions.map<Transition>((t) => t).toSet(),
+      acceptingStates: acceptingStates,
+      initialState: initialState,
+      alphabet: alphabet,
+    );
+  }
+}

--- a/lib/presentation/widgets/pda_canvas_graphview.dart
+++ b/lib/presentation/widgets/pda_canvas_graphview.dart
@@ -1,0 +1,853 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphview/GraphView.dart';
+
+import '../../core/models/pda.dart';
+import '../../core/models/simulation_highlight.dart';
+import '../../core/services/simulation_highlight_service.dart';
+import '../../features/canvas/graphview/graphview_pda_canvas_controller.dart';
+import '../../features/canvas/graphview/graphview_canvas_models.dart';
+import '../../features/canvas/graphview/graphview_highlight_channel.dart';
+import '../providers/pda_editor_provider.dart';
+import 'transition_editors/pda_transition_editor.dart';
+
+class PDACanvasGraphView extends ConsumerStatefulWidget {
+  const PDACanvasGraphView({
+    super.key,
+    required this.onPdaModified,
+    this.controller,
+  });
+
+  final ValueChanged<PDA> onPdaModified;
+  final GraphViewPdaCanvasController? controller;
+
+  @override
+  ConsumerState<PDACanvasGraphView> createState() =>
+      _PDACanvasGraphViewState();
+}
+
+class _PDACanvasGraphViewState extends ConsumerState<PDACanvasGraphView> {
+  late GraphViewPdaCanvasController _canvasController;
+  late bool _ownsController;
+  late SugiyamaAlgorithm _algorithm;
+  ProviderSubscription<PDAEditorState>? _subscription;
+  PDA? _lastDeliveredPda;
+  SimulationHighlightService? _highlightService;
+  SimulationHighlightChannel? _previousHighlightChannel;
+  GraphViewSimulationHighlightChannel? _highlightChannel;
+  final GlobalKey _canvasKey = GlobalKey();
+
+  GraphViewPdaCanvasController get controller => _canvasController;
+
+  @override
+  void initState() {
+    super.initState();
+    final externalController = widget.controller;
+    if (externalController != null) {
+      _canvasController = externalController;
+      _ownsController = false;
+    } else {
+      _canvasController = GraphViewPdaCanvasController(
+        editorNotifier: ref.read(pdaEditorProvider.notifier),
+      );
+      _ownsController = true;
+      final highlightService = ref.read(canvasHighlightServiceProvider);
+      _highlightService = highlightService;
+      _previousHighlightChannel = highlightService.channel;
+      final highlightChannel = GraphViewSimulationHighlightChannel(
+        _canvasController,
+      );
+      _highlightChannel = highlightChannel;
+      highlightService.channel = highlightChannel;
+    }
+
+    _algorithm = SugiyamaAlgorithm(SugiyamaConfiguration()
+      ..nodeSeparation = 160
+      ..levelSeparation = 160
+      ..orientation = SugiyamaConfiguration.ORIENTATION_TOP_BOTTOM);
+
+    final initialState = ref.read(pdaEditorProvider);
+    _canvasController.synchronize(initialState.pda);
+    if (initialState.pda?.states.isNotEmpty ?? false) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _canvasController.fitToContent();
+      });
+    }
+
+    _lastDeliveredPda = initialState.pda;
+    if (initialState.pda != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        widget.onPdaModified(initialState.pda!);
+      });
+    }
+
+    _subscription = ref.listenManual<PDAEditorState>(
+      pdaEditorProvider,
+      (previous, next) {
+        if (!mounted) return;
+        final pda = next.pda;
+        if (pda != null && !identical(pda, _lastDeliveredPda)) {
+          _lastDeliveredPda = pda;
+          widget.onPdaModified(pda);
+        } else if (pda == null) {
+          _lastDeliveredPda = null;
+        }
+        if (_shouldSynchronize(previous, next)) {
+          final hadNodes = _canvasController.nodes.isNotEmpty;
+          _canvasController.synchronize(pda);
+          if (!hadNodes && (pda?.states.isNotEmpty ?? false)) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              _canvasController.fitToContent();
+            });
+          }
+        }
+      },
+    );
+  }
+
+  bool _shouldSynchronize(PDAEditorState? previous, PDAEditorState next) {
+    final pda = next.pda;
+    if (pda == null) {
+      return true;
+    }
+    if (previous?.pda == null) {
+      return true;
+    }
+
+    final nodeIds = {for (final node in _canvasController.nodes) node.id};
+    final stateIds = {for (final state in pda.states) state.id};
+    if (nodeIds.length != stateIds.length || !nodeIds.containsAll(stateIds)) {
+      return true;
+    }
+
+    final edgeIds = {for (final edge in _canvasController.edges) edge.id};
+    final transitionIds = {
+      for (final transition in pda.pdaTransitions) transition.id
+    };
+    if (edgeIds.length != transitionIds.length ||
+        !edgeIds.containsAll(transitionIds)) {
+      return true;
+    }
+
+    for (final state in pda.states) {
+      final node = _canvasController.nodeById(state.id);
+      if (node == null) {
+        return true;
+      }
+      if ((node.x - state.position.x).abs() > 0.5 ||
+          (node.y - state.position.y).abs() > 0.5) {
+        return true;
+      }
+      if (node.label.trim() != state.label.trim()) {
+        return true;
+      }
+    }
+
+    for (final transition in pda.pdaTransitions) {
+      final edge = _canvasController.edgeById(transition.id);
+      if (edge == null) {
+        return true;
+      }
+      if (edge.fromStateId != transition.fromState.id ||
+          edge.toStateId != transition.toState.id) {
+        return true;
+      }
+      final controlPoint = transition.controlPoint;
+      final edgeX = edge.controlPointX ?? controlPoint.x;
+      final edgeY = edge.controlPointY ?? controlPoint.y;
+      if ((edgeX - controlPoint.x).abs() > 0.5 ||
+          (edgeY - controlPoint.y).abs() > 0.5) {
+        return true;
+      }
+      final read = transition.inputSymbol;
+      final pop = transition.popSymbol;
+      final push = transition.pushSymbol;
+      final edgeRead = edge.readSymbol ?? '';
+      final edgePop = edge.popSymbol ?? '';
+      final edgePush = edge.pushSymbol ?? '';
+      if (edgeRead.trim() != read.trim() ||
+          edgePop.trim() != pop.trim() ||
+          edgePush.trim() != push.trim()) {
+        return true;
+      }
+      if ((edge.isLambdaInput ?? false) != transition.isLambdaInput ||
+          (edge.isLambdaPop ?? false) != transition.isLambdaPop ||
+          (edge.isLambdaPush ?? false) != transition.isLambdaPush) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    if (_ownsController) {
+      _canvasController.dispose();
+    }
+    if (_highlightService != null) {
+      _highlightService!.channel = _previousHighlightChannel;
+      _highlightChannel = null;
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(child: _buildCanvas(context)),
+        const SizedBox(height: 12),
+        SizedBox(
+          height: 240,
+          child: _buildInspector(context),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCanvas(BuildContext context) {
+    final theme = Theme.of(context);
+    return GestureDetector(
+      key: _canvasKey,
+      onDoubleTap: _handleAddStateAtCenter,
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: ValueListenableBuilder<int>(
+            valueListenable: _canvasController.graphRevision,
+            builder: (context, _, __) {
+              final nodes =
+                  _canvasController.nodes.toList(growable: false);
+              final edges =
+                  _canvasController.edges.toList(growable: false);
+              return ValueListenableBuilder(
+                valueListenable: _canvasController.highlightNotifier,
+                builder: (context, highlight, __) {
+                  return Stack(
+                    children: [
+                      GraphView.builder(
+                        graph: _canvasController.graph,
+                        controller: _canvasController.graphController,
+                        algorithm: _algorithm,
+                        builder: (node) {
+                          final nodeId = node.key?.value?.toString();
+                          if (nodeId == null) {
+                            return const SizedBox.shrink();
+                          }
+                          final canvasNode =
+                              _canvasController.nodeById(nodeId);
+                          if (canvasNode == null) {
+                            return const SizedBox.shrink();
+                          }
+                          final isHighlighted =
+                              highlight.stateIds.contains(canvasNode.id);
+                          return _GraphNodeWidget(
+                            label: canvasNode.label,
+                            isInitial: canvasNode.isInitial,
+                            isAccepting: canvasNode.isAccepting,
+                            isHighlighted: isHighlighted,
+                          );
+                        },
+                      ),
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: CustomPaint(
+                            painter: _GraphEdgePainter(
+                              edges: edges,
+                              nodes: nodes,
+                              highlight: highlight,
+                              theme: theme,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  void _handleAddStateAtCenter() {
+    controller.addStateAtCenter();
+  }
+
+  Widget _buildInspector(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: ValueListenableBuilder<int>(
+          valueListenable: _canvasController.graphRevision,
+          builder: (context, _, __) {
+            final nodes =
+                _canvasController.nodes.toList(growable: false);
+            final edges =
+                _canvasController.edges.toList(growable: false);
+            return ListView(
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      'States',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      onPressed: () => _handleCreateState(context),
+                      icon: const Icon(Icons.add),
+                      label: const Text('Add state'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (nodes.isEmpty)
+                  Text(
+                    'No states yet. Double tap on the canvas or use the button above to add one.',
+                    style: theme.textTheme.bodyMedium,
+                  )
+                else
+                  ...nodes.map((node) => _buildStateTile(context, node)),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Text(
+                      'Transitions',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      onPressed:
+                          nodes.isEmpty ? null : () => _handleCreateTransition(context, nodes),
+                      icon: const Icon(Icons.add),
+                      label: const Text('Add transition'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (edges.isEmpty)
+                  Text(
+                    'Create transitions to define stack behaviour.',
+                    style: theme.textTheme.bodyMedium,
+                  )
+                else
+                  ...edges.map((edge) => _buildTransitionTile(context, edge)),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  void _handleCreateState(BuildContext context) {
+    controller.addStateAt(const Offset(0, 0));
+  }
+
+  Widget _buildStateTile(BuildContext context, GraphViewCanvasNode node) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    node.label.isEmpty ? node.id : node.label,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  tooltip: 'Rename state',
+                  onPressed: () => _handleRenameState(context, node),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: 'Remove state',
+                  onPressed: () => controller.removeState(node.id),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                FilterChip(
+                  label: const Text('Initial'),
+                  selected: node.isInitial,
+                  onSelected: (value) =>
+                      controller.updateStateFlags(node.id, isInitial: value),
+                ),
+                FilterChip(
+                  label: const Text('Accepting'),
+                  selected: node.isAccepting,
+                  onSelected: (value) => controller.updateStateFlags(
+                    node.id,
+                    isAccepting: value,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleRenameState(
+    BuildContext context,
+    GraphViewCanvasNode node,
+  ) async {
+    final labelController = TextEditingController(text: node.label);
+    final result = await showDialog<String?>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Rename state'),
+          content: TextField(
+            controller: labelController,
+            decoration: const InputDecoration(labelText: 'State label'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(null),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.of(context).pop(labelController.text.trim()),
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+    if (result != null) {
+      controller.updateStateLabel(node.id, result);
+    }
+  }
+
+  Widget _buildTransitionTile(
+    BuildContext context,
+    GraphViewCanvasEdge edge,
+  ) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: Text('${edge.fromStateId} → ${edge.toStateId}'),
+        subtitle: Text(edge.label),
+        trailing: Wrap(
+          spacing: 8,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.edit),
+              tooltip: 'Edit transition',
+              onPressed: () => _handleEditTransition(context, edge),
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Remove transition',
+              onPressed: () => controller.removeTransition(edge.id),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleEditTransition(
+    BuildContext context,
+    GraphViewCanvasEdge edge,
+  ) async {
+    final result = await showDialog<_PdaTransitionResult?>(
+      context: context,
+      builder: (context) {
+        return Dialog(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: PdaTransitionEditor(
+              initialRead: edge.readSymbol ?? '',
+              initialPop: edge.popSymbol ?? '',
+              initialPush: edge.pushSymbol ?? '',
+              isLambdaInput: edge.isLambdaInput ?? false,
+              isLambdaPop: edge.isLambdaPop ?? false,
+              isLambdaPush: edge.isLambdaPush ?? false,
+              onSubmit: ({
+                required String readSymbol,
+                required String popSymbol,
+                required String pushSymbol,
+                required bool lambdaInput,
+                required bool lambdaPop,
+                required bool lambdaPush,
+              }) {
+                Navigator.of(context).pop(
+                  _PdaTransitionResult(
+                    fromStateId: edge.fromStateId,
+                    toStateId: edge.toStateId,
+                    readSymbol: readSymbol,
+                    popSymbol: popSymbol,
+                    pushSymbol: pushSymbol,
+                    lambdaInput: lambdaInput,
+                    lambdaPop: lambdaPop,
+                    lambdaPush: lambdaPush,
+                    transitionId: edge.id,
+                    controlPointX: edge.controlPointX,
+                    controlPointY: edge.controlPointY,
+                  ),
+                );
+              },
+              onCancel: () => Navigator.of(context).pop(null),
+            ),
+          ),
+        );
+      },
+    );
+
+    if (result == null) {
+      return;
+    }
+
+    controller.addOrUpdateTransition(
+      fromStateId: result.fromStateId,
+      toStateId: result.toStateId,
+      readSymbol: result.readSymbol,
+      popSymbol: result.popSymbol,
+      pushSymbol: result.pushSymbol,
+      isLambdaInput: result.lambdaInput,
+      isLambdaPop: result.lambdaPop,
+      isLambdaPush: result.lambdaPush,
+      transitionId: result.transitionId,
+      controlPointX: result.controlPointX,
+      controlPointY: result.controlPointY,
+    );
+  }
+
+  Future<void> _handleCreateTransition(
+    BuildContext context,
+    List<GraphViewCanvasNode> nodes,
+  ) async {
+    if (nodes.isEmpty) {
+      return;
+    }
+
+    String fromStateId = nodes.first.id;
+    String toStateId = nodes.first.id;
+
+    final result = await showDialog<_PdaTransitionResult?>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return Dialog(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: fromStateId,
+                            decoration: const InputDecoration(
+                              labelText: 'From',
+                            ),
+                            items: nodes
+                                .map(
+                                  (node) => DropdownMenuItem(
+                                    value: node.id,
+                                    child: Text(node.label.isEmpty
+                                        ? node.id
+                                        : node.label),
+                                  ),
+                                )
+                                .toList(),
+                            onChanged: (value) {
+                              if (value != null) {
+                                setState(() => fromStateId = value);
+                              }
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: toStateId,
+                            decoration: const InputDecoration(
+                              labelText: 'To',
+                            ),
+                            items: nodes
+                                .map(
+                                  (node) => DropdownMenuItem(
+                                    value: node.id,
+                                    child: Text(node.label.isEmpty
+                                        ? node.id
+                                        : node.label),
+                                  ),
+                                )
+                                .toList(),
+                            onChanged: (value) {
+                              if (value != null) {
+                                setState(() => toStateId = value);
+                              }
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    PdaTransitionEditor(
+                      initialRead: '',
+                      initialPop: '',
+                      initialPush: '',
+                      isLambdaInput: true,
+                      isLambdaPop: true,
+                      isLambdaPush: true,
+                      onSubmit: ({
+                        required String readSymbol,
+                        required String popSymbol,
+                        required String pushSymbol,
+                        required bool lambdaInput,
+                        required bool lambdaPop,
+                        required bool lambdaPush,
+                      }) {
+                        Navigator.of(context).pop(
+                          _PdaTransitionResult(
+                            fromStateId: fromStateId,
+                            toStateId: toStateId,
+                            readSymbol: readSymbol,
+                            popSymbol: popSymbol,
+                            pushSymbol: pushSymbol,
+                            lambdaInput: lambdaInput,
+                            lambdaPop: lambdaPop,
+                            lambdaPush: lambdaPush,
+                          ),
+                        );
+                      },
+                      onCancel: () => Navigator.of(context).pop(null),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+
+    if (result == null) {
+      return;
+    }
+
+    controller.addOrUpdateTransition(
+      fromStateId: result.fromStateId,
+      toStateId: result.toStateId,
+      readSymbol: result.readSymbol,
+      popSymbol: result.popSymbol,
+      pushSymbol: result.pushSymbol,
+      isLambdaInput: result.lambdaInput,
+      isLambdaPop: result.lambdaPop,
+      isLambdaPush: result.lambdaPush,
+    );
+  }
+}
+
+class _PdaTransitionResult {
+  _PdaTransitionResult({
+    required this.fromStateId,
+    required this.toStateId,
+    required this.readSymbol,
+    required this.popSymbol,
+    required this.pushSymbol,
+    required this.lambdaInput,
+    required this.lambdaPop,
+    required this.lambdaPush,
+    this.transitionId,
+    this.controlPointX,
+    this.controlPointY,
+  });
+
+  final String fromStateId;
+  final String toStateId;
+  final String readSymbol;
+  final String popSymbol;
+  final String pushSymbol;
+  final bool lambdaInput;
+  final bool lambdaPop;
+  final bool lambdaPush;
+  final String? transitionId;
+  final double? controlPointX;
+  final double? controlPointY;
+}
+
+class _GraphNodeWidget extends StatelessWidget {
+  const _GraphNodeWidget({
+    required this.label,
+    required this.isInitial,
+    required this.isAccepting,
+    required this.isHighlighted,
+  });
+
+  final String label;
+  final bool isInitial;
+  final bool isAccepting;
+  final bool isHighlighted;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderColor = isHighlighted
+        ? theme.colorScheme.secondary
+        : theme.colorScheme.primary;
+    return Container(
+      width: 80,
+      height: 80,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: theme.colorScheme.surface,
+        border: Border.all(color: borderColor, width: 3),
+      ),
+      alignment: Alignment.center,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (isAccepting)
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: borderColor, width: 2),
+              ),
+            ),
+          Text(
+            label.isEmpty ? 'q' : label,
+            style: theme.textTheme.titleMedium,
+          ),
+          if (isInitial)
+            Positioned(
+              left: -24,
+              child: Icon(
+                Icons.play_arrow,
+                color: borderColor,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GraphEdgePainter extends CustomPainter {
+  _GraphEdgePainter({
+    required this.edges,
+    required this.nodes,
+    required this.highlight,
+    required this.theme,
+  });
+
+  final List<GraphViewCanvasEdge> edges;
+  final List<GraphViewCanvasNode> nodes;
+  final SimulationHighlight highlight;
+  final ThemeData theme;
+
+  GraphViewCanvasNode? _nodeById(String id) {
+    for (final node in nodes) {
+      if (node.id == id) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    final textPainter = TextPainter(
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    );
+
+    for (final edge in edges) {
+      final from = _nodeById(edge.fromStateId);
+      final to = _nodeById(edge.toStateId);
+      if (from == null || to == null) {
+        continue;
+      }
+      final path = Path();
+      final fromOffset = Offset(from.x, from.y);
+      final toOffset = Offset(to.x, to.y);
+      final control = edge.controlPointX != null && edge.controlPointY != null
+          ? Offset(edge.controlPointX!, edge.controlPointY!)
+          : Offset(
+              (fromOffset.dx + toOffset.dx) / 2,
+              (fromOffset.dy + toOffset.dy) / 2,
+            );
+
+      path.moveTo(fromOffset.dx, fromOffset.dy);
+      path.quadraticBezierTo(
+        control.dx,
+        control.dy,
+        toOffset.dx,
+        toOffset.dy,
+      );
+
+      paint.color = highlight.transitionIds.contains(edge.id)
+          ? theme.colorScheme.tertiary
+          : theme.colorScheme.onSurfaceVariant;
+      canvas.drawPath(path, paint);
+
+      final metrics = path.computeMetrics();
+      for (final metric in metrics) {
+        final tangent = metric.getTangentForOffset(metric.length * 0.5);
+        if (tangent == null) {
+          continue;
+        }
+        textPainter.text = TextSpan(
+          text: edge.label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurface,
+          ),
+        );
+        textPainter.layout();
+        final offset = tangent.position -
+            Offset(textPainter.width / 2, textPainter.height / 2);
+        textPainter.paint(canvas, offset);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _GraphEdgePainter oldDelegate) {
+    return oldDelegate.edges != edges ||
+        oldDelegate.nodes != nodes ||
+        oldDelegate.highlight != highlight;
+  }
+}

--- a/lib/presentation/widgets/tm_canvas_graphview.dart
+++ b/lib/presentation/widgets/tm_canvas_graphview.dart
@@ -1,0 +1,800 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:graphview/GraphView.dart';
+
+import '../../core/models/simulation_highlight.dart';
+import '../../core/models/tm.dart';
+import '../../core/models/tm_transition.dart';
+import '../../core/services/simulation_highlight_service.dart';
+import '../../features/canvas/graphview/graphview_canvas_models.dart';
+import '../../features/canvas/graphview/graphview_highlight_channel.dart';
+import '../../features/canvas/graphview/graphview_tm_canvas_controller.dart';
+import '../providers/tm_editor_provider.dart';
+import 'transition_editors/tm_transition_operations_editor.dart';
+
+class TMCanvasGraphView extends ConsumerStatefulWidget {
+  const TMCanvasGraphView({
+    super.key,
+    required this.onTmModified,
+    this.controller,
+  });
+
+  final ValueChanged<TM> onTmModified;
+  final GraphViewTmCanvasController? controller;
+
+  @override
+  ConsumerState<TMCanvasGraphView> createState() => _TMCanvasGraphViewState();
+}
+
+class _TMCanvasGraphViewState extends ConsumerState<TMCanvasGraphView> {
+  late GraphViewTmCanvasController _canvasController;
+  late bool _ownsController;
+  late SugiyamaAlgorithm _algorithm;
+  ProviderSubscription<TMEditorState>? _subscription;
+  TM? _lastDeliveredTm;
+  SimulationHighlightService? _highlightService;
+  SimulationHighlightChannel? _previousHighlightChannel;
+  GraphViewSimulationHighlightChannel? _highlightChannel;
+
+  GraphViewTmCanvasController get controller => _canvasController;
+
+  @override
+  void initState() {
+    super.initState();
+    final externalController = widget.controller;
+    if (externalController != null) {
+      _canvasController = externalController;
+      _ownsController = false;
+    } else {
+      _canvasController = GraphViewTmCanvasController(
+        editorNotifier: ref.read(tmEditorProvider.notifier),
+      );
+      _ownsController = true;
+      final highlightService = ref.read(canvasHighlightServiceProvider);
+      _highlightService = highlightService;
+      _previousHighlightChannel = highlightService.channel;
+      final highlightChannel = GraphViewSimulationHighlightChannel(
+        _canvasController,
+      );
+      _highlightChannel = highlightChannel;
+      highlightService.channel = highlightChannel;
+    }
+
+    _algorithm = SugiyamaAlgorithm(SugiyamaConfiguration()
+      ..nodeSeparation = 160
+      ..levelSeparation = 160
+      ..orientation = SugiyamaConfiguration.ORIENTATION_TOP_BOTTOM);
+
+    final initialState = ref.read(tmEditorProvider);
+    _canvasController.synchronize(initialState.tm);
+    if (initialState.tm?.states.isNotEmpty ?? false) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        _canvasController.fitToContent();
+      });
+    }
+
+    _lastDeliveredTm = initialState.tm;
+    if (initialState.tm != null) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted) return;
+        widget.onTmModified(initialState.tm!);
+      });
+    }
+
+    _subscription = ref.listenManual<TMEditorState>(
+      tmEditorProvider,
+      (previous, next) {
+        if (!mounted) return;
+        final tm = next.tm;
+        if (tm != null && !identical(tm, _lastDeliveredTm)) {
+          _lastDeliveredTm = tm;
+          widget.onTmModified(tm);
+        } else if (tm == null) {
+          _lastDeliveredTm = null;
+        }
+        if (_shouldSynchronize(previous, next)) {
+          final hadNodes = _canvasController.nodes.isNotEmpty;
+          _canvasController.synchronize(tm);
+          if (!hadNodes && (tm?.states.isNotEmpty ?? false)) {
+            WidgetsBinding.instance.addPostFrameCallback((_) {
+              if (!mounted) return;
+              _canvasController.fitToContent();
+            });
+          }
+        }
+      },
+    );
+  }
+
+  bool _shouldSynchronize(TMEditorState? previous, TMEditorState next) {
+    final tm = next.tm;
+    if (tm == null) {
+      return true;
+    }
+    if (previous?.tm == null) {
+      return true;
+    }
+
+    final nodeIds = {for (final node in _canvasController.nodes) node.id};
+    final stateIds = {for (final state in next.states) state.id};
+    if (nodeIds.length != stateIds.length || !nodeIds.containsAll(stateIds)) {
+      return true;
+    }
+
+    final edgeIds = {for (final edge in _canvasController.edges) edge.id};
+    final transitionIds = {for (final transition in next.transitions) transition.id};
+    if (edgeIds.length != transitionIds.length ||
+        !edgeIds.containsAll(transitionIds)) {
+      return true;
+    }
+
+    for (final state in next.states) {
+      final node = _canvasController.nodeById(state.id);
+      if (node == null) {
+        return true;
+      }
+      if ((node.x - state.position.x).abs() > 0.5 ||
+          (node.y - state.position.y).abs() > 0.5) {
+        return true;
+      }
+      if (node.label.trim() != state.label.trim()) {
+        return true;
+      }
+    }
+
+    for (final transition in next.transitions) {
+      final edge = _canvasController.edgeById(transition.id);
+      if (edge == null) {
+        return true;
+      }
+      if (edge.fromStateId != transition.fromState.id ||
+          edge.toStateId != transition.toState.id) {
+        return true;
+      }
+      final controlPoint = transition.controlPoint;
+      final edgeX = edge.controlPointX ?? controlPoint.x;
+      final edgeY = edge.controlPointY ?? controlPoint.y;
+      if ((edgeX - controlPoint.x).abs() > 0.5 ||
+          (edgeY - controlPoint.y).abs() > 0.5) {
+        return true;
+      }
+      final read = transition.readSymbol.trim();
+      final write = transition.writeSymbol.trim();
+      final edgeRead = (edge.readSymbol ?? '').trim();
+      final edgeWrite = (edge.writeSymbol ?? '').trim();
+      if (edgeRead != read || edgeWrite != write) {
+        return true;
+      }
+      if ((edge.direction ?? TapeDirection.right) != transition.direction) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @override
+  void dispose() {
+    _subscription?.close();
+    if (_ownsController) {
+      _canvasController.dispose();
+    }
+    if (_highlightService != null) {
+      _highlightService!.channel = _previousHighlightChannel;
+      _highlightChannel = null;
+    }
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.stretch,
+      children: [
+        Expanded(child: _buildCanvas(context)),
+        const SizedBox(height: 12),
+        SizedBox(
+          height: 240,
+          child: _buildInspector(context),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildCanvas(BuildContext context) {
+    final theme = Theme.of(context);
+    return GestureDetector(
+      onDoubleTap: () => controller.addStateAtCenter(),
+      child: DecoratedBox(
+        decoration: BoxDecoration(
+          color: theme.colorScheme.surfaceVariant.withOpacity(0.4),
+          borderRadius: BorderRadius.circular(8),
+        ),
+        child: Padding(
+          padding: const EdgeInsets.all(8),
+          child: ValueListenableBuilder<int>(
+            valueListenable: _canvasController.graphRevision,
+            builder: (context, _, __) {
+              final nodes =
+                  _canvasController.nodes.toList(growable: false);
+              final edges =
+                  _canvasController.edges.toList(growable: false);
+              return ValueListenableBuilder(
+                valueListenable: _canvasController.highlightNotifier,
+                builder: (context, highlight, __) {
+                  return Stack(
+                    children: [
+                      GraphView.builder(
+                        graph: _canvasController.graph,
+                        controller: _canvasController.graphController,
+                        algorithm: _algorithm,
+                        builder: (node) {
+                          final nodeId = node.key?.value?.toString();
+                          if (nodeId == null) {
+                            return const SizedBox.shrink();
+                          }
+                          final canvasNode =
+                              _canvasController.nodeById(nodeId);
+                          if (canvasNode == null) {
+                            return const SizedBox.shrink();
+                          }
+                          final isHighlighted =
+                              highlight.stateIds.contains(canvasNode.id);
+                          return _GraphNodeWidget(
+                            label: canvasNode.label,
+                            isInitial: canvasNode.isInitial,
+                            isAccepting: canvasNode.isAccepting,
+                            isHighlighted: isHighlighted,
+                          );
+                        },
+                      ),
+                      Positioned.fill(
+                        child: IgnorePointer(
+                          child: CustomPaint(
+                            painter: _GraphEdgePainter(
+                              edges: edges,
+                              nodes: nodes,
+                              highlight: highlight,
+                              theme: theme,
+                            ),
+                          ),
+                        ),
+                      ),
+                    ],
+                  );
+                },
+              );
+            },
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildInspector(BuildContext context) {
+    final theme = Theme.of(context);
+    return Card(
+      elevation: 0,
+      color: theme.colorScheme.surface,
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: ValueListenableBuilder<int>(
+          valueListenable: _canvasController.graphRevision,
+          builder: (context, _, __) {
+            final nodes =
+                _canvasController.nodes.toList(growable: false);
+            final edges =
+                _canvasController.edges.toList(growable: false);
+            return ListView(
+              children: [
+                Row(
+                  children: [
+                    Text(
+                      'States',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      onPressed: () => controller.addStateAt(const Offset(0, 0)),
+                      icon: const Icon(Icons.add),
+                      label: const Text('Add state'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (nodes.isEmpty)
+                  Text(
+                    'Start by adding states to the machine.',
+                    style: theme.textTheme.bodyMedium,
+                  )
+                else
+                  ...nodes.map((node) => _buildStateTile(context, node)),
+                const SizedBox(height: 16),
+                Row(
+                  children: [
+                    Text(
+                      'Transitions',
+                      style: theme.textTheme.titleMedium,
+                    ),
+                    const Spacer(),
+                    FilledButton.icon(
+                      onPressed:
+                          nodes.isEmpty ? null : () => _handleCreateTransition(context, nodes),
+                      icon: const Icon(Icons.add),
+                      label: const Text('Add transition'),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                if (edges.isEmpty)
+                  Text(
+                    'Transitions control tape operations. Add one to begin.',
+                    style: theme.textTheme.bodyMedium,
+                  )
+                else
+                  ...edges.map((edge) => _buildTransitionTile(context, edge)),
+              ],
+            );
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildStateTile(BuildContext context, GraphViewCanvasNode node) {
+    final theme = Theme.of(context);
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Expanded(
+                  child: Text(
+                    node.label.isEmpty ? node.id : node.label,
+                    style: theme.textTheme.titleMedium,
+                  ),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.edit),
+                  tooltip: 'Rename state',
+                  onPressed: () => _handleRenameState(context, node),
+                ),
+                IconButton(
+                  icon: const Icon(Icons.delete_outline),
+                  tooltip: 'Remove state',
+                  onPressed: () => controller.removeState(node.id),
+                ),
+              ],
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 12,
+              runSpacing: 8,
+              children: [
+                FilterChip(
+                  label: const Text('Initial'),
+                  selected: node.isInitial,
+                  onSelected: (value) =>
+                      controller.updateStateFlags(node.id, isInitial: value),
+                ),
+                FilterChip(
+                  label: const Text('Accepting'),
+                  selected: node.isAccepting,
+                  onSelected: (value) => controller.updateStateFlags(
+                    node.id,
+                    isAccepting: value,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleRenameState(
+    BuildContext context,
+    GraphViewCanvasNode node,
+  ) async {
+    final labelController = TextEditingController(text: node.label);
+    final result = await showDialog<String?>(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Rename state'),
+          content: TextField(
+            controller: labelController,
+            decoration: const InputDecoration(labelText: 'State label'),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(null),
+              child: const Text('Cancel'),
+            ),
+            FilledButton(
+              onPressed: () =>
+                  Navigator.of(context).pop(labelController.text.trim()),
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+    if (result != null) {
+      controller.updateStateLabel(node.id, result);
+    }
+  }
+
+  Widget _buildTransitionTile(
+    BuildContext context,
+    GraphViewCanvasEdge edge,
+  ) {
+    return Card(
+      margin: const EdgeInsets.symmetric(vertical: 4),
+      child: ListTile(
+        title: Text('${edge.fromStateId} → ${edge.toStateId}'),
+        subtitle: Text(edge.label),
+        trailing: Wrap(
+          spacing: 8,
+          children: [
+            IconButton(
+              icon: const Icon(Icons.edit),
+              tooltip: 'Edit transition',
+              onPressed: () => _handleEditTransition(context, edge),
+            ),
+            IconButton(
+              icon: const Icon(Icons.delete_outline),
+              tooltip: 'Remove transition',
+              onPressed: () => controller.removeTransition(edge.id),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Future<void> _handleEditTransition(
+    BuildContext context,
+    GraphViewCanvasEdge edge,
+  ) async {
+    final result = await showDialog<_TmTransitionResult?>(
+      context: context,
+      builder: (context) {
+        return Dialog(
+          child: Padding(
+            padding: const EdgeInsets.all(12),
+            child: TmTransitionOperationsEditor(
+              initialRead: edge.readSymbol ?? '',
+              initialWrite: edge.writeSymbol ?? '',
+              initialDirection: edge.direction ?? TapeDirection.right,
+              onSubmit: ({
+                required String readSymbol,
+                required String writeSymbol,
+                required TapeDirection direction,
+              }) {
+                Navigator.of(context).pop(
+                  _TmTransitionResult(
+                    fromStateId: edge.fromStateId,
+                    toStateId: edge.toStateId,
+                    readSymbol: readSymbol,
+                    writeSymbol: writeSymbol,
+                    direction: direction,
+                    transitionId: edge.id,
+                    controlPointX: edge.controlPointX,
+                    controlPointY: edge.controlPointY,
+                  ),
+                );
+              },
+              onCancel: () => Navigator.of(context).pop(null),
+            ),
+          ),
+        );
+      },
+    );
+
+    if (result == null) {
+      return;
+    }
+
+    controller.addOrUpdateTransition(
+      fromStateId: result.fromStateId,
+      toStateId: result.toStateId,
+      readSymbol: result.readSymbol,
+      writeSymbol: result.writeSymbol,
+      direction: result.direction,
+      transitionId: result.transitionId,
+      controlPointX: result.controlPointX,
+      controlPointY: result.controlPointY,
+    );
+  }
+
+  Future<void> _handleCreateTransition(
+    BuildContext context,
+    List<GraphViewCanvasNode> nodes,
+  ) async {
+    if (nodes.isEmpty) {
+      return;
+    }
+
+    String fromStateId = nodes.first.id;
+    String toStateId = nodes.first.id;
+
+    final result = await showDialog<_TmTransitionResult?>(
+      context: context,
+      builder: (context) {
+        return StatefulBuilder(
+          builder: (context, setState) {
+            return Dialog(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  children: [
+                    Row(
+                      children: [
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: fromStateId,
+                            decoration: const InputDecoration(labelText: 'From'),
+                            items: nodes
+                                .map(
+                                  (node) => DropdownMenuItem(
+                                    value: node.id,
+                                    child: Text(node.label.isEmpty
+                                        ? node.id
+                                        : node.label),
+                                  ),
+                                )
+                                .toList(),
+                            onChanged: (value) {
+                              if (value != null) {
+                                setState(() => fromStateId = value);
+                              }
+                            },
+                          ),
+                        ),
+                        const SizedBox(width: 12),
+                        Expanded(
+                          child: DropdownButtonFormField<String>(
+                            value: toStateId,
+                            decoration: const InputDecoration(labelText: 'To'),
+                            items: nodes
+                                .map(
+                                  (node) => DropdownMenuItem(
+                                    value: node.id,
+                                    child: Text(node.label.isEmpty
+                                        ? node.id
+                                        : node.label),
+                                  ),
+                                )
+                                .toList(),
+                            onChanged: (value) {
+                              if (value != null) {
+                                setState(() => toStateId = value);
+                              }
+                            },
+                          ),
+                        ),
+                      ],
+                    ),
+                    const SizedBox(height: 12),
+                    TmTransitionOperationsEditor(
+                      initialRead: '',
+                      initialWrite: '',
+                      initialDirection: TapeDirection.right,
+                      onSubmit: ({
+                        required String readSymbol,
+                        required String writeSymbol,
+                        required TapeDirection direction,
+                      }) {
+                        Navigator.of(context).pop(
+                          _TmTransitionResult(
+                            fromStateId: fromStateId,
+                            toStateId: toStateId,
+                            readSymbol: readSymbol,
+                            writeSymbol: writeSymbol,
+                            direction: direction,
+                          ),
+                        );
+                      },
+                      onCancel: () => Navigator.of(context).pop(null),
+                    ),
+                  ],
+                ),
+              ),
+            );
+          },
+        );
+      },
+    );
+
+    if (result == null) {
+      return;
+    }
+
+    controller.addOrUpdateTransition(
+      fromStateId: result.fromStateId,
+      toStateId: result.toStateId,
+      readSymbol: result.readSymbol,
+      writeSymbol: result.writeSymbol,
+      direction: result.direction,
+    );
+  }
+}
+
+class _TmTransitionResult {
+  _TmTransitionResult({
+    required this.fromStateId,
+    required this.toStateId,
+    required this.readSymbol,
+    required this.writeSymbol,
+    required this.direction,
+    this.transitionId,
+    this.controlPointX,
+    this.controlPointY,
+  });
+
+  final String fromStateId;
+  final String toStateId;
+  final String readSymbol;
+  final String writeSymbol;
+  final TapeDirection direction;
+  final String? transitionId;
+  final double? controlPointX;
+  final double? controlPointY;
+}
+
+class _GraphNodeWidget extends StatelessWidget {
+  const _GraphNodeWidget({
+    required this.label,
+    required this.isInitial,
+    required this.isAccepting,
+    required this.isHighlighted,
+  });
+
+  final String label;
+  final bool isInitial;
+  final bool isAccepting;
+  final bool isHighlighted;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderColor = isHighlighted
+        ? theme.colorScheme.secondary
+        : theme.colorScheme.primary;
+    return Container(
+      width: 80,
+      height: 80,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        color: theme.colorScheme.surface,
+        border: Border.all(color: borderColor, width: 3),
+      ),
+      alignment: Alignment.center,
+      child: Stack(
+        alignment: Alignment.center,
+        children: [
+          if (isAccepting)
+            Container(
+              width: 72,
+              height: 72,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: borderColor, width: 2),
+              ),
+            ),
+          Text(
+            label.isEmpty ? 'q' : label,
+            style: theme.textTheme.titleMedium,
+          ),
+          if (isInitial)
+            Positioned(
+              left: -24,
+              child: Icon(
+                Icons.play_arrow,
+                color: borderColor,
+              ),
+            ),
+        ],
+      ),
+    );
+  }
+}
+
+class _GraphEdgePainter extends CustomPainter {
+  _GraphEdgePainter({
+    required this.edges,
+    required this.nodes,
+    required this.highlight,
+    required this.theme,
+  });
+
+  final List<GraphViewCanvasEdge> edges;
+  final List<GraphViewCanvasNode> nodes;
+  final SimulationHighlight highlight;
+  final ThemeData theme;
+
+  GraphViewCanvasNode? _nodeById(String id) {
+    for (final node in nodes) {
+      if (node.id == id) {
+        return node;
+      }
+    }
+    return null;
+  }
+
+  @override
+  void paint(Canvas canvas, Size size) {
+    final paint = Paint()
+      ..style = PaintingStyle.stroke
+      ..strokeWidth = 2;
+    final textPainter = TextPainter(
+      textDirection: TextDirection.ltr,
+      maxLines: 1,
+    );
+
+    for (final edge in edges) {
+      final from = _nodeById(edge.fromStateId);
+      final to = _nodeById(edge.toStateId);
+      if (from == null || to == null) {
+        continue;
+      }
+      final path = Path();
+      final fromOffset = Offset(from.x, from.y);
+      final toOffset = Offset(to.x, to.y);
+      final control = edge.controlPointX != null && edge.controlPointY != null
+          ? Offset(edge.controlPointX!, edge.controlPointY!)
+          : Offset(
+              (fromOffset.dx + toOffset.dx) / 2,
+              (fromOffset.dy + toOffset.dy) / 2,
+            );
+
+      path.moveTo(fromOffset.dx, fromOffset.dy);
+      path.quadraticBezierTo(
+        control.dx,
+        control.dy,
+        toOffset.dx,
+        toOffset.dy,
+      );
+
+      paint.color = highlight.transitionIds.contains(edge.id)
+          ? theme.colorScheme.tertiary
+          : theme.colorScheme.onSurfaceVariant;
+      canvas.drawPath(path, paint);
+
+      final metrics = path.computeMetrics();
+      for (final metric in metrics) {
+        final tangent = metric.getTangentForOffset(metric.length * 0.5);
+        if (tangent == null) {
+          continue;
+        }
+        textPainter.text = TextSpan(
+          text: edge.label,
+          style: theme.textTheme.bodySmall?.copyWith(
+            color: theme.colorScheme.onSurface,
+          ),
+        );
+        textPainter.layout();
+        final offset = tangent.position -
+            Offset(textPainter.width / 2, textPainter.height / 2);
+        textPainter.paint(canvas, offset);
+      }
+    }
+  }
+
+  @override
+  bool shouldRepaint(covariant _GraphEdgePainter oldDelegate) {
+    return oldDelegate.edges != edges ||
+        oldDelegate.nodes != nodes ||
+        oldDelegate.highlight != highlight;
+  }
+}

--- a/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
@@ -1,0 +1,192 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/pda.dart';
+import 'package:jflutter/core/models/pda_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_pda_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GraphViewPdaCanvasController', () {
+    late PDAEditorNotifier notifier;
+    late GraphViewPdaCanvasController controller;
+
+    setUp(() {
+      notifier = PDAEditorNotifier();
+      controller = GraphViewPdaCanvasController(editorNotifier: notifier);
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    PDA _buildSamplePda() {
+      final initialState = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      final acceptingState = State(
+        id: 'q1',
+        label: 'accept',
+        position: Vector2(160, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      final transition = PDATransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        label: 'a, Z/ZZ',
+        controlPoint: Vector2(40, 30),
+        type: TransitionType.deterministic,
+        inputSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'ZZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+      return PDA(
+        id: 'pda-1',
+        name: 'Sample PDA',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2023, 1, 1),
+        modified: DateTime.utc(2023, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        stackAlphabet: {'Z'},
+        initialStackSymbol: 'Z',
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+    }
+
+    test('synchronize populates nodes and edges from PDA', () {
+      final pda = _buildSamplePda();
+
+      controller.synchronize(pda);
+
+      final node = controller.nodeById('q0');
+      expect(node, isNotNull);
+      expect(node!.label, equals('start'));
+      final edge = controller.edgeById('t0');
+      expect(edge, isNotNull);
+      expect(edge!.readSymbol, equals('a'));
+    });
+
+    test('addStateAt inserts state into notifier', () {
+      controller.addStateAt(const Offset(24, 48));
+
+      final pda = notifier.state.pda;
+      expect(pda, isNotNull);
+      expect(pda!.states.length, equals(1));
+      final state = pda.states.single;
+      expect(state.position.x, closeTo(24, 0.0001));
+      expect(state.position.y, closeTo(48, 0.0001));
+      expect(state.label, isNotEmpty);
+    });
+
+    test('addOrUpdateTransition writes transition metadata', () {
+      controller.addStateAt(const Offset(0, 0));
+      controller.addStateAt(const Offset(120, 80));
+      final pda = notifier.state.pda!;
+      final statesById = {for (final state in pda.states) state.id: state};
+
+      controller.addOrUpdateTransition(
+        fromStateId: statesById.keys.first,
+        toStateId: statesById.keys.last,
+        readSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'AZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+
+      final updated = notifier.state.pda!;
+      expect(updated.pdaTransitions, hasLength(1));
+      final transition = updated.pdaTransitions.single;
+      expect(transition.inputSymbol, equals('a'));
+      expect(transition.popSymbol, equals('Z'));
+      expect(transition.pushSymbol, equals('AZ'));
+    });
+
+    test('removeTransition clears transition from notifier', () {
+      final pda = _buildSamplePda();
+      notifier.setPda(pda);
+      controller.synchronize(pda);
+
+      controller.removeTransition('t0');
+
+      final updated = notifier.state.pda!;
+      expect(updated.pdaTransitions, isEmpty);
+    });
+
+    test('applySnapshotToDomain rebuilds PDA and synchronizes controller', () {
+      final snapshot = GraphViewAutomatonSnapshot(
+        nodes: const [
+          GraphViewCanvasNode(
+            id: 'q0',
+            label: 'start',
+            x: 10,
+            y: 20,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          GraphViewCanvasNode(
+            id: 'q1',
+            label: 'accept',
+            x: 180,
+            y: 120,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          GraphViewCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: <String>[],
+            controlPointX: 42,
+            controlPointY: 32,
+            readSymbol: 'b',
+            popSymbol: 'Z',
+            pushSymbol: 'XZ',
+            isLambdaInput: false,
+            isLambdaPop: false,
+            isLambdaPush: false,
+          ),
+        ],
+        metadata: const GraphViewAutomatonMetadata(
+          id: 'pda-1',
+          name: 'Snapshot PDA',
+          alphabet: ['a', 'b'],
+        ),
+      );
+
+      controller.applySnapshotToDomain(snapshot);
+
+      final rebuilt = notifier.state.pda;
+      expect(rebuilt, isNotNull);
+      expect(rebuilt!.states.length, equals(2));
+      expect(rebuilt.pdaTransitions.single.inputSymbol, equals('b'));
+      expect(controller.nodeById('q0'), isNotNull);
+      expect(controller.edgeById('t0'), isNotNull);
+    });
+  });
+}

--- a/test/features/canvas/graphview/graphview_pda_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_mapper_test.dart
@@ -1,0 +1,170 @@
+import 'dart:math' as math;
+
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/pda.dart';
+import 'package:jflutter/core/models/pda_transition.dart';
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_pda_mapper.dart';
+
+void main() {
+  group('GraphViewPdaMapper', () {
+    late State initialState;
+    late State acceptingState;
+    late PDATransition transition;
+    late PDA basePda;
+
+    setUp(() {
+      initialState = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      acceptingState = State(
+        id: 'q1',
+        label: 'accept',
+        position: Vector2(180, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      transition = PDATransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        label: 'a, Z/AZ',
+        controlPoint: Vector2(40, 20),
+        type: TransitionType.deterministic,
+        inputSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'AZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+      basePda = PDA(
+        id: 'pda-1',
+        name: 'Sample PDA',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2023, 1, 1),
+        modified: DateTime.utc(2023, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        stackAlphabet: {'Z', 'A'},
+        initialStackSymbol: 'Z',
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+    });
+
+    test('toSnapshot encodes PDA structure', () {
+      final snapshot = GraphViewPdaMapper.toSnapshot(basePda);
+
+      expect(snapshot.metadata.id, equals('pda-1'));
+      expect(snapshot.metadata.name, equals('Sample PDA'));
+      expect(snapshot.metadata.alphabet, contains('a'));
+
+      expect(snapshot.nodes, hasLength(2));
+      final nodeIds = snapshot.nodes.map((node) => node.id).toSet();
+      expect(nodeIds, containsAll({'q0', 'q1'}));
+
+      final encodedInitial =
+          snapshot.nodes.firstWhere((node) => node.id == 'q0');
+      expect(encodedInitial.isInitial, isTrue);
+      expect(encodedInitial.x, closeTo(0, 0.0001));
+      expect(encodedInitial.y, closeTo(0, 0.0001));
+
+      expect(snapshot.edges, hasLength(1));
+      final edge = snapshot.edges.single;
+      expect(edge.id, equals('t0'));
+      expect(edge.fromStateId, equals('q0'));
+      expect(edge.toStateId, equals('q1'));
+      expect(edge.readSymbol, equals('a'));
+      expect(edge.popSymbol, equals('Z'));
+      expect(edge.pushSymbol, equals('AZ'));
+      expect(edge.isLambdaInput, isFalse);
+      expect(edge.isLambdaPop, isFalse);
+      expect(edge.isLambdaPush, isFalse);
+    });
+
+    test('mergeIntoTemplate rebuilds PDA from snapshot', () {
+      final template = basePda.copyWith(
+        states: {initialState},
+        transitions: {},
+        acceptingStates: {initialState},
+      );
+
+      final snapshot = GraphViewAutomatonSnapshot(
+        nodes: const [
+          GraphViewCanvasNode(
+            id: 'q0',
+            label: 'start',
+            x: 12,
+            y: 18,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          GraphViewCanvasNode(
+            id: 'q1',
+            label: 'accept',
+            x: 200,
+            y: 140,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          GraphViewCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: <String>[],
+            controlPointX: 40,
+            controlPointY: 24,
+            readSymbol: 'b',
+            popSymbol: 'Z',
+            pushSymbol: 'X',
+            isLambdaInput: false,
+            isLambdaPop: true,
+            isLambdaPush: false,
+          ),
+        ],
+        metadata: const GraphViewAutomatonMetadata(
+          id: 'pda-1',
+          name: 'Updated PDA',
+          alphabet: ['a', 'b'],
+        ),
+      );
+
+      final rebuilt = GraphViewPdaMapper.mergeIntoTemplate(snapshot, template);
+
+      expect(rebuilt.states.length, equals(2));
+      final rebuiltInitial =
+          rebuilt.states.firstWhere((state) => state.id == 'q0');
+      final rebuiltAccepting =
+          rebuilt.states.firstWhere((state) => state.id == 'q1');
+      expect(rebuiltInitial.position.x, closeTo(12, 0.0001));
+      expect(rebuiltInitial.position.y, closeTo(18, 0.0001));
+      expect(rebuiltAccepting.isAccepting, isTrue);
+
+      final rebuiltTransition = rebuilt.pdaTransitions.single;
+      expect(rebuiltTransition.inputSymbol, equals('b'));
+      expect(rebuiltTransition.popSymbol, equals(''));
+      expect(rebuiltTransition.pushSymbol, equals('X'));
+      expect(rebuiltTransition.isLambdaPop, isTrue);
+      expect(rebuiltTransition.label, equals('b, λ/X'));
+
+      expect(rebuilt.alphabet, containsAll({'a', 'b'}));
+      expect(rebuilt.stackAlphabet, containsAll({'Z', 'X'}));
+      expect(rebuilt.initialState?.id, equals('q0'));
+      expect(rebuilt.acceptingStates.single.id, equals('q1'));
+    });
+  });
+}

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -1,0 +1,187 @@
+import 'dart:math' as math;
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_tm_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('GraphViewTmCanvasController', () {
+    late TMEditorNotifier notifier;
+    late GraphViewTmCanvasController controller;
+
+    setUp(() {
+      notifier = TMEditorNotifier();
+      controller = GraphViewTmCanvasController(editorNotifier: notifier);
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    TM _buildSampleTm() {
+      final initialState = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      final acceptingState = State(
+        id: 'q1',
+        label: 'accept',
+        position: Vector2(200, 120),
+        isInitial: false,
+        isAccepting: true,
+      );
+      final transition = TMTransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        label: 'a/b,R',
+        controlPoint: Vector2(42, 30),
+        type: TransitionType.deterministic,
+        readSymbol: 'a',
+        writeSymbol: 'b',
+        direction: TapeDirection.right,
+      );
+      return TM(
+        id: 'tm-1',
+        name: 'Sample TM',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a', 'b'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2023, 1, 1),
+        modified: DateTime.utc(2023, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        tapeAlphabet: {'a', 'b', 'B'},
+        blankSymbol: 'B',
+        tapeCount: 1,
+        panOffset: Vector2.zero(),
+        zoomLevel: 1,
+      );
+    }
+
+    test('synchronize populates TM nodes and edges', () {
+      final tm = _buildSampleTm();
+
+      controller.synchronize(tm);
+
+      final node = controller.nodeById('q0');
+      expect(node, isNotNull);
+      expect(node!.label, equals('start'));
+      final edge = controller.edgeById('t0');
+      expect(edge, isNotNull);
+      expect(edge!.readSymbol, equals('a'));
+      expect(edge.writeSymbol, equals('b'));
+    });
+
+    test('addStateAt inserts state into notifier', () {
+      controller.addStateAt(const Offset(12, 24));
+
+      final tm = notifier.state.tm;
+      expect(tm, isNotNull);
+      expect(tm!.states.length, equals(1));
+      final state = tm.states.single;
+      expect(state.position.x, closeTo(12, 0.0001));
+      expect(state.position.y, closeTo(24, 0.0001));
+    });
+
+    test('addOrUpdateTransition stores TM transition data', () {
+      controller.addStateAt(const Offset(0, 0));
+      controller.addStateAt(const Offset(160, 100));
+      final tm = notifier.state.tm!;
+      final stateIds = tm.states.map((state) => state.id).toList();
+
+      controller.addOrUpdateTransition(
+        fromStateId: stateIds.first,
+        toStateId: stateIds.last,
+        readSymbol: '1',
+        writeSymbol: '0',
+        direction: TapeDirection.left,
+      );
+
+      final updated = notifier.state.tm!;
+      expect(updated.tmTransitions, hasLength(1));
+      final transition = updated.tmTransitions.single;
+      expect(transition.readSymbol, equals('1'));
+      expect(transition.writeSymbol, equals('0'));
+      expect(transition.direction, equals(TapeDirection.left));
+    });
+
+    test('removeTransition removes TM transition', () {
+      final tm = _buildSampleTm();
+      notifier.setTm(tm);
+      controller.synchronize(tm);
+
+      controller.removeTransition('t0');
+
+      final updated = notifier.state.tm!;
+      expect(updated.tmTransitions, isEmpty);
+    });
+
+    test('applySnapshotToDomain rebuilds TM and synchronizes controller', () {
+      final snapshot = GraphViewAutomatonSnapshot(
+        nodes: const [
+          GraphViewCanvasNode(
+            id: 'q0',
+            label: 'start',
+            x: 20,
+            y: 30,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          GraphViewCanvasNode(
+            id: 'q1',
+            label: 'accept',
+            x: 200,
+            y: 150,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          GraphViewCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: <String>[],
+            controlPointX: 50,
+            controlPointY: 42,
+            readSymbol: '0',
+            writeSymbol: '1',
+            direction: TapeDirection.stay,
+          ),
+        ],
+        metadata: const GraphViewAutomatonMetadata(
+          id: 'tm-1',
+          name: 'Snapshot TM',
+          alphabet: ['0', '1'],
+        ),
+      );
+
+      controller.applySnapshotToDomain(snapshot);
+
+      final rebuilt = notifier.state.tm;
+      expect(rebuilt, isNotNull);
+      expect(rebuilt!.states.length, equals(2));
+      final transition = rebuilt.tmTransitions.single;
+      expect(transition.readSymbol, equals('0'));
+      expect(transition.writeSymbol, equals('1'));
+      expect(transition.direction, equals(TapeDirection.stay));
+      expect(controller.nodeById('q0'), isNotNull);
+      expect(controller.edgeById('t0'), isNotNull);
+    });
+  });
+}

--- a/test/features/canvas/graphview/graphview_tm_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_mapper_test.dart
@@ -1,0 +1,148 @@
+import 'dart:math' as math;
+
+import 'package:test/test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/state.dart';
+import 'package:jflutter/core/models/tm.dart';
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/core/models/transition.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_tm_mapper.dart';
+
+void main() {
+  group('GraphViewTmMapper', () {
+    late State initialState;
+    late State acceptingState;
+    late TMTransition transition;
+    late TM machine;
+
+    setUp(() {
+      initialState = State(
+        id: 'q0',
+        label: 'start',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      acceptingState = State(
+        id: 'q1',
+        label: 'accept',
+        position: Vector2(200, 140),
+        isInitial: false,
+        isAccepting: true,
+      );
+      transition = TMTransition(
+        id: 't0',
+        fromState: initialState,
+        toState: acceptingState,
+        label: 'a/b,R',
+        controlPoint: Vector2(32, 28),
+        type: TransitionType.deterministic,
+        readSymbol: 'a',
+        writeSymbol: 'b',
+        direction: TapeDirection.right,
+      );
+      machine = TM(
+        id: 'tm-1',
+        name: 'Sample TM',
+        states: {initialState, acceptingState},
+        transitions: {transition},
+        alphabet: {'a', 'b'},
+        initialState: initialState,
+        acceptingStates: {acceptingState},
+        created: DateTime.utc(2023, 1, 1),
+        modified: DateTime.utc(2023, 1, 1),
+        bounds: const math.Rectangle<double>(0, 0, 400, 300),
+        tapeAlphabet: {'a', 'b', 'B'},
+        blankSymbol: 'B',
+        tapeCount: 1,
+        panOffset: Vector2.zero(),
+        zoomLevel: 1,
+      );
+    });
+
+    test('toSnapshot encodes TM states and transitions', () {
+      final snapshot = GraphViewTmMapper.toSnapshot(machine);
+
+      expect(snapshot.metadata.id, equals('tm-1'));
+      expect(snapshot.metadata.name, equals('Sample TM'));
+      expect(snapshot.metadata.alphabet, containsAll(['a', 'b']));
+
+      expect(snapshot.nodes, hasLength(2));
+      final nodeIds = snapshot.nodes.map((node) => node.id).toSet();
+      expect(nodeIds, containsAll({'q0', 'q1'}));
+
+      final edge = snapshot.edges.single;
+      expect(edge.id, equals('t0'));
+      expect(edge.readSymbol, equals('a'));
+      expect(edge.writeSymbol, equals('b'));
+      expect(edge.direction, equals(TapeDirection.right));
+    });
+
+    test('mergeIntoTemplate rebuilds TM from snapshot', () {
+      final template = machine.copyWith(
+        states: {initialState},
+        transitions: {},
+        acceptingStates: {initialState},
+      );
+
+      final snapshot = GraphViewAutomatonSnapshot(
+        nodes: const [
+          GraphViewCanvasNode(
+            id: 'q0',
+            label: 'start',
+            x: 10,
+            y: 20,
+            isInitial: true,
+            isAccepting: false,
+          ),
+          GraphViewCanvasNode(
+            id: 'q1',
+            label: 'accept',
+            x: 180,
+            y: 150,
+            isInitial: false,
+            isAccepting: true,
+          ),
+        ],
+        edges: const [
+          GraphViewCanvasEdge(
+            id: 't0',
+            fromStateId: 'q0',
+            toStateId: 'q1',
+            symbols: <String>[],
+            controlPointX: 24,
+            controlPointY: 30,
+            readSymbol: 'c',
+            writeSymbol: 'd',
+            direction: TapeDirection.left,
+          ),
+        ],
+        metadata: const GraphViewAutomatonMetadata(
+          id: 'tm-1',
+          name: 'Updated TM',
+          alphabet: ['a', 'b', 'c', 'd'],
+        ),
+      );
+
+      final rebuilt = GraphViewTmMapper.mergeIntoTemplate(snapshot, template);
+
+      expect(rebuilt.states.length, equals(2));
+      final rebuiltInitial =
+          rebuilt.states.firstWhere((state) => state.id == 'q0');
+      expect(rebuiltInitial.position.x, closeTo(10, 0.0001));
+      expect(rebuiltInitial.position.y, closeTo(20, 0.0001));
+
+      final rebuiltTransition = rebuilt.tmTransitions.single;
+      expect(rebuiltTransition.readSymbol, equals('c'));
+      expect(rebuiltTransition.writeSymbol, equals('d'));
+      expect(rebuiltTransition.direction, equals(TapeDirection.left));
+      expect(rebuiltTransition.label, equals('c/d,L'));
+
+      expect(rebuilt.alphabet, containsAll({'a', 'b', 'c', 'd'}));
+      expect(rebuilt.initialState?.id, equals('q0'));
+      expect(rebuilt.acceptingStates.single.id, equals('q1'));
+    });
+  });
+}

--- a/test/widget/presentation/pda_canvas_graphview_test.dart
+++ b/test/widget/presentation/pda_canvas_graphview_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:jflutter/presentation/providers/pda_editor_provider.dart';
+import 'package:jflutter/presentation/widgets/pda_canvas_graphview.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_pda_canvas_controller.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('PDACanvasGraphView', () {
+    late PDAEditorNotifier notifier;
+    late GraphViewPdaCanvasController controller;
+
+    setUp(() {
+      notifier = PDAEditorNotifier();
+      controller = GraphViewPdaCanvasController(editorNotifier: notifier);
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('renders states and transitions from controller', (tester) async {
+      final delivered = <int>[];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            pdaEditorProvider.overrideWith((ref) => notifier),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: PDACanvasGraphView(
+                controller: controller,
+                onPdaModified: (pda) => delivered.add(pda.states.length),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      expect(find.text('States'), findsOneWidget);
+      expect(delivered, isEmpty);
+
+      controller.addStateAt(const Offset(0, 0));
+      await tester.pumpAndSettle();
+
+      expect(find.text('q0'), findsOneWidget);
+      expect(delivered, isNotEmpty);
+
+      controller.addStateAt(const Offset(120, 80));
+      await tester.pumpAndSettle();
+
+      final states = notifier.state.pda!.states.toList();
+      controller.addOrUpdateTransition(
+        fromStateId: states.first.id,
+        toStateId: states.last.id,
+        readSymbol: 'a',
+        popSymbol: 'Z',
+        pushSymbol: 'AZ',
+        isLambdaInput: false,
+        isLambdaPop: false,
+        isLambdaPush: false,
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.textContaining('${states.first.id} → ${states.last.id}'),
+          findsOneWidget);
+    });
+  });
+}

--- a/test/widget/presentation/tm_canvas_graphview_test.dart
+++ b/test/widget/presentation/tm_canvas_graphview_test.dart
@@ -1,0 +1,70 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:jflutter/core/models/tm_transition.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_tm_canvas_controller.dart';
+import 'package:jflutter/presentation/providers/tm_editor_provider.dart';
+import 'package:jflutter/presentation/widgets/tm_canvas_graphview.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('TMCanvasGraphView', () {
+    late TMEditorNotifier notifier;
+    late GraphViewTmCanvasController controller;
+
+    setUp(() {
+      notifier = TMEditorNotifier();
+      controller = GraphViewTmCanvasController(editorNotifier: notifier);
+    });
+
+    tearDown(() {
+      controller.dispose();
+    });
+
+    testWidgets('displays TM states and transitions', (tester) async {
+      final delivered = <int>[];
+
+      await tester.pumpWidget(
+        ProviderScope(
+          overrides: [
+            tmEditorProvider.overrideWith((ref) => notifier),
+          ],
+          child: MaterialApp(
+            home: Scaffold(
+              body: TMCanvasGraphView(
+                controller: controller,
+                onTmModified: (tm) => delivered.add(tm.states.length),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await tester.pump();
+      expect(find.text('States'), findsOneWidget);
+
+      controller.addStateAt(const Offset(0, 0));
+      controller.addStateAt(const Offset(140, 80));
+      await tester.pumpAndSettle();
+
+      expect(find.text('q0'), findsOneWidget);
+      expect(find.text('q1'), findsOneWidget);
+
+      final states = notifier.state.tm!.states.toList();
+      controller.addOrUpdateTransition(
+        fromStateId: states.first.id,
+        toStateId: states.last.id,
+        readSymbol: 'a',
+        writeSymbol: 'b',
+        direction: TapeDirection.right,
+      );
+
+      await tester.pumpAndSettle();
+      expect(find.textContaining('${states.first.id} → ${states.last.id}'),
+          findsOneWidget);
+      expect(delivered, isNotEmpty);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- implement GraphView PDA and TM canvas controllers tied to the Riverpod editors
- add GraphView-based PDA/TM widgets with inspector tools and highlight integration
- create GraphView mappers plus controller and widget tests for PDA/TM flows

## Testing
- Not run (Flutter SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e1bed3c0d0832ea2997e95c80c24e9