### PR TITLE
Fix GraphView to show disconnected nodes

### DIFF
--- a/lib/features/canvas/graphview/graphview_all_nodes_builder.dart
+++ b/lib/features/canvas/graphview/graphview_all_nodes_builder.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/widgets.dart';
+import 'package:graphview/GraphView.dart';
+
+class GraphViewAllNodes extends GraphView {
+  GraphViewAllNodes.builder({
+    Key? key,
+    required Graph graph,
+    required Algorithm algorithm,
+    Paint? paint,
+    required NodeWidgetBuilder builder,
+    GraphViewController? controller,
+    bool animated = true,
+    ValueKey? initialNode,
+    bool autoZoomToFit = false,
+    Duration? panAnimationDuration,
+    Duration? toggleAnimationDuration,
+    bool centerGraph = false,
+  }) : super.builder(
+          key: key,
+          graph: graph,
+          algorithm: algorithm,
+          paint: paint,
+          builder: builder,
+          controller: controller,
+          animated: animated,
+          initialNode: initialNode,
+          autoZoomToFit: autoZoomToFit,
+          panAnimationDuration: panAnimationDuration,
+          toggleAnimationDuration: toggleAnimationDuration,
+          centerGraph: centerGraph,
+        ) {
+    delegate = _GraphViewAllNodesDelegate(
+      graph: graph,
+      algorithm: algorithm,
+      builder: builder,
+      controller: controller,
+      centerGraph: centerGraph,
+    );
+  }
+}
+
+class _GraphViewAllNodesDelegate extends GraphChildDelegate {
+  _GraphViewAllNodesDelegate({
+    required super.graph,
+    required super.algorithm,
+    required super.builder,
+    required super.controller,
+    super.centerGraph,
+  });
+
+  @override
+  Graph getVisibleGraph() {
+    final visibleGraph = super.getVisibleGraph();
+    _ensureAllNodesPresent(visibleGraph);
+    return visibleGraph;
+  }
+
+  @override
+  Graph getVisibleGraphOnly() {
+    final visibleGraph = super.getVisibleGraphOnly();
+    _ensureAllNodesPresent(visibleGraph);
+    return visibleGraph;
+  }
+
+  void _ensureAllNodesPresent(Graph visibleGraph) {
+    if (visibleGraph.nodes.length == graph.nodes.length) {
+      return;
+    }
+
+    for (final node in graph.nodes) {
+      if (!visibleGraph.nodes.contains(node)) {
+        visibleGraph.addNode(node);
+      }
+    }
+  }
+}

--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -14,6 +14,7 @@ import '../../core/services/simulation_highlight_service.dart';
 import '../../features/canvas/graphview/graphview_canvas_controller.dart';
 import '../../features/canvas/graphview/graphview_canvas_models.dart';
 import '../../features/canvas/graphview/graphview_highlight_channel.dart';
+import '../../features/canvas/graphview/graphview_all_nodes_builder.dart';
 import '../../features/canvas/graphview/graphview_label_field_editor.dart';
 import '../../features/canvas/graphview/graphview_link_overlay_utils.dart';
 import '../providers/automaton_provider.dart';
@@ -681,7 +682,7 @@ class _AutomatonGraphViewCanvasState
                         if (viewport.width.isFinite && viewport.height.isFinite) {
                           _controller.updateViewportSize(viewport);
                         }
-                        return GraphView.builder(
+                        return GraphViewAllNodes.builder(
                           graph: _controller.graph,
                           controller: _controller.graphController,
                           algorithm: _algorithm,

--- a/lib/presentation/widgets/pda_canvas_graphview.dart
+++ b/lib/presentation/widgets/pda_canvas_graphview.dart
@@ -7,6 +7,7 @@ import 'package:graphview/GraphView.dart';
 import '../../core/models/pda.dart';
 import '../../core/models/simulation_highlight.dart';
 import '../../core/services/simulation_highlight_service.dart';
+import '../../features/canvas/graphview/graphview_all_nodes_builder.dart';
 import '../../features/canvas/graphview/graphview_pda_canvas_controller.dart';
 import '../../features/canvas/graphview/graphview_canvas_models.dart';
 import '../../features/canvas/graphview/graphview_highlight_channel.dart';
@@ -243,7 +244,7 @@ class _PDACanvasGraphViewState extends ConsumerState<PDACanvasGraphView> {
                           if (viewport.width.isFinite && viewport.height.isFinite) {
                             _canvasController.updateViewportSize(viewport);
                           }
-                          return GraphView.builder(
+                          return GraphViewAllNodes.builder(
                             graph: _canvasController.graph,
                             controller: _canvasController.graphController,
                             algorithm: _algorithm,

--- a/lib/presentation/widgets/tm_canvas_graphview.dart
+++ b/lib/presentation/widgets/tm_canvas_graphview.dart
@@ -8,6 +8,7 @@ import '../../core/models/simulation_highlight.dart';
 import '../../core/models/tm.dart';
 import '../../core/models/tm_transition.dart';
 import '../../core/services/simulation_highlight_service.dart';
+import '../../features/canvas/graphview/graphview_all_nodes_builder.dart';
 import '../../features/canvas/graphview/graphview_canvas_models.dart';
 import '../../features/canvas/graphview/graphview_highlight_channel.dart';
 import '../../features/canvas/graphview/graphview_tm_canvas_controller.dart';
@@ -233,7 +234,7 @@ class _TMCanvasGraphViewState extends ConsumerState<TMCanvasGraphView> {
                           if (viewport.width.isFinite && viewport.height.isFinite) {
                             _canvasController.updateViewportSize(viewport);
                           }
-                          return GraphView.builder(
+                          return GraphViewAllNodes.builder(
                             graph: _canvasController.graph,
                             controller: _canvasController.graphController,
                             algorithm: _algorithm,


### PR DESCRIPTION
## Summary
- add a GraphViewAllNodes builder that keeps disconnected nodes visible
- update the automaton, PDA, and TM canvases to render via the new builder so every state is shown

## Testing
- `flutter analyze` *(fails: flutter is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e1e0a505cc832eaed0e565d7c1dd8f