### PR TITLE
Add viewport-aware add-state center placement

### DIFF
--- a/lib/features/canvas/graphview/graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_controller.dart
@@ -116,7 +116,8 @@ class GraphViewCanvasController
   /// Adds a new state centred in the current viewport.
   void addStateAtCenter() {
     _logAutomatonCanvas('addStateAtCenter requested');
-    addStateAt(Offset.zero);
+    final worldCenter = resolveViewportCenterWorld();
+    addStateAt(worldCenter);
   }
 
   /// Adds a new state at the provided [worldPosition].

--- a/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
@@ -115,7 +115,8 @@ class GraphViewPdaCanvasController
   /// Adds a new state centred in the current viewport.
   void addStateAtCenter() {
     _logPdaCanvas('addStateAtCenter requested');
-    addStateAt(Offset.zero);
+    final worldCenter = resolveViewportCenterWorld();
+    addStateAt(worldCenter);
   }
 
   /// Adds a new state at the provided [worldPosition].

--- a/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
@@ -116,7 +116,8 @@ class GraphViewTmCanvasController
   /// Adds a new state centred in the current viewport.
   void addStateAtCenter() {
     _logTmCanvas('addStateAtCenter requested');
-    addStateAt(Offset.zero);
+    final worldCenter = resolveViewportCenterWorld();
+    addStateAt(worldCenter);
   }
 
   /// Adds a new state at the provided [worldPosition].

--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -675,40 +675,48 @@ class _AutomatonGraphViewCanvasState
               return Stack(
                 children: [
                   Positioned.fill(
-                    child: GraphView.builder(
-                      graph: _controller.graph,
-                      controller: _controller.graphController,
-                      algorithm: _algorithm,
-                      paint: Paint()..color = Colors.transparent,
-                      builder: (node) {
-                        final nodeId = node.key?.value?.toString();
-                        if (nodeId == null) {
-                          return const SizedBox.shrink();
+                    child: LayoutBuilder(
+                      builder: (context, constraints) {
+                        final viewport = constraints.biggest;
+                        if (viewport.width.isFinite && viewport.height.isFinite) {
+                          _controller.updateViewportSize(viewport);
                         }
-                        final canvasNode =
-                            _controller.nodeById(nodeId) ??
-                            GraphViewCanvasNode(
-                              id: nodeId,
-                              label: nodeId,
-                              x: node.position.dx,
-                              y: node.position.dy,
-                              isInitial: false,
-                              isAccepting: false,
+                        return GraphView.builder(
+                          graph: _controller.graph,
+                          controller: _controller.graphController,
+                          algorithm: _algorithm,
+                          paint: Paint()..color = Colors.transparent,
+                          builder: (node) {
+                            final nodeId = node.key?.value?.toString();
+                            if (nodeId == null) {
+                              return const SizedBox.shrink();
+                            }
+                            final canvasNode =
+                                _controller.nodeById(nodeId) ??
+                                GraphViewCanvasNode(
+                                  id: nodeId,
+                                  label: nodeId,
+                                  x: node.position.dx,
+                                  y: node.position.dy,
+                                  isInitial: false,
+                                  isAccepting: false,
+                                );
+                            final isHighlighted = _isNodeHighlighted(
+                              canvasNode,
+                              highlight,
                             );
-                        final isHighlighted = _isNodeHighlighted(
-                          canvasNode,
-                          highlight,
-                        );
-                        return _AutomatonGraphNode(
-                          label: canvasNode.label,
-                          isInitial: canvasNode.isInitial,
-                          isAccepting: canvasNode.isAccepting,
-                          isHighlighted: isHighlighted,
-                          onTap: () => _handleNodeTap(canvasNode.id),
-                          onPanStart: (details) =>
-                              _handleNodePanStart(canvasNode.id, details),
-                          onPanUpdate: (details) =>
-                              _handleNodePanUpdate(canvasNode.id, details),
+                            return _AutomatonGraphNode(
+                              label: canvasNode.label,
+                              isInitial: canvasNode.isInitial,
+                              isAccepting: canvasNode.isAccepting,
+                              isHighlighted: isHighlighted,
+                              onTap: () => _handleNodeTap(canvasNode.id),
+                              onPanStart: (details) =>
+                                  _handleNodePanStart(canvasNode.id, details),
+                              onPanUpdate: (details) =>
+                                  _handleNodePanUpdate(canvasNode.id, details),
+                            );
+                          },
                         );
                       },
                     ),

--- a/lib/presentation/widgets/pda_canvas_graphview.dart
+++ b/lib/presentation/widgets/pda_canvas_graphview.dart
@@ -237,27 +237,35 @@ class _PDACanvasGraphViewState extends ConsumerState<PDACanvasGraphView> {
                 builder: (context, highlight, __) {
                   return Stack(
                     children: [
-                      GraphView.builder(
-                        graph: _canvasController.graph,
-                        controller: _canvasController.graphController,
-                        algorithm: _algorithm,
-                        builder: (node) {
-                          final nodeId = node.key?.value?.toString();
-                          if (nodeId == null) {
-                            return const SizedBox.shrink();
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          final viewport = constraints.biggest;
+                          if (viewport.width.isFinite && viewport.height.isFinite) {
+                            _canvasController.updateViewportSize(viewport);
                           }
-                          final canvasNode =
-                              _canvasController.nodeById(nodeId);
-                          if (canvasNode == null) {
-                            return const SizedBox.shrink();
-                          }
-                          final isHighlighted =
-                              highlight.stateIds.contains(canvasNode.id);
-                          return _GraphNodeWidget(
-                            label: canvasNode.label,
-                            isInitial: canvasNode.isInitial,
-                            isAccepting: canvasNode.isAccepting,
-                            isHighlighted: isHighlighted,
+                          return GraphView.builder(
+                            graph: _canvasController.graph,
+                            controller: _canvasController.graphController,
+                            algorithm: _algorithm,
+                            builder: (node) {
+                              final nodeId = node.key?.value?.toString();
+                              if (nodeId == null) {
+                                return const SizedBox.shrink();
+                              }
+                              final canvasNode =
+                                  _canvasController.nodeById(nodeId);
+                              if (canvasNode == null) {
+                                return const SizedBox.shrink();
+                              }
+                              final isHighlighted =
+                                  highlight.stateIds.contains(canvasNode.id);
+                              return _GraphNodeWidget(
+                                label: canvasNode.label,
+                                isInitial: canvasNode.isInitial,
+                                isAccepting: canvasNode.isAccepting,
+                                isHighlighted: isHighlighted,
+                              );
+                            },
                           );
                         },
                       ),

--- a/lib/presentation/widgets/tm_canvas_graphview.dart
+++ b/lib/presentation/widgets/tm_canvas_graphview.dart
@@ -227,27 +227,35 @@ class _TMCanvasGraphViewState extends ConsumerState<TMCanvasGraphView> {
                 builder: (context, highlight, __) {
                   return Stack(
                     children: [
-                      GraphView.builder(
-                        graph: _canvasController.graph,
-                        controller: _canvasController.graphController,
-                        algorithm: _algorithm,
-                        builder: (node) {
-                          final nodeId = node.key?.value?.toString();
-                          if (nodeId == null) {
-                            return const SizedBox.shrink();
+                      LayoutBuilder(
+                        builder: (context, constraints) {
+                          final viewport = constraints.biggest;
+                          if (viewport.width.isFinite && viewport.height.isFinite) {
+                            _canvasController.updateViewportSize(viewport);
                           }
-                          final canvasNode =
-                              _canvasController.nodeById(nodeId);
-                          if (canvasNode == null) {
-                            return const SizedBox.shrink();
-                          }
-                          final isHighlighted =
-                              highlight.stateIds.contains(canvasNode.id);
-                          return _GraphNodeWidget(
-                            label: canvasNode.label,
-                            isInitial: canvasNode.isInitial,
-                            isAccepting: canvasNode.isAccepting,
-                            isHighlighted: isHighlighted,
+                          return GraphView.builder(
+                            graph: _canvasController.graph,
+                            controller: _canvasController.graphController,
+                            algorithm: _algorithm,
+                            builder: (node) {
+                              final nodeId = node.key?.value?.toString();
+                              if (nodeId == null) {
+                                return const SizedBox.shrink();
+                              }
+                              final canvasNode =
+                                  _canvasController.nodeById(nodeId);
+                              if (canvasNode == null) {
+                                return const SizedBox.shrink();
+                              }
+                              final isHighlighted =
+                                  highlight.stateIds.contains(canvasNode.id);
+                              return _GraphNodeWidget(
+                                label: canvasNode.label,
+                                isInitial: canvasNode.isInitial,
+                                isAccepting: canvasNode.isAccepting,
+                                isHighlighted: isHighlighted,
+                              );
+                            },
                           );
                         },
                       ),

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -174,6 +174,30 @@ void main() {
       expect(call['isInitial'], isTrue);
     });
 
+    test('addStateAtCenter converts viewport centre into world coordinates', () {
+      final transformation = controller.graphController.transformationController;
+      expect(transformation, isNotNull);
+      controller.updateViewportSize(const Size(800, 600));
+
+      transformation!.value = Matrix4.identity();
+      controller.addStateAtCenter();
+
+      expect(provider.addStateCalls, hasLength(1));
+      final firstCall = provider.addStateCalls.first;
+      expect(firstCall['x'], closeTo(400, 0.0001));
+      expect(firstCall['y'], closeTo(300, 0.0001));
+
+      transformation.value = Matrix4.identity()
+        ..translate(150.0, -50.0)
+        ..scale(1.5);
+      controller.addStateAtCenter();
+
+      expect(provider.addStateCalls, hasLength(2));
+      final secondCall = provider.addStateCalls.last;
+      expect(secondCall['x'], closeTo((400 - 150) / 1.5, 0.0001));
+      expect(secondCall['y'], closeTo((300 - (-50)) / 1.5, 0.0001));
+    });
+
     test('moveState forwards coordinates to provider', () {
       controller.addStateAt(const Offset(0, 0));
       final id = provider.addStateCalls.first['id'] as String;

--- a/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
@@ -100,6 +100,35 @@ void main() {
       expect(state.label, isNotEmpty);
     });
 
+    test('addStateAtCenter maps viewport centre to PDA world coordinates', () {
+      final transformation = controller.graphController.transformationController;
+      expect(transformation, isNotNull);
+      controller.updateViewportSize(const Size(700, 500));
+
+      transformation!.value = Matrix4.identity();
+      controller.addStateAtCenter();
+
+      var pda = notifier.state.pda;
+      expect(pda, isNotNull);
+      var states = pda!.states.toList(growable: false);
+      expect(states, hasLength(1));
+      expect(states.first.position.x, closeTo(350, 0.0001));
+      expect(states.first.position.y, closeTo(250, 0.0001));
+
+      transformation.value = Matrix4.identity()
+        ..translate(60.0, 140.0)
+        ..scale(1.2);
+      controller.addStateAtCenter();
+
+      pda = notifier.state.pda;
+      expect(pda, isNotNull);
+      states = pda!.states.toList(growable: false);
+      expect(states, hasLength(2));
+      final newest = states.last;
+      expect(newest.position.x, closeTo((350 - 60) / 1.2, 0.0001));
+      expect(newest.position.y, closeTo((250 - 140) / 1.2, 0.0001));
+    });
+
     test('addOrUpdateTransition writes transition metadata', () {
       controller.addStateAt(const Offset(0, 0));
       controller.addStateAt(const Offset(120, 80));

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -98,6 +98,35 @@ void main() {
       expect(state.position.y, closeTo(24, 0.0001));
     });
 
+    test('addStateAtCenter resolves world position from viewport centre', () {
+      final transformation = controller.graphController.transformationController;
+      expect(transformation, isNotNull);
+      controller.updateViewportSize(const Size(600, 400));
+
+      transformation!.value = Matrix4.identity();
+      controller.addStateAtCenter();
+
+      var tm = notifier.state.tm;
+      expect(tm, isNotNull);
+      var states = tm!.states.toList(growable: false);
+      expect(states, hasLength(1));
+      expect(states.first.position.x, closeTo(300, 0.0001));
+      expect(states.first.position.y, closeTo(200, 0.0001));
+
+      transformation.value = Matrix4.identity()
+        ..translate(-120.0, 80.0)
+        ..scale(0.8);
+      controller.addStateAtCenter();
+
+      tm = notifier.state.tm;
+      expect(tm, isNotNull);
+      states = tm!.states.toList(growable: false);
+      expect(states, hasLength(2));
+      final latest = states.last;
+      expect(latest.position.x, closeTo((300 - (-120)) / 0.8, 0.0001));
+      expect(latest.position.y, closeTo((200 - 80) / 0.8, 0.0001));
+    });
+
     test('addOrUpdateTransition stores TM transition data', () {
       controller.addStateAt(const Offset(0, 0));
       controller.addStateAt(const Offset(160, 100));


### PR DESCRIPTION
## Summary
- compute the viewport centre in world space inside the shared GraphView canvas base controller and reuse it in all specialised controllers
- update the GraphView-based widgets to report viewport dimensions so addStateAtCenter can drop nodes at the visual centre
- extend the controller test suites to verify addStateAtCenter respects panning and zooming

## Testing
- not run (Flutter/Dart tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e1e971ce70832eb7ac2d1203031f66