### PR TITLE
Add standard headers to feature files

### DIFF
--- a/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/base_graphview_canvas_controller.dart
+/// Descrição: Implementa o controlador base do GraphView, lidando com histórico
+///            de snapshots, animações de camera e integrações de destaque.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:graphview/GraphView.dart';

--- a/lib/features/canvas/graphview/graphview_all_nodes_builder.dart
+++ b/lib/features/canvas/graphview/graphview_all_nodes_builder.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_all_nodes_builder.dart
+/// Descrição: Estende o GraphView padrão para renderizar todos os nós do
+///            canvas, respeitando animações e ajustes de zoom personalizados.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/widgets.dart';
 import 'package:graphview/GraphView.dart';
 

--- a/lib/features/canvas/graphview/graphview_automaton_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_automaton_mapper.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_automaton_mapper.dart
+/// Descrição: Converte autômatos finitos em snapshots do GraphView,
+///            traduzindo estados e transições para o modelo visual do canvas.
+/// ---------------------------------------------------------------------------
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/fsa.dart';

--- a/lib/features/canvas/graphview/graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_controller.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_canvas_controller.dart
+/// Descrição: Gerencia o canvas GraphView para autômatos finitos, sincronizando
+///            o grafo renderizado com o provedor e eventos de interação.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/canvas/graphview/graphview_canvas_models.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_models.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_canvas_models.dart
+/// Descrição: Define modelos imutáveis usados pelo canvas GraphView para
+///            representar metadados, nós e transições durante a renderização.
+/// ---------------------------------------------------------------------------
 import 'package:collection/collection.dart';
 
 import '../../../core/models/tm_transition.dart';

--- a/lib/features/canvas/graphview/graphview_highlight_channel.dart
+++ b/lib/features/canvas/graphview/graphview_highlight_channel.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_highlight_channel.dart
+/// Descrição: Encaminha realces do serviço de simulação para controladores
+///            GraphView, mantendo o canvas alinhado com o estado da execução.
+/// ---------------------------------------------------------------------------
 import '../../../core/models/simulation_highlight.dart';
 import '../../../core/services/simulation_highlight_service.dart';
 import 'graphview_highlight_controller.dart';

--- a/lib/features/canvas/graphview/graphview_highlight_controller.dart
+++ b/lib/features/canvas/graphview/graphview_highlight_controller.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_highlight_controller.dart
+/// Descrição: Define o contrato de controle de destaques de simulação para o
+///            canvas GraphView, padronizando aplicação e limpeza de realces.
+/// ---------------------------------------------------------------------------
 import '../../../core/models/simulation_highlight.dart';
 
 /// Common contract exposed by GraphView canvas controllers that support

--- a/lib/features/canvas/graphview/graphview_label_field_editor.dart
+++ b/lib/features/canvas/graphview/graphview_label_field_editor.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_label_field_editor.dart
+/// Descrição: Fornece o overlay de edição de rótulos de transição no GraphView,
+///            mediando entrada do usuário e confirmação/cancelamento no canvas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../presentation/widgets/transition_editors/transition_label_editor.dart';

--- a/lib/features/canvas/graphview/graphview_link_overlay_utils.dart
+++ b/lib/features/canvas/graphview/graphview_link_overlay_utils.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_link_overlay_utils.dart
+/// Descrição: Calcula âncoras e posições de sobreposição para arestas no
+///            GraphView, garantindo alinhamento visual consistente no canvas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../core/constants/automaton_canvas.dart';

--- a/lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
+++ b/lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
+/// Descrição: Define payloads leves para eventos do editor GraphView, como
+///            seleção por arrasto e destaques de links durante edições.
+/// ---------------------------------------------------------------------------
 import 'dart:ui';
 
 /// Lightweight payload describing the result of a drag-selection gesture within

--- a/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
+/// Descrição: Coordena o canvas GraphView para autômatos de pilha, gerenciando
+///            sincronização, seleção e manipulação visual das estruturas PDA.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/canvas/graphview/graphview_pda_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_pda_mapper.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_pda_mapper.dart
+/// Descrição: Transforma autômatos de pilha em snapshots consumidos pelo
+///            GraphView, organizando estados, pilha e transições para o canvas.
+/// ---------------------------------------------------------------------------
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/pda.dart';

--- a/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
+/// Descrição: Administra o canvas GraphView para Turing Machines, mantendo
+///            sincronismo entre o grafo, o provedor e interações de edição.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/canvas/graphview/graphview_tm_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_tm_mapper.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_tm_mapper.dart
+/// Descrição: Faz a ponte entre Turing Machines do domínio e snapshots do
+///            GraphView, mapeando estados, transições e fitas para o canvas.
+/// ---------------------------------------------------------------------------
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/state.dart';

--- a/lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
+++ b/lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
@@ -1,3 +1,9 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
+/// Descrição: Reúne utilidades de viewport e destaque para controladores
+///            GraphView, incluindo enquadramento automático e animações de foco.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/layout/layout_repository_impl.dart
+++ b/lib/features/layout/layout_repository_impl.dart
@@ -1,3 +1,10 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/features/layout/layout_repository_impl.dart
+/// Descrição: Implementa heurísticas de auto layout para autômatos, calculando
+///            posições dos estados com distribuição radial e espaçamentos
+///            seguros no canvas.
+/// ---------------------------------------------------------------------------
 import 'dart:collection';
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';


### PR DESCRIPTION
## Summary
- add the standard Portuguese header block to the layout repository implementation
- document the responsibilities of the GraphView controllers, mappers, and utilities with the same header format

## Testing
- not run (dart SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68e515d87530832e921f81474c75328f