### PR TITLE
Wire data trace persistence provider via GetIt

### DIFF
--- a/lib/presentation/providers/unified_trace_provider.dart
+++ b/lib/presentation/providers/unified_trace_provider.dart
@@ -303,7 +303,7 @@ class UnifiedTraceNotifier extends StateNotifier<UnifiedTraceState> {
 /// Provider for trace persistence service (data layer version)
 final dataTracePersistenceServiceProvider =
     Provider<data_trace.TracePersistenceService>((ref) {
-      throw UnimplementedError('TracePersistenceService must be initialized');
+      return getIt<data_trace.TracePersistenceService>();
     });
 
 /// Provider for unified trace state


### PR DESCRIPTION
## Summary
- resolve the data trace persistence provider by returning the registered TracePersistenceService from GetIt

## Testing
- flutter analyze *(fails: flutter command is not available in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e516b32fc0832e83aab790e868be75