### PR TITLE
Refine self-loop geometry rendering

### DIFF
--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -515,4 +515,26 @@ void main() {
         normalizedDirection.dy * tangent.vector.dy;
     expect(dot, closeTo(1, 0.1));
   });
+
+  test('self-loop geometry label anchor responds to factor', () {
+    const center = Offset(72, 64);
+    const nodeRadius = 26.0;
+
+    final early = buildSelfLoopGeometry(
+      center: center,
+      nodeRadius: nodeRadius,
+      labelPositionFactor: 0.25,
+    );
+
+    final late = buildSelfLoopGeometry(
+      center: center,
+      nodeRadius: nodeRadius,
+      labelPositionFactor: 0.75,
+    );
+
+    expect(early.labelAnchor, isNot(equals(late.labelAnchor)));
+    final earlyDistance = (early.tip - early.labelAnchor).distance;
+    final lateDistance = (late.tip - late.labelAnchor).distance;
+    expect(lateDistance, lessThan(earlyDistance));
+  });
 }


### PR DESCRIPTION
## Summary
- align self-loop generation with tangent-based arrow direction and configurable label positioning
- expose a label position constant so width, height, tightness, and label placement can be tuned together
- extend the widget test suite to cover the label position factor behaviour

## Testing
- Not run (Flutter tooling is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3962c5630832eb9016f7b3a973052