### PR TITLE
Freeze canvas panning for non-selection tools

### DIFF
--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -12,6 +12,7 @@ import 'package:jflutter/core/repositories/automaton_repository.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:jflutter/data/services/automaton_service.dart';
 import 'package:jflutter/features/canvas/graphview/graphview_canvas_controller.dart';
+import 'package:jflutter/features/canvas/graphview/graphview_label_field_editor.dart';
 import 'package:jflutter/presentation/providers/automaton_provider.dart';
 import 'package:jflutter/presentation/widgets/automaton_canvas_tool.dart';
 import 'package:jflutter/presentation/widgets/automaton_graphview_canvas.dart';
@@ -312,6 +313,32 @@ void main() {
       );
       await tester.pumpAndSettle();
     }
+
+    testWidgets(
+      'shows transition editor after jittery taps when transition tool is active',
+      (tester) async {
+        final automaton = _buildAutomaton({});
+
+        await _pumpCanvas(tester, automaton);
+
+        final sourceGesture =
+            await tester.startGesture(tester.getCenter(find.text('A')));
+        await sourceGesture.moveBy(const Offset(1, 1));
+        await sourceGesture.up();
+        await tester.pump();
+
+        final targetGesture =
+            await tester.startGesture(tester.getCenter(find.text('B')));
+        await targetGesture.moveBy(const Offset(1, -1));
+        await targetGesture.up();
+        await tester.pumpAndSettle();
+
+        expect(
+          find.byType(GraphViewLabelFieldEditor),
+          findsOneWidget,
+        );
+      },
+    );
 
     testWidgets('allows creating a new edge when one already exists', (
       tester,


### PR DESCRIPTION
## Summary
- freeze the current transformation when leaving selection mode so panning stays locked for add/transition tools without suppressing gestures
- only wire the add-state tap handler on the canvas when that tool is active to keep transition taps responsive
- add a widget test that mimics jittery transition taps to confirm the editor still opens

## Testing
- Not run (Flutter/`dart` tooling unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e28fd67060832e8d5ee84893995f35