### PR TITLE
Fix automaton canvas gesture recognizer coordination

### DIFF
--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -1086,6 +1086,8 @@ class _AutomatonGraphViewCanvasState
   }
 
   Map<Type, GestureRecognizerFactory> _buildGestureRecognizers() {
+    final team = GestureArenaTeam();
+
     final gestures = <Type, GestureRecognizerFactory>{
       _NodePanGestureRecognizer:
           GestureRecognizerFactoryWithHandlers<_NodePanGestureRecognizer>(
@@ -1100,11 +1102,12 @@ class _AutomatonGraphViewCanvasState
             ),
             (recognizer) {
               recognizer
+                ..team = team
                 ..onStart = _handleNodePanStart
                 ..onUpdate = _handleNodePanUpdate
                 ..onEnd = _handleNodePanEnd
                 ..onCancel = _handleNodePanCancel
-                ..dragStartBehavior = DragStartBehavior.down;
+                ..dragStartBehavior = DragStartBehavior.start;
             },
           ),
     };
@@ -1121,6 +1124,7 @@ class _AutomatonGraphViewCanvasState
             ),
           ),
           (recognizer) {
+            recognizer.team = team;
             recognizer.onNodeTap = (node) => _handleNodeTap(node.id);
           },
         );
@@ -1137,6 +1141,7 @@ class _AutomatonGraphViewCanvasState
             ),
           ),
           (recognizer) {
+            recognizer.team = team;
             recognizer.onNodeDoubleTap = (node) =>
                 _handleNodeContextTap(node.id);
           },
@@ -1635,7 +1640,6 @@ class _NodePanGestureRecognizer extends PanGestureRecognizer {
     );
     _activePointer = event.pointer;
     super.addAllowedPointer(event);
-    resolvePointer(event.pointer, GestureDisposition.accepted);
   }
 
   @override
@@ -1691,7 +1695,6 @@ class _NodeTapGestureRecognizer extends TapGestureRecognizer {
       'down on ${node.id} tool=${toolResolver().name}',
     );
     super.addAllowedPointer(event);
-    resolvePointer(event.pointer, GestureDisposition.accepted);
   }
 
   @override

--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -243,6 +243,64 @@ void main() {
           );
         },
       );
+
+    testWidgets(
+      'double tap on a node with selection tool opens the state options sheet',
+      (tester) async {
+        toolController.setActiveTool(AutomatonCanvasTool.selection);
+        final state = automaton_state.State(
+          id: 'A',
+          label: 'A',
+          position: Vector2(40, 40),
+          isInitial: true,
+        );
+        final automaton = FSA(
+          id: 'context',
+          name: 'Automaton',
+          states: {state},
+          transitions: const <FSATransition>{},
+          alphabet: const <String>{'a'},
+          initialState: state,
+          acceptingStates: <automaton_state.State>{},
+          created: DateTime.utc(2024, 1, 1),
+          modified: DateTime.utc(2024, 1, 1),
+          bounds: const math.Rectangle<double>(0, 0, 400, 300),
+          zoomLevel: 1,
+          panOffset: Vector2.zero(),
+        );
+
+        provider.updateAutomaton(automaton);
+        controller.synchronize(automaton);
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: AutomatonGraphViewCanvas(
+                automaton: automaton,
+                canvasKey: GlobalKey(),
+                controller: controller,
+                toolController: toolController,
+              ),
+            ),
+          ),
+        );
+
+        await tester.pumpAndSettle();
+
+        final stateFinder = find.text('A');
+        expect(stateFinder, findsOneWidget);
+
+        await tester.tap(stateFinder);
+        await tester.pump(const Duration(milliseconds: 100));
+        await tester.tap(stateFinder);
+        await tester.pumpAndSettle();
+
+        expect(find.text('State label'), findsOneWidget);
+
+        await tester.tap(find.text('Close'));
+        await tester.pumpAndSettle();
+      },
+    );
   });
 
   group('AutomatonGraphViewCanvas', () {


### PR DESCRIPTION
## Summary
- stop forcing immediate acceptance in the node pan and tap recognizers and delay drags until movement begins
- add a shared GestureArenaTeam so pan, tap, and double-tap recognizers coordinate like GestureDetector
- add a widget test that double taps a node and ensures the state options sheet opens

## Testing
- Not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e393e84c58832e865b0363e40a45fa