### PR TITLE
Fix gesture arena interactions for node gestures

### DIFF
--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -1104,8 +1104,10 @@ class _AutomatonGraphViewCanvasState
               ),
             ),
             (recognizer) {
+              if (recognizer.team == null) {
+                recognizer.team = team;
+              }
               recognizer
-                ..team = team
                 ..onStart = _handleNodePanStart
                 ..onUpdate = _handleNodePanUpdate
                 ..onEnd = _handleNodePanEnd
@@ -1127,7 +1129,9 @@ class _AutomatonGraphViewCanvasState
             ),
           ),
           (recognizer) {
-            recognizer.team = team;
+            if (recognizer.team == null) {
+              recognizer.team = team;
+            }
             recognizer.onNodeTap = (node) => _handleNodeTap(node.id);
           },
         );
@@ -1144,7 +1148,6 @@ class _AutomatonGraphViewCanvasState
             ),
           ),
           (recognizer) {
-            recognizer.team = team;
             recognizer.onNodeDoubleTap = (node) =>
                 _handleNodeContextTap(node.id);
           },

--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -1702,11 +1702,11 @@ class _NodePanGestureRecognizer extends PanGestureRecognizer {
     if (node == null) {
       return;
     }
+    _activePointer = event.pointer;
     debugPrint(
-      '[NodePanRecognizer] accepting pointer ${event.pointer} '
+      '[NodePanRecognizer] tracking pointer ${event.pointer} '
       'for node ${node.id}',
     );
-    _activePointer = event.pointer;
     super.addAllowedPointer(event);
   }
 
@@ -1741,16 +1741,10 @@ class _NodeTapGestureRecognizer extends TapGestureRecognizer {
   ValueChanged<GraphViewCanvasNode>? onNodeTap;
   GraphViewCanvasNode? _downNode;
 
-  bool get _toolEnabled {
-    final tool = toolResolver();
-    return tool == AutomatonCanvasTool.transition ||
-        tool == AutomatonCanvasTool.selection;
-  }
-
   @override
   void addAllowedPointer(PointerDownEvent event) {
     onPointerDown?.call(event.position);
-    if (!_toolEnabled) {
+    if (toolResolver() != AutomatonCanvasTool.transition) {
       return;
     }
     final node = hitTester(event.position);


### PR DESCRIPTION
## Summary
- allow the node pan recognizer to keep a single active pointer without pre-emptively accepting the gesture
- gate the single-tap recognizer to the transition tool so double-taps remain available in selection mode

## Testing
- flutter analyze *(fails: flutter binary not available in container)*
- Manual verification of drag/double-tap behaviour *(not run; no device/emulator available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e396265efc832e81d07b8b22a16011