### PR TITLE
docs: normalize reference paths

### DIFF
--- a/QUICKSTART_EVIDENCE.md
+++ b/QUICKSTART_EVIDENCE.md
@@ -42,9 +42,9 @@ This document provides evidence of the successful execution of the JFlutter appl
 - **Architecture**: arm64
 
 ### Build Artifacts
-- **Application Path**: `/Users/thales/Documents/GitHub/jflutter/build/macos/Build/Products/Debug/jflutter.app`
-- **Build Directory**: `/Users/thales/Documents/GitHub/jflutter/build/macos/`
-- **Xcode Workspace**: `/Users/thales/Documents/GitHub/jflutter/macos/Runner.xcworkspace`
+- **Application Path**: `build/macos/Build/Products/Debug/jflutter.app`
+- **Build Directory**: `build/macos/`
+- **Xcode Workspace**: `macos/Runner.xcworkspace`
 
 ### Verification Commands Used
 ```bash

--- a/docs/references-alignment.md
+++ b/docs/references-alignment.md
@@ -4,16 +4,16 @@
 This document pairs each algorithm, simulator, and interoperability feature from the JFlutter reinforcement effort with the authoritative implementation kept in `References/`. It also records how we will validate our Dart/Flutter port against those sources during development.
 
 ## Reference Catalog
-| Domain | Reference Source (absolute path) | Notes |
+| Domain | Reference Source | Notes |
 | --- | --- | --- |
-| Finite Automata (DFA/NFA/λ-NFA) | /Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/dfa/dfa.py<br>/Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/nfa/nfa.py<br>/Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/fa.py | Python implementations for conversions, Hopcroft minimization, closure properties; exposes deterministic checks and state/transition models. |
-| FA Conversions (NFA→DFA UI sample) | /Users/thales/Documents/GitHub/jflutter/References/nfa_2_dfa-main/lib | Flutter demo showing state/transition modeling and conversion flows used for UI parity checks. |
-| Regex → AST → Thompson NFA | /Users/thales/Documents/GitHub/jflutter/References/dart-petitparser-examples-main/lib/src/regex | PetitParser grammars and AST builders used to validate parser structure and Thompson construction. |
-| CFG Toolkit & CYK | /Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/cfg/cfg.py<br>/Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/grammar/ | CNF transforms, useless symbol elimination, and CYK membership checks. |
-| PDA Simulation & Determinism Checks | /Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/pda/pda.py | Acceptance by final state, empty stack, or both; determinism validation and configuration stepping. |
-| Turing Machine Simulation | /Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/tm/tm.py<br>/Users/thales/Documents/GitHub/jflutter/References/turing-machine-generator-main/lib | Deterministic/Nondeterministic TM models and generator utilities for building traces and editing primitives. |
-| Pumping Lemma Game & Automata Visualizations | /Users/thales/Documents/GitHub/jflutter/References/AutomataTheory-master/lib | Dart teaching library with canonical pumping lemma challenges and canvas interaction patterns. |
-| Examples Library & Round-trip Artifacts | /Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/data<br>/Users/thales/Documents/GitHub/jflutter/References/nfa_2_dfa-main/assets | Source `.jff`, JSON, and SVG artifacts for regression and interoperability tests. |
+| Finite Automata (DFA/NFA/λ-NFA) | [References/automata-main/automata/dfa/dfa.py](../References/automata-main/automata/dfa/dfa.py)<br>[References/automata-main/automata/nfa/nfa.py](../References/automata-main/automata/nfa/nfa.py)<br>[References/automata-main/automata/fa.py](../References/automata-main/automata/fa.py) | Python implementations for conversions, Hopcroft minimization, closure properties; exposes deterministic checks and state/transition models. |
+| FA Conversions (NFA→DFA UI sample) | [References/nfa_2_dfa-main/lib](../References/nfa_2_dfa-main/lib) | Flutter demo showing state/transition modeling and conversion flows used for UI parity checks. |
+| Regex → AST → Thompson NFA | [References/dart-petitparser-examples-main/lib/src/regex](../References/dart-petitparser-examples-main/lib/src/regex) | PetitParser grammars and AST builders used to validate parser structure and Thompson construction. |
+| CFG Toolkit & CYK | [References/automata-main/automata/cfg/cfg.py](../References/automata-main/automata/cfg/cfg.py)<br>[References/automata-main/automata/grammar/](../References/automata-main/automata/grammar) | CNF transforms, useless symbol elimination, and CYK membership checks. |
+| PDA Simulation & Determinism Checks | [References/automata-main/automata/pda/pda.py](../References/automata-main/automata/pda/pda.py) | Acceptance by final state, empty stack, or both; determinism validation and configuration stepping. |
+| Turing Machine Simulation | [References/automata-main/automata/tm/tm.py](../References/automata-main/automata/tm/tm.py)<br>[References/turing-machine-generator-main/lib](../References/turing-machine-generator-main/lib) | Deterministic/Nondeterministic TM models and generator utilities for building traces and editing primitives. |
+| Pumping Lemma Game & Automata Visualizations | [References/AutomataTheory-master/lib](../References/AutomataTheory-master/lib) | Dart teaching library with canonical pumping lemma challenges and canvas interaction patterns. |
+| Examples Library & Round-trip Artifacts | [References/automata-main/tests/data](../References/automata-main/tests/data)<br>[References/nfa_2_dfa-main/assets](../References/nfa_2_dfa-main/assets) | Source `.jff`, JSON, and SVG artifacts for regression and interoperability tests. |
 
 ## Validation Plan
 
@@ -27,13 +27,13 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Finite Automata (DFA/NFA/λ-NFA)
 - **Scope**: Conversions (NFA→DFA, λ-NFA closure), Hopcroft minimization, regex↔automaton conversions, language operations (union, intersection, complement, concatenation, Kleene/star, reverse), property diagnostics (emptiness, finiteness, equivalence).
 - **Reference usage**:
-  1. **Primary**: Mirror acceptance and minimization scenarios from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/test_dfa.py` and `test_nfa.py` inside new Dart unit tests (T004, T005, T012, T013).
+  1. **Primary**: Mirror acceptance and minimization scenarios from [References/automata-main/tests/test_dfa.py](../References/automata-main/tests/test_dfa.py) and [References/automata-main/tests/test_nfa.py](../References/automata-main/tests/test_nfa.py) inside new Dart unit tests (T004, T005, T012, T013).
   2. **Supporting**: Validate against `jflutter_js/examples/` artifacts:
      - `afd_binary_divisible_by_3.json` - DFA divisibility by 3 (binary)
      - `afd_ends_with_a.json` - DFA string ending validation
      - `afd_parity_AB.json` - DFA parity checking
      - `afn_lambda_a_or_ab.json` - NFA with epsilon transitions
-  3. **UI Integration**: Use Flutter sample in `/Users/thales/Documents/GitHub/jflutter/References/nfa_2_dfa-main/lib` for UI interaction constraints (state naming, epsilon handling) during widget tests (T016).
+  3. **UI Integration**: Use Flutter sample in [References/nfa_2_dfa-main/lib](../References/nfa_2_dfa-main/lib) for UI interaction constraints (state naming, epsilon handling) during widget tests (T016).
 - **Validation checkpoints**:
   - `test/unit/dfa_validation_test.dart` fails prior to implementation, then passes with identical traces as Python reference
   - `test/unit/nfa_validation_test.dart` validates epsilon closure and nondeterministic branching
@@ -43,11 +43,11 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Context-Free Grammars (CFG) and CYK
 - **Scope**: CFG normalization (ε, unit, useless removals), CFG↔PDA conversions, CYK parse trees, CNF transformations.
 - **Reference usage**:
-  1. **Primary**: Reuse CNF transformation tests in `/Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/test_cfg.py` and CYK acceptance data from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/test_cyk.py`.
+  1. **Primary**: Reuse CNF transformation tests in [References/automata-main/tests/test_cfg.py](../References/automata-main/tests/test_cfg.py) and CYK acceptance data from [References/automata-main/tests/test_cyk.py](../References/automata-main/tests/test_cyk.py).
   2. **Supporting**: Validate against `jflutter_js/examples/` artifacts:
      - `glc_balanced_parentheses.json` - CFG for balanced parentheses
      - `glc_palindrome.json` - CFG for palindrome generation
-  3. **Parser Integration**: Use PetitParser grammars from `/Users/thales/Documents/GitHub/jflutter/References/dart-petitparser-examples-main/lib/src/regex` as baseline for parser structure and AST node taxonomy.
+  3. **Parser Integration**: Use PetitParser grammars from [References/dart-petitparser-examples-main/lib/src/regex](../References/dart-petitparser-examples-main/lib/src/regex) as baseline for parser structure and AST node taxonomy.
 - **Validation checkpoints**:
   - `test/unit/glc_validation_test.dart` validates CFG parsing and CYK algorithm
   - `test/unit/cyk_validation_test.dart` ensures CNF parsing and derivation correctness
@@ -56,10 +56,10 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Pushdown Automata (PDA)
 - **Scope**: Immutable PDA simulator, nondeterministic branching with trace folding, acceptance by final state / empty stack / both, determinism warnings.
 - **Reference usage**:
-  1. **Primary**: Replicate PDA acceptance scenarios from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/test_pda.py` for stack discipline and deterministic edge cases.
+  1. **Primary**: Replicate PDA acceptance scenarios from [References/automata-main/tests/test_pda.py](../References/automata-main/tests/test_pda.py) for stack discipline and deterministic edge cases.
   2. **Supporting**: Validate against `jflutter_js/examples/` artifacts:
      - `apda_palindrome.json` - PDA for palindrome recognition
-  3. **Configuration Logic**: Leverage configuration stepping logic from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/pda/pda.py` to validate stack snapshots and transition guards.
+  3. **Configuration Logic**: Leverage configuration stepping logic from [References/automata-main/automata/pda/pda.py](../References/automata-main/automata/pda/pda.py) to validate stack snapshots and transition guards.
 - **Validation checkpoints**:
   - `test/unit/pda_validation_test.dart` asserts identical configuration sequences and acceptance results
   - Trace-folding logic compares aggregated branches with Python reference outputs exported as JSON fixtures
@@ -67,11 +67,11 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Turing Machines (TM)
 - **Scope**: Deterministic and nondeterministic single-tape TM simulation, immutable configuration traces, time-travel UI hooks, editing building blocks.
 - **Reference usage**:
-  1. **Primary**: Adopt transition semantics and halting criteria from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/tm/tm.py`.
+  1. **Primary**: Adopt transition semantics and halting criteria from [References/automata-main/automata/tm/tm.py](../References/automata-main/automata/tm/tm.py).
   2. **Supporting**: Validate against `jflutter_js/examples/` artifacts:
      - `tm_binary_to_unary.json` - TM for binary to unary conversion
-  3. **Generator Integration**: Use generator blueprints in `/Users/thales/Documents/GitHub/jflutter/References/turing-machine-generator-main/lib` to validate tape editing primitives and ensure exported formats stay compatible.
-  4. **Test Integration**: Import canonical machines from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/test_tm.py` for integration tests.
+  3. **Generator Integration**: Use generator blueprints in [References/turing-machine-generator-main/lib](../References/turing-machine-generator-main/lib) to validate tape editing primitives and ensure exported formats stay compatible.
+  4. **Test Integration**: Import canonical machines from [References/automata-main/tests/test_tm.py](../References/automata-main/tests/test_tm.py) for integration tests.
 - **Validation checkpoints**:
   - `test/unit/tm_validation_test.dart` reproduces step-by-step traces delivered by the Python reference
   - UI/widget tests confirm trace navigation matches generator expectations (no state mutation outside providers)
@@ -79,8 +79,8 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Regex Processing
 - **Scope**: Regex parsing to AST, Thompson NFA construction, regex↔automaton conversions.
 - **Reference usage**:
-  1. **Primary**: Validate Thompson NFA edges by comparing with Python automata library conversions from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/automata/regex`.
-  2. **Parser Integration**: Use PetitParser grammars from `/Users/thales/Documents/GitHub/jflutter/References/dart-petitparser-examples-main/lib/src/regex` as baseline for parser structure and AST node taxonomy.
+  1. **Primary**: Validate Thompson NFA edges by comparing with Python automata library conversions from [References/automata-main/automata/regex](../References/automata-main/automata/regex).
+  2. **Parser Integration**: Use PetitParser grammars from [References/dart-petitparser-examples-main/lib/src/regex](../References/dart-petitparser-examples-main/lib/src/regex) as baseline for parser structure and AST node taxonomy.
 - **Validation checkpoints**:
   - `test/unit/regex_validation_test.dart` validates regex→NFA, FA→regex, and equivalence conversions
   - Unit tests under `test/unit/core/regex/` assert structural equality with reference outputs
@@ -88,7 +88,7 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Pumping Lemma & Visualizations
 - **Scope**: Interactive pumping lemma challenges for regular and context-free languages, canvas visualizations (FA/PDA/TM) with ≥60fps target.
 - **Reference usage**:
-  1. Use predefined language challenges and decomposition strategies from `/Users/thales/Documents/GitHub/jflutter/References/AutomataTheory-master/lib/implementations/pumping_lemma`.
+  1. Use predefined language challenges and decomposition strategies from [References/AutomataTheory-master/lib/implementations/pumping_lemma](../References/AutomataTheory-master/lib/implementations/pumping_lemma).
   2. Carry over canvas interaction baselines from the same project to calibrate gesture and layout behaviour.
 - **Validation checkpoints**:
   - `test/unit/presentation/pumping_lemma_game_test.dart` compares challenge progression and feedback messages with the reference definitions.
@@ -97,8 +97,8 @@ This document pairs each algorithm, simulator, and interoperability feature from
 ### Interoperability & Examples Library
 - **Scope**: `.jff`/JSON/SVG round-trip, offline "Examples v1" catalog, reference verifier service integrating Python outputs.
 - **Reference usage**:
-  1. Import `.jff` fixtures from `/Users/thales/Documents/GitHub/jflutter/References/automata-main/tests/data` to seed round-trip tests (T009, T021, T023).
-  2. Reuse assets from `/Users/thales/Documents/GitHub/jflutter/References/nfa_2_dfa-main/assets` for UI smoke tests and to ensure examples render consistently across platforms.
+  1. Import `.jff` fixtures from [References/automata-main/tests/data](../References/automata-main/tests/data) to seed round-trip tests (T009, T021, T023).
+  2. Reuse assets from [References/nfa_2_dfa-main/assets](../References/nfa_2_dfa-main/assets) for UI smoke tests and to ensure examples render consistently across platforms.
   3. Implement the on-device verifier (T022) by invoking the Python algorithms through embedded fixtures and comparing hashed traces.
 - **Validation checkpoints**:
   - Integration tests under `test/integration/io/examples_roundtrip_test.dart` confirm lossless serialization.
@@ -138,6 +138,6 @@ This document pairs each algorithm, simulator, and interoperability feature from
 
 ## Maintenance
 - **Reference Updates**: Re-run upstream reference test suites (`pytest` in `automata-main`, `flutter test` in Dart projects) whenever references are updated to detect breaking changes before porting.
-- **Deviation Tracking**: Record any intentional deviations (e.g., performance optimizations, UI-driven constraints) in `/docs/reference-deviations.md` during implementation tasks (T029).
+- **Deviation Tracking**: Record any intentional deviations (e.g., performance optimizations, UI-driven constraints) in [`docs/reference-deviations.md`](../docs/reference-deviations.md) during implementation tasks (T029).
 - **Documentation Updates**: Update this file if new reference repositories are added or existing paths change.
 - **Example Validation**: Regularly validate `jflutter_js/examples/` artifacts against current implementation to ensure UI/export compatibility.

--- a/specs/001-projeto-jflutter-refor/plan.md
+++ b/specs/001-projeto-jflutter-refor/plan.md
@@ -1,8 +1,8 @@
 
 # Implementation Plan: JFlutter Core Reinforcement Initiative
 
-**Branch**: `001-projeto-jflutter-refor` | **Date**: 2025-09-25 | **Spec**: [/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/spec.md](/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/spec.md)
-**Input**: Feature specification from `/specs/001-projeto-jflutter-refor/spec.md`
+**Branch**: `001-projeto-jflutter-refor` | **Date**: 2025-09-25 | **Spec**: [`specs/001-projeto-jflutter-refor/spec.md`](./spec.md)
+**Input**: Feature specification from [`specs/001-projeto-jflutter-refor/spec.md`](./spec.md)
 
 ## Execution Flow (/plan command scope)
 ```
@@ -102,7 +102,7 @@ lib/
 4. Documentar implicações de licença (Apache-2.0 + JFLAP 7.1) e restrições de distribuição de exemplos.
 5. **Entregar rapidamente** o documento `research.md` consolidando decisões para habilitar as fases seguintes.
 
-**Output**: `/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/research.md`
+**Output**: [`specs/001-projeto-jflutter-refor/research.md`](./research.md)
 
 ## Phase 1: Design & Contracts
 *Prerequisites: research.md complete*
@@ -114,7 +114,7 @@ lib/
 5. Rodar `.specify/scripts/bash/update-agent-context.sh cursor` se novas dependências forem adicionadas.
 6. **Tratar a criação de `data-model.md`, `contracts/` e `quickstart.md` como tarefas prioritárias antes de iniciar implementação.**
 
-**Output**: `/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/data-model.md`, `/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/contracts/`, `/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/quickstart.md`
+**Output**: [`specs/001-projeto-jflutter-refor/data-model.md`](./data-model.md), [`specs/001-projeto-jflutter-refor/contracts/`](./contracts/), [`specs/001-projeto-jflutter-refor/quickstart.md`](./quickstart.md)
 
 ## Phase 2: Task Planning Approach
 *This section describes what the /tasks command will do - DO NOT execute during /plan*

--- a/specs/001-projeto-jflutter-refor/tasks.md
+++ b/specs/001-projeto-jflutter-refor/tasks.md
@@ -61,8 +61,8 @@
 
 ## Phase 3.5: QA & Documentation
 - [X] T027 [P] Rodar `flutter analyze`, `dart format`, e toda suíte de testes garantindo determinismo — Obs.: antes de implementar, estudar as implementações em `References/`
-- [X] T028 [P] Documentar quickstart offline em `/Users/thales/Documents/GitHub/jflutter/specs/001-projeto-jflutter-refor/quickstart.md` e atualizar README com "Examples v1" e novo escopo
-- [X] T029 [P] Registrar resultados de regressão e desvios das referências em `/docs/reference-deviations.md`
+- [X] T028 [P] Documentar quickstart offline em [`specs/001-projeto-jflutter-refor/quickstart.md`](./quickstart.md) e atualizar README com "Examples v1" e novo escopo
+- [X] T029 [P] Registrar resultados de regressão e desvios das referências em [`docs/reference-deviations.md`](../../docs/reference-deviations.md)
 
 ## Dependencies
 - T001 → T002 → T003 (Setup antes dos testes)

--- a/specs/002-dois-objetivos-principais/plan.md
+++ b/specs/002-dois-objetivos-principais/plan.md
@@ -1,8 +1,8 @@
 
 # Implementation Plan: Auditoria de algoritmos vs referências e validação de UI
 
-**Branch**: `002-dois-objetivos-principais` | **Date**: 2025-09-29 | **Spec**: `/Users/thales/Documents/GitHub/jflutter/specs/002-dois-objetivos-principais/spec.md`
-**Input**: Feature specification from `/specs/002-dois-objetivos-principais/spec.md`
+**Branch**: `002-dois-objetivos-principais` | **Date**: 2025-09-29 | **Spec**: [`specs/002-dois-objetivos-principais/spec.md`](./spec.md)
+**Input**: Feature specification from [`specs/002-dois-objetivos-principais/spec.md`](./spec.md)
 
 ## Execution Flow (/plan command scope)
 ```

--- a/specs/003-ui-improvement-taskforce/plan.md
+++ b/specs/003-ui-improvement-taskforce/plan.md
@@ -1,8 +1,8 @@
 
 # Implementation Plan: UI Improvement Taskforce
 
-**Branch**: `003-ui-improvement-taskforce` | **Date**: 2025-10-01 | **Spec**: `/Users/thales/Documents/GitHub/jflutter/specs/003-ui-improvement-taskforce/spec.md`
-**Input**: Feature specification from `/Users/thales/Documents/GitHub/jflutter/specs/003-ui-improvement-taskforce/spec.md`
+**Branch**: `003-ui-improvement-taskforce` | **Date**: 2025-10-01 | **Spec**: [`specs/003-ui-improvement-taskforce/spec.md`](./spec.md)
+**Input**: Feature specification from [`specs/003-ui-improvement-taskforce/spec.md`](./spec.md)
 
 ## Execution Flow (/plan command scope)
 ```

--- a/specs/003-ui-improvement-taskforce/quickstart.md
+++ b/specs/003-ui-improvement-taskforce/quickstart.md
@@ -25,7 +25,7 @@ Manual UI validation workflow for QA and developers to verify UI improvements ar
 
 ### Build and Run
 ```bash
-cd /Users/thales/Documents/GitHub/jflutter
+cd <jflutter-repo-root>
 
 # Run on iOS simulator
 flutter run -d ios

--- a/specs/003-ui-improvement-taskforce/tasks.md
+++ b/specs/003-ui-improvement-taskforce/tasks.md
@@ -1,6 +1,6 @@
 # Tasks: UI Improvement Taskforce
 
-**Input**: Design documents from `/Users/thales/Documents/GitHub/jflutter/specs/003-ui-improvement-taskforce/`
+**Input**: Design documents from [`specs/003-ui-improvement-taskforce/`](./)
 **Prerequisites**: plan.md (required), research.md, data-model.md, contracts/, quickstart.md
 
 ## Execution Flow (main)


### PR DESCRIPTION
## Summary
- replace machine-specific absolute paths in documentation with repository-relative references and internal links
- convert reference catalog entries to markdown hyperlinks targeting `References/` assets and update plan/task documents accordingly
- generalize quickstart instructions so that collaborators can run from any cloned repository path

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e515f8eb0c832e9beb41e7435f4ad2