### PR TITLE
Add documentation headers to presentation layer

### DIFF
--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/fsa_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Agrega ferramentas de edição, simulação e algoritmos para Autômatos Finitos em layout integrado. Coordena canvas GraphView, painel de algoritmos e controles móveis oferecendo ambiente completo de experimentação.
+/// Contexto: Interage com provedores de automato e algoritmos para executar operações como minimização, conversões e simulações. Sincroniza serviços de destaque e controladores para garantir visualização consistente em todo o workspace.
+/// Observações: Inicializa controladores compartilhados no initState e garante descarte adequado no ciclo de vida do widget. Estrutura modular permite incorporar novas funcionalidades como exportação ou análises adicionais com mínimo acoplamento.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/entities/automaton_entity.dart';

--- a/lib/presentation/pages/grammar_page.dart
+++ b/lib/presentation/pages/grammar_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/grammar_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Organiza ferramentas para edição, simulação e análise de gramáticas livres de contexto em layouts responsivos. Permite alternar painéis conforme o espaço disponível oferecendo experiência personalizada em desktop e mobile.
+/// Contexto: Agrupa widgets como GrammarEditor, GrammarSimulationPanel e GrammarAlgorithmPanel para cobrir todo o ciclo de estudo. Inclui controles para mostrar ou ocultar seções e adaptar a interface a diferentes tamanhos de tela.
+/// Observações: Mantém estado local simples indicando quais módulos estão visíveis, facilitando futuras expansões. Estrutura scaffold neutro que pode receber barras ou menus adicionais sem grande esforço.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/grammar_editor.dart';

--- a/lib/presentation/pages/help_page.dart
+++ b/lib/presentation/pages/help_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/help_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Reúne conteúdo de ajuda interativo e tutoriais organizados por módulos como FSA, PDA e MT. Oferece navegação tabulada e exemplos passo a passo para guiar estudantes dentro do aplicativo.
+/// Contexto: Inspirado na documentação do JFLAP original, adapta tópicos para a experiência Flutter com componentes responsivos. Combina explicações textuais, listas e fluxos orientados para facilitar o aprendizado progressivo.
+/// Observações: Usa PageView e controladores de estado para alternar seções mantendo estado consistente entre abas. Facilita extensão com novos capítulos adicionando itens à lista de HelpSection.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/home_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Página inicial que organiza todos os módulos do aplicativo com navegação responsiva e foco mobile-first. Integra páginas de autômatos, gramáticas, expressões regulares, lema do bombeamento e configurações em um hub unificado.
+/// Contexto: Utiliza Riverpod para sincronizar índice de navegação e provedores principais, além de PageView para transições suaves entre seções. Fornece navegação inferior para dispositivos móveis e mantém serviços de destaque compartilhados quando necessário.
+/// Observações: Mantém registro do último índice para coordenar animações e reutiliza um serviço de destaque padrão quando módulos específicos não fornecem um. Estrutura pronta para adicionar novos itens simplesmente estendendo a lista de NavigationItem.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/automaton_provider.dart';

--- a/lib/presentation/pages/pda_page.dart
+++ b/lib/presentation/pages/pda_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/pda_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Disponibiliza ambiente completo para criação, simulação e análise de Autômatos de Pilha. Integra canvas GraphView, painéis de algoritmos e controles adaptados a diferentes formatos de tela.
+/// Contexto: Coordena provedores de edição, serviços de destaque e controladores para manter o estado do PDA sincronizado entre componentes. Exibe métricas e controla indicadores de alterações pendentes para orientar ações do usuário.
+/// Observações: Gerencia inscrições Riverpod no ciclo de vida garantindo limpeza de recursos. Estrutura pronta para incorporar novos módulos como exportação ou diagnósticos adicionais mantendo fluxo atual.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/pages/pumping_lemma_page.dart
+++ b/lib/presentation/pages/pumping_lemma_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/pumping_lemma_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Orquestra a experiência do jogo do Lema do Bombeamento combinando módulos de jogo, ajuda teórica e progresso. Adapta o layout para desktop e mobile permitindo alternar seções conforme o espaço disponível.
+/// Contexto: Utiliza widgets especializados para cada aspecto do aprendizado e fornece controles para mostrar ou ocultar painéis. Centraliza a lógica de disposição para oferecer fluxo pedagógico coeso sobre linguagens regulares e não regulares.
+/// Observações: Mantém estado local para visibilidade de seções facilitando personalização da experiência pelo usuário. Pode ser expandida com novos modos ou métricas preservando a estrutura de alternância existente.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/pumping_lemma_game/pumping_lemma_game.dart';

--- a/lib/presentation/pages/regex_page.dart
+++ b/lib/presentation/pages/regex_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/regex_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Página dedicada a expressões regulares permitindo testá-las, convertê-las em autômatos e comparar equivalências. Integra controles de simulação e algoritmos para fornecer ciclo completo de validação.
+/// Contexto: Aproveita provedores de autômatos e casos de uso para executar conversões NFA↔DFA e verificações de aceitação. Organiza formulários e resultados em cartões para oferecer feedback claro sobre erros e coincidências.
+/// Observações: Gerencia controladores de texto e estado local de validação para atualizar indicadores conforme o usuário digita. Pode ser expandida com novas ferramentas analíticas preservando a estrutura já estabelecida.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/algorithms/automaton_simulator.dart';

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/settings_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Exibe e permite configurar preferências globais da aplicação como aparência e comportamento padrão. Carrega dados persistidos e sincroniza alterações com o repositório de configurações.
+/// Contexto: Utiliza Riverpod e repositórios baseados em SharedPreferences para fornecer experiência consistente entre plataformas. Organiza controles em cartões e seções que refletem o SettingsModel vigente.
+/// Observações: Gerencia estados de carregamento e persistência assegurando feedback ao usuário durante operações assíncronas. Flexível para incorporar novas categorias de configuração mantendo arquitetura existente.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/pages/tm_page.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Centraliza ferramentas de edição, simulação e análise de Máquinas de Turing em layout responsivo. Integra canvas GraphView, painéis de algoritmos e controles móveis para oferecer ambiente completo de estudo.
+/// Contexto: Coordena provedores e serviços de destaque para manter sincronização entre editor, simulador e métricas. Acompanha métricas como quantidade de estados, transições e símbolos garantindo feedback sobre a configuração da máquina.
+/// Observações: Gerencia ciclo de vida de controladores e assinaturas Riverpod evitando vazamentos e estados inconsistentes. Pode ser personalizado com novos painéis mantendo a arquitetura modular existente.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/providers/algorithm_provider.dart
+++ b/lib/presentation/providers/algorithm_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/algorithm_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Centraliza a chamada dos casos de uso de algoritmos formais expostos na interface. Garante que operações de conversão, minimização e equivalência emitam estados coerentes para feedback ao usuário.
+/// Contexto: Implementa um StateNotifier Riverpod que encadeia repositórios e casos de uso definidos no domínio. Padroniza os ciclos de carregamento e propagação de erros para componentes de UI que consomem resultados de algoritmos.
+/// Observações: Mantém o último resultado ou falha para reutilização em painéis subsequentes. Facilita a extensão futura adicionando novos casos de uso sem alterar a superfície pública dos widgets.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/use_cases/algorithm_use_cases.dart';
 import '../../core/entities/automaton_entity.dart';

--- a/lib/presentation/providers/automaton_provider.dart
+++ b/lib/presentation/providers/automaton_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/automaton_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Orquestra a criação, edição e persistência de autômatos no editor visual. Expõe estado reativo com informações de layout, dados de transições e indicadores de carregamento para a interface.
+/// Contexto: Encapsula integrações com serviços de automaton, algoritmos de conversão e o repositório de layout para manter consistência entre domínio e canvas. Coordena operações de simulação, conversão e minimização respeitando a infraestrutura de GraphView.
+/// Observações: Registra mutações relevantes para depuração e alimenta históricos de traços quando persistência está habilitada. Fornece métodos para atualizar estados, transições e propriedades estruturais sincronizando widgets e provedores auxiliares.
+/// ---------------------------------------------------------------------------
 import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/presentation/providers/fa_trace_provider.dart
+++ b/lib/presentation/providers/fa_trace_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/fa_trace_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Controla o estado imutável das simulações de autômatos finitos determinísticos e não determinísticos. Centraliza a seleção do autômato ativo, o progresso da execução e os resultados em memória.
+/// Contexto: Expõe uma StateNotifier do Riverpod que dispara execuções via SimulationService e atualiza histórico de traços. Fornece operações para alternar modos, executar simulações passo a passo e armazenar falhas de forma apresentável.
+/// Observações: Inclui utilitários de navegação entre passos para sincronizar os painéis de visualização. Mantém histórico de execuções para que telas e widgets possam reabrir traços anteriores.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/fsa.dart';
 import '../../core/models/simulation_result.dart';

--- a/lib/presentation/providers/grammar_provider.dart
+++ b/lib/presentation/providers/grammar_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/grammar_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Controla a edição de gramáticas formais e as conversões disponíveis no workspace dedicado. Mantém estado com produções, símbolo inicial, tipo selecionado e resultados recentes de transformações para automatos.
+/// Contexto: Usa um StateNotifier que integra o ConversionService para executar pipelines como Gramática→AF e Gramática→AP. Organiza identificadores e ordem das produções garantindo edição previsível para componentes visuais.
+/// Observações: Expõe métodos para adicionar, atualizar, excluir e limpar produções além de lidar com feedback de erros. Permite rastrear conversões ativas e resultados de PDA para que widgets exibam progresso e mensagens de sucesso ou falha.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/fsa.dart';

--- a/lib/presentation/providers/home_navigation_provider.dart
+++ b/lib/presentation/providers/home_navigation_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/home_navigation_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Define o estado de navegação entre os espaços de trabalho principais exibidos na página inicial. Mapeia índices simbólicos para cada módulo de teoria de autômatos disponível na aplicação.
+/// Contexto: Utiliza um StateNotifier simples para permitir que widgets mudem a aba ativa de forma reativa. Centraliza constantes de navegação garantindo consistência entre botões, menus e rotas internas.
+/// Observações: Oferece atalhos legíveis para alternar rapidamente entre editores específicos. Pode ser estendido com novos índices sem impactar consumidores que apenas observam o estado inteiro.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Controls navigation between the major workspaces displayed on the home page.

--- a/lib/presentation/providers/pda_editor_provider.dart
+++ b/lib/presentation/providers/pda_editor_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/pda_editor_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Administra o autômato de pilha editado no canvas e metadados derivados como transições lambda ou não determinísticas. Garante que alterações interativas sejam refletidas em modelos consistentes com o domínio.
+/// Contexto: Utiliza um StateNotifier para consolidar mutações de estados, transições e configurações básicas do PDA. Serve de ponte entre eventos de interface e os objetos imutáveis usados por simuladores e exportadores.
+/// Observações: Fornece operações utilitárias para criação, movimentação e remoção de elementos mantendo integridade referencial. Atualiza conjuntos auxiliares que alimentam destaques visuais e diagnósticos pedagógicos.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/presentation/providers/pda_simulation_provider.dart
+++ b/lib/presentation/providers/pda_simulation_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/pda_simulation_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Controla execuções de autômatos de pilha expondo estado e resultados para a interface. Permite alternar entre modos de aceitação e executar simulações passo a passo.
+/// Contexto: Reutiliza a fachada de simulação do domínio para encapsular regras de aceitação por estado final ou pilha vazia. Atua como camada intermediária entre os widgets e os modelos de PDA mantendo o último insumo processado.
+/// Observações: Propaga falhas como resultados estruturados garantindo feedback consistente em painéis. Pode ser combinado com outros provedores de edição para atualizar o autômato monitorado em tempo real.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
 import '../../core/algorithms/pda/pda_simulator_facade.dart' as pda;

--- a/lib/presentation/providers/pda_trace_provider.dart
+++ b/lib/presentation/providers/pda_trace_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/pda_trace_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Administra o estado das simulações de autômatos de pilha, incluindo histórico persistente e navegação por passos. Fornece feedback sobre execuções bem-sucedidas e falhas para os painéis de visualização.
+/// Contexto: Utiliza o PDASimulatorFacade do domínio para executar cadeias e traduzir respostas em objetos Riverpod reativos. Mantém indicadores de carregamento, modo passo a passo e última entrada processada para sincronizar controles interativos.
+/// Observações: Disponibiliza utilitários de navegação para avançar, retroceder ou saltar a passos específicos da simulação. Registra erros como resultados estruturados permitindo tratamento uniforme em widgets consumidores.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
 import '../../core/models/simulation_step.dart';

--- a/lib/presentation/providers/pumping_lemma_progress_provider.dart
+++ b/lib/presentation/providers/pumping_lemma_progress_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/pumping_lemma_progress_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Mantém o histórico de desafios e estatísticas do jogo do Lema do Bombeamento. Modela tentativas, replays e pontuação para alimentar os painéis pedagógicos.
+/// Contexto: Implementa um StateNotifier imutável que registra interações relevantes como respostas e reinícios. Facilita a sincronização entre widgets do jogo fornecendo métricas agregadas e logs cronológicos.
+/// Observações: Expõe fábricas de entrada para simplificar a criação de registros e operações de reset. Permite que componentes verifiquem conquistas e progresso sem acessar diretamente fontes externas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/settings_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Disponibiliza configurações persistidas para a árvore de widgets por meio de um StateNotifier Riverpod. Realiza leitura inicial e sincronizações subsequentes com a fonte de dados padrão baseada em SharedPreferences.
+/// Contexto: Encapsula o repositório de configurações para abstrair detalhes de persistência e facilitar substituições em testes. Garante que alterações de modelo sejam gravadas com tratamento de erros e preservação de ciclo de vida.
+/// Observações: Oferece métodos para atualização, recarregamento e restauração dos valores padrão do SettingsModel. Controla descarte seguro para evitar escrituras após a liberação do provedor.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/providers/tm_editor_provider.dart
+++ b/lib/presentation/providers/tm_editor_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/tm_editor_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Garante a construção consistente das Máquinas de Turing manipuladas no canvas, acompanhando estados, transições e símbolos de fita. Traduz interações do usuário em modelos imutáveis consumidos por simuladores e exportadores.
+/// Contexto: Mantém caches mutáveis internos para aplicar transformações incrementais e gerar uma TM consolidada sempre que o editor sofre alterações. Fornece metadados úteis como direções de movimento e transições não determinísticas para destacar regras específicas.
+/// Observações: Oferece métodos abrangentes para adicionar, mover e renomear estados ou transições preservando integridade de ligações. Atualiza o estado Riverpod com coleções clonadas para evitar efeitos colaterais em widgets observadores.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/presentation/providers/unified_trace_provider.dart
+++ b/lib/presentation/providers/unified_trace_provider.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/providers/unified_trace_provider.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Consolida o gerenciamento de traços de simulação para todos os tipos de autômatos em uma interface única. Controla o contexto ativo, histórico persistido e estatísticas agregadas para compartilhamento entre módulos.
+/// Contexto: Opera como StateNotifier que integra serviços de persistência, carregamento lazily e navegação por passos de execução. Permite resgatar execuções anteriores com base em identificadores e tipos registrados.
+/// Observações: Trata erros de I/O exibindo mensagens amigáveis e mantém coerência entre preferências e dados carregados. Automatiza salvamentos após novas simulações garantindo continuidade entre sessões.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get_it/get_it.dart';

--- a/lib/presentation/theme/app_theme.dart
+++ b/lib/presentation/theme/app_theme.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/theme/app_theme.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Define paleta e configurações principais do tema Material 3 utilizado pelo aplicativo. Fornece acesso a esquema de cores, estilos de botões e elementos padrão para manter consistência visual.
+/// Contexto: Centraliza ajustes como cores primárias, temas de AppBar e botões elevados garantindo identidade compartilhada entre plataformas. Facilita evolução da linguagem visual sem necessidade de alterar widgets individuais.
+/// Observações: Estrutura métodos para tema claro podendo ser expandido com variações escuras ou de alto contraste. Serve como ponto de referência para componentes que precisam alinhar-se ao design oficial do projeto.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 /// Modern app theme for JFlutter

--- a/lib/presentation/widgets/algorithm_panel.dart
+++ b/lib/presentation/widgets/algorithm_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/algorithm_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Consolida comandos de algoritmos para autômatos finitos como conversões, operações de linguagem e equivalência. Integra entradas de expressão regular, seleção de automatos externos e feedback passo a passo.
+/// Contexto: Utiliza serviços de arquivos para importar modelos adicionais e chama callbacks fornecidos pelos provedores para executar os algoritmos. Apresenta controles agrupados e indicadores de progresso para acompanhar execuções longas.
+/// Observações: Gerencia estado interno de execução incluindo mensagens e etapas registradas pelo AlgorithmOperations. Estrutura modular facilita a ativação seletiva de funcionalidades conforme cada página precisa.
+/// ---------------------------------------------------------------------------
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import '../../core/models/fsa.dart';

--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/automaton_canvas.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Redireciona para o canvas unificado baseado em GraphView garantindo interface consistente para importações legadas. Fornece typedef amigável para manter nomenclaturas utilizadas anteriormente no projeto.
+/// Contexto: Funciona como ponto de entrada simplificado permitindo alternar implementações sem atualizar consumidores espalhados. Mantém compatibilidade ao reexportar o widget principal com escopo controlado.
+/// Observações: Estrutura mínima facilita futuras adaptações específicas por plataforma. Documentação clara auxilia desenvolvedores na transição para a nova infraestrutura de canvas.
+/// ---------------------------------------------------------------------------
 import 'automaton_graphview_canvas.dart';
 
 export 'automaton_graphview_canvas.dart' show AutomatonGraphViewCanvas;

--- a/lib/presentation/widgets/automaton_canvas_tool.dart
+++ b/lib/presentation/widgets/automaton_canvas_tool.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/automaton_canvas_tool.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Define os modos de edição disponíveis no canvas de autômatos e fornece controlador observável para alterná-los. Facilita integração com toolbars e componentes que precisam reagir a mudanças de ferramenta.
+/// Contexto: Utiliza ChangeNotifier para propagar eventos de seleção permitindo múltiplos ouvintes sincronizados. Mantém estado simples com valor padrão focado na ferramenta de seleção para edições comuns.
+/// Observações: Pode ser expandido com novos modos sem alterar contratos existentes. Ideal para coordenação entre painéis e gestos do canvas que dependem da ferramenta ativa.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/foundation.dart';
 
 /// Editing tools supported by the automaton canvas.

--- a/lib/presentation/widgets/automaton_canvas_web.dart
+++ b/lib/presentation/widgets/automaton_canvas_web.dart
@@ -1,2 +1,10 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/automaton_canvas_web.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Expõe a implementação compartilhada do canvas de autômatos baseada em GraphView para a plataforma web. Simplifica a manutenção apontando diretamente para o widget principal utilizado nas demais plataformas.
+/// Contexto: Este arquivo atua como adaptador mínimo preservando compatibilidade com imports históricos. Garante que o build web utilize a mesma infraestrutura rica de edição disponível no ambiente desktop.
+/// Observações: Mantém comentário orientativo destacando a reutilização do canvas unificado. Pode ser expandido caso diferenças específicas da web sejam necessárias no futuro.
+/// ---------------------------------------------------------------------------
 /// Web now shares the GraphView-based automaton canvas implementation.
 export 'automaton_graphview_canvas.dart';

--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/automaton_graphview_canvas.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Implementa canvas interativo baseado em GraphView para edição e visualização de autômatos finitos. Administra ferramentas, destaques de simulação e sincronização com provedores Riverpod garantindo experiência fluida.
+/// Contexto: Coordena controladores internos e externos para manipular nós, transições e overlays de rótulos, além de emitir atualizações para o AutomatonProvider. Incorpora algoritmos de layout e integrações com serviços de destaque para acompanhar execuções.
+/// Observações: Gerencia gestos complexos, estados de arrasto e atualizações diferidas para manter desempenho em autômatos grandes. Estrutura lógica extensível permitindo adicionar novas ferramentas ou interações sem refatorações profundas.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';

--- a/lib/presentation/widgets/canvas_actions_sheet.dart
+++ b/lib/presentation/widgets/canvas_actions_sheet.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/canvas_actions_sheet.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Exibe folha de ações contextuais para o canvas permitindo criar estados e ajustar enquadramento rapidamente. Aplica feedback háptico e navegação consistente ao interagir com as opções.
+/// Contexto: Foi projetado para ser chamado por gestos no canvas, oferecendo atalhos para adicionar nós, ajustar zoom ao conteúdo e resetar a visão. Utiliza ModalBottomSheet para manter linguagem visual do Material Design.
+/// Observações: Ajusta habilitação de ações conforme a área selecionada evitando duplicidades no grafo. Pode ser estendido com novos itens preservando a estrutura existente de callbacks e feedbacks.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/presentation/widgets/diagnostics_panel.dart
+++ b/lib/presentation/widgets/diagnostics_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/diagnostics_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Apresenta mensagens de diagnóstico sobre autômatos com ações de atualização e feedback visual. Fornece resumo quando não há problemas e detalha sugestões acionáveis quando disponíveis.
+/// Contexto: Consome instâncias de DiagnosticMessage geradas pelo domínio para auxiliar estudantes na correção de modelos. Estrutura uma lista expansível que evidencia severidade e orienta correções passo a passo.
+/// Observações: Permite incorporar controle de recarregamento opcional com indicador de progresso embutido. Pode ser reutilizado em diferentes páginas mantendo consistência na comunicação de erros e alertas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import '../../core/services/diagnostics_service.dart';
 

--- a/lib/presentation/widgets/export/svg_exporter.dart
+++ b/lib/presentation/widgets/export/svg_exporter.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/export/svg_exporter.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Implementa gerador de SVGs para autômatos, gramáticas e máquinas de Turing convertendo modelos em diagramas vetoriais. Fornece opções de personalização e estilos padrão alinhados à identidade visual do projeto.
+/// Contexto: Atua como utilitário compartilhado entre widgets de exportação permitindo distribuir representações em arquivos externos. Realiza conversões auxiliares para reuso de layouts e simplifica renderizações ao aplicar algoritmos básicos de posicionamento.
+/// Observações: Estrutura saída com cabeçalhos SVG, definições de marcadores e máscaras para estados de aceitação. Serve de base para extensões futuras como suporte a estilos adicionais ou integração com exportadores específicos de plataforma.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 import 'package:flutter/material.dart' hide Colors;
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/presentation/widgets/file_operations_panel.dart
+++ b/lib/presentation/widgets/file_operations_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/file_operations_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Centraliza ações de salvar, carregar e exportar autômatos ou gramáticas em formatos suportados, incluindo JFLAP e SVG. Fornece botões agrupados por tipo de estrutura para facilitar o fluxo do usuário.
+/// Contexto: Utiliza FileOperationsService e FilePicker para manipular arquivos locais, atualizando provedores através de callbacks. Apresenta indicadores de carregamento para sinalizar operações assíncronas em andamento.
+/// Observações: Organização modular permite habilitar seções de acordo com os dados disponíveis, evitando opções inválidas. Ideal para ser incorporado a painéis laterais ou janelas de diálogo mantendo coesão visual com o restante da aplicação.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import '../../core/models/fsa.dart';

--- a/lib/presentation/widgets/grammar_algorithm_panel.dart
+++ b/lib/presentation/widgets/grammar_algorithm_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/grammar_algorithm_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Concentra botões e fluxos de algoritmos relacionados a gramáticas como conversões, fatoração e análise LL. Fornece feedback textual sobre execuções para orientar ajustes e próximas ações.
+/// Contexto: Interage com diversos provedores para disparar conversões para AF, AP e atualizações de navegabilidade entre espaços de trabalho. Exibe resultados produzidos pelos serviços do domínio garantindo continuidade entre edições e simulações.
+/// Observações: Controla estado interno simples de carregamento e resultado para evitar bloqueio do restante da interface. Pode ser expandido com novos algoritmos mantendo a estrutura modular de seções e descrições.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/grammar_editor.dart
+++ b/lib/presentation/widgets/grammar_editor.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/grammar_editor.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Disponibiliza editor completo de gramáticas com suporte a criação, edição e listagem de produções. Integra campos reativos, ações rápidas e validações para facilitar a modelagem de linguagens formais.
+/// Contexto: Conecta-se ao GrammarProvider para refletir alterações de estado e executar comandos como limpar regras ou iniciar conversões. Estrutura layouts responsivos adaptados a telas móveis e desktops mantendo a usabilidade.
+/// Observações: Gerencia controladores de texto e seleção de produções garantindo consistência ao alternar entre modos de edição. Pode ser combinado com painéis de conversão e simulação graças à sua comunicação via Riverpod.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/production.dart';

--- a/lib/presentation/widgets/grammar_simulation_panel.dart
+++ b/lib/presentation/widgets/grammar_simulation_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/grammar_simulation_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Disponibiliza painel para testar cadeias em gramáticas utilizando diferentes algoritmos de parsing. Reúne seleção de estratégia, entrada de cadeia e visualização dos passos gerados.
+/// Contexto: Consome dados do GrammarProvider e algoritmos do domínio como CYK, LL e LR para validar derivabilidades. Estrutura controles e resultados em cartões responsivos alinhados ao restante da interface.
+/// Observações: Armazena estado local de execução, incluindo tempos e passos, permitindo análise detalhada após cada simulação. Pode ser ampliado com novos algoritmos mantendo o fluxo de interação existente.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/graphview_canvas_toolbar.dart
+++ b/lib/presentation/widgets/graphview_canvas_toolbar.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/graphview_canvas_toolbar.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Implementa a barra de ferramentas que controla o canvas baseado em GraphView, fornecendo atalhos de edição e navegação. Permite selecionar ferramentas, adicionar elementos e ajustar a visualização do grafo.
+/// Contexto: Comunica-se diretamente com o controlador do canvas para executar ações como desfazer, refit e reset de viewport. Expõe ganchos opcionais para botões de transição, limpeza e mensagens de status adaptando-se a layouts desktop ou mobile.
+/// Observações: Gerencia escuta de alterações do controlador para manter o estado visual atualizado. Pode ser configurada para funcionar como conjunto de toggles quando ferramentas exclusivas precisam permanecer ativas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../features/canvas/graphview/base_graphview_canvas_controller.dart';

--- a/lib/presentation/widgets/mobile_automaton_controls.dart
+++ b/lib/presentation/widgets/mobile_automaton_controls.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/mobile_automaton_controls.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Agrupa os principais controles do editor de autômatos em uma superfície otimizada para toque. Combina ações de simulação, algoritmos, métricas e ferramentas de canvas em um único painel configurável.
+/// Contexto: Facilita o uso em dispositivos móveis ao substituir botões flutuantes dispersos por uma barra organizada com ícones e rótulos. Integra-se ao AutomatonCanvasToolController para refletir a ferramenta ativa e habilitar alternâncias.
+/// Observações: Aceita callbacks opcionais permitindo adaptar o conjunto de ações às capacidades da página hospedeira. Oferece feedback visual sobre disponibilidade e seleção para orientar usuários durante a edição.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import 'automaton_canvas_tool.dart';

--- a/lib/presentation/widgets/mobile_navigation.dart
+++ b/lib/presentation/widgets/mobile_navigation.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/mobile_navigation.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Fornece barra de navegação inferior otimizada para dispositivos móveis com itens personalizáveis. Ajusta visual e feedback para acomodar múltiplos módulos do aplicativo em telas reduzidas.
+/// Contexto: Recebe lista de NavigationItem que descreve rótulos, ícones e descrições permitindo integração com ferramentas de acessibilidade. Mantém estilo consistente com Material 3 incluindo sombras e SafeArea.
+/// Observações: Destaca item ativo com cor primária e tipografia reforçada melhorando a orientação do usuário. Estrutura flexível facilita adição ou remoção de seções sem alterar o widget principal.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 /// Mobile-optimized bottom navigation widget

--- a/lib/presentation/widgets/pda_algorithm_panel.dart
+++ b/lib/presentation/widgets/pda_algorithm_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pda_algorithm_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Agrupa atalhos para algoritmos de análise de autômatos de pilha, oferecendo conversões e diagnósticos como determinismo e alcance de estados. Exibe resultados textuais para orientar correções do estudante.
+/// Contexto: Comunica-se com o PDAEditorProvider e serviços de conversão para gerar gramáticas equivalentes ou relatórios. Organiza botões temáticos com descrições claras, funcionando como hub de ferramentas dentro do workspace.
+/// Observações: Mantém estado local de carregamento e armazena última gramática convertida para uso posterior. Pode ser ampliado com novos algoritmos mantendo a estrutura de cartões e seções já estabelecida.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pda_canvas_graphview.dart
+++ b/lib/presentation/widgets/pda_canvas_graphview.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pda_canvas_graphview.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Renderiza o canvas de autômatos de pilha usando GraphView, sincronizando estados e transições com o provedor de edição. Lida com destaques de simulação, algoritmos de layout e propagação de mudanças para ouvintes externos.
+/// Contexto: Integra controladores especializados para atualizar nós, gerenciar canal de destaques e ajustar a visualização conforme o conteúdo. Inscreve-se manualmente no PDAEditorProvider para detectar mutações relevantes e aplicar sincronização eficiente.
+/// Observações: Oferece opção de reutilizar controlador externo preservando recursos e evitando substituição de canais existentes. Quando proprietário, configura automaticamente o serviço de destaque e aplica fit-to-content em inicializações apropriadas.
+/// ---------------------------------------------------------------------------
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/lib/presentation/widgets/pda_simulation_panel.dart
+++ b/lib/presentation/widgets/pda_simulation_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pda_simulation_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Widget que executa simulações de autômatos de pilha permitindo configurar entrada, símbolo inicial da pilha e modo passo a passo. Exibe resultados, mensagens de erro e traços detalhados para estudo.
+/// Contexto: Trabalha em conjunto com o PDAEditorProvider e serviços de destaque para manter sincronização visual com o canvas. Organiza controles em cartões materiais de fácil leitura adequados a diversos tamanhos de tela.
+/// Observações: Administra controladores de texto e estado local para preservar interações do usuário entre execuções. Invoca o simulador central garantindo que os mesmos modelos do domínio sejam utilizados em toda a aplicação.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pumping_lemma_game.dart
+++ b/lib/presentation/widgets/pumping_lemma_game.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pumping_lemma_game.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Implementa versão compacta do jogo do Lema do Bombeamento com seleção de desafios e feedback imediato. Sincroniza pontuação e progresso com o provedor dedicado para acompanhar o desempenho do usuário.
+/// Contexto: Utiliza Riverpod para armazenar histórico global enquanto mantém estados locais para fluxo de jogo e seleção de respostas. Apresenta interface baseada em cartões com instruções e resultado ao final de cada rodada.
+/// Observações: Lista conjunto inicial de desafios que pode ser expandido conforme necessário. Cuida da inicialização do provedor ao montar para garantir contagem correta de desafios disponíveis.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart
+++ b/lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pumping_lemma_game/pumping_lemma_game.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Implementa o jogo interativo do Lema do Bombeamento com níveis progressivos, feedback imediato e registro de pontuação. Oferece desafios que alternam entre linguagens regulares e não regulares com explicações detalhadas.
+/// Contexto: Consome o PumpingLemmaProgressProvider para sincronizar histórico e métricas enquanto gerencia estado local de rodada. Renderiza instruções, dicas, exemplos e avaliações para reforçar conceitos de forma lúdica dentro da interface educacional.
+/// Observações: Organiza listas extensas de desafios e respostas para suportar múltiplas dificuldades sem depender de serviços externos. Pode ser expandido com novas fases utilizando o mesmo esquema de dados e lógica de progresso.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pumping_lemma_help.dart
+++ b/lib/presentation/widgets/pumping_lemma_help.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pumping_lemma_help.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Fornece painel de apoio teórico ao jogo do Lema do Bombeamento com abas de teoria, passos e exemplos. Ajuda estudantes a revisar conceitos-chave enquanto experimentam o minigame.
+/// Contexto: Utiliza estrutura de abas controlada localmente para alternar conteúdos estáticos e orientativos. Pode ser renderizado ao lado do jogo principal oferecendo referência rápida em uma interface coesa.
+/// Observações: Mantém estado interno simples apenas para alternância de abas, evitando dependências externas. O conteúdo pode ser expandido com novas seções mantendo a mesma organização visual e pedagógica.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pumping_lemma_progress.dart
+++ b/lib/presentation/widgets/pumping_lemma_progress.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/pumping_lemma_progress.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Exibe painel de progresso do jogo do Lema do Bombeamento consolidando métricas como desafios concluídos, pontuação e histórico. Oferece visualizações com barras de progresso e listas para acompanhamento pedagógico.
+/// Contexto: Observa o PumpingLemmaProgressProvider para refletir atualizações em tempo real conforme os jogadores avançam. Estrutura cartões temáticos que podem ser incorporados a dashboards ou páginas dedicadas.
+/// Observações: Calcula porcentagens e acurácia localmente evitando requisições adicionais. Facilita a análise de desempenho ao destacar últimas interações diretamente na interface.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/simulation_panel.dart
+++ b/lib/presentation/widgets/simulation_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/simulation_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Gerencia interface de simulação para autômatos com controles de entrada, execução e visualização passo a passo. Integra destaque de transições e reprodução automática para auxiliar no entendimento do processo.
+/// Contexto: Utiliza SimulationHighlightService e resultados centralizados para sincronizar canvas e relatórios textuais. Oferece funcionalidades como modo passo a passo, reprodução contínua e exibição de mensagens de aceitação ou rejeição.
+/// Observações: Controla ciclo de vida de controladores e timers garantindo limpeza adequada ao atualizar widgets. Design modular permite adaptar a painel lateral ou seções independentes em páginas diversas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import '../../core/models/simulation_result.dart';
 import '../../core/models/simulation_step.dart';

--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/tm_algorithm_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Disponibiliza conjunto de análises para Máquinas de Turing abrangendo decidibilidade, alcançabilidade e métricas de fita. Apresenta resultados estruturados para auxiliar na depuração dos modelos criados.
+/// Contexto: Interage com o TMEditorProvider e algoritmos do domínio para executar inspeções detalhadas sobre estados e transições. Usa seções temáticas que permitem ao usuário focar em aspectos específicos da máquina.
+/// Observações: Mantém estado interno de foco e resultados para evitar recomputações desnecessárias. Pode ser expandido com novos diagnósticos mantendo a mesma experiência visual e organizacional.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/tm_canvas_graphview.dart
+++ b/lib/presentation/widgets/tm_canvas_graphview.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/tm_canvas_graphview.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Renderiza o canvas de Máquinas de Turing utilizando GraphView e mantém sincronização com o provedor de edição. Ajusta layouts, monitora destaques de simulação e encaminha alterações para consumidores externos.
+/// Contexto: Configura controladores dedicados, assinaturas Riverpod e canais de destaque para alinhar o canvas com o estado global. Oferece suporte a edição de transições via sobreposições contextuais adaptando-se ao fluxo de trabalho do editor.
+/// Observações: Permite reutilizar controladores existentes ou criar novos, garantindo limpeza apropriada de recursos. Executa ajustes automáticos de enquadramento quando estados são adicionados para melhorar a experiência de navegação.
+/// ---------------------------------------------------------------------------
 import 'dart:async';
 
 import 'package:flutter/material.dart';

--- a/lib/presentation/widgets/tm_simulation_panel.dart
+++ b/lib/presentation/widgets/tm_simulation_panel.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/tm_simulation_panel.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Componente de interface que executa simulações de Máquinas de Turing a partir do autômato ativo. Exibe campos de entrada, botões de controle e resultados para orientar o usuário durante a análise.
+/// Contexto: Interage com o TMEditorProvider para obter configurações atuais e utiliza serviços de destaque para sincronizar o canvas. Organiza visualizações como histórico de passos e mensagens de aceitação dentro de um painel responsivo.
+/// Observações: Gerencia ciclo de vida de controladores locais e limpa realces quando desmontado para evitar estados residuais. Pode ser embutido em páginas maiores compartilhando a instância de SimulationHighlightService entre widgets.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Fornece componente base para visualização de traços reutilizado por FA, PDA e TM. Gerencia colapso de listas longas, seleção de passos e integração opcional com destaques do canvas.
+/// Contexto: Recebe um SimulationResult genérico e um construtor de linhas para especializações, garantindo comportamento comum entre diferentes automatos. Administra estado interno para dobragem e seleção respeitando as necessidades de acessibilidade.
+/// Observações: Emite eventos para SimulationHighlightService quando habilitado, permitindo sincronização imediata com visualizações gráficas. Flexível o bastante para suportar novos tipos de traço sem alteração estrutural significativa.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../core/models/simulation_result.dart';

--- a/lib/presentation/widgets/trace_viewers/fa_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/fa_trace_viewer.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/trace_viewers/fa_trace_viewer.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Apresenta traços de simulação de autômatos finitos detalhando estado corrente, entrada restante e transição utilizada. Utiliza convenções como ε para cadeia vazia reforçando terminologia de teoria de autômatos.
+/// Contexto: Se baseia no BaseTraceViewer para renderização padronizada e suporta personalização de linhas de passo. É utilizado por painéis de simulação para oferecer visão cronológica de execuções.
+/// Observações: Opera diretamente com SimulationResult genérico tornando-se compatível com DFAs, NFAs e execuções passo a passo. Pode ser estendido para incluir metadados adicionais sem romper a API existente.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../core/models/simulation_result.dart';

--- a/lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Exibe traços de simulações de autômatos de pilha destacando estado atual, entrada remanescente e conteúdo da pilha. Converte resultados específicos do simulador em formato comum para reutilizar a infraestrutura de visualização.
+/// Contexto: Trabalha com SimulationHighlightService para sincronizar destaques no canvas e com BaseTraceViewer para renderização consistente. Usa convenções como λ para entradas vazias reforçando conceitos teóricos na interface.
+/// Observações: Simplifica tratamento de resultados aceitos ou rejeitados mantendo mensagens claras. Pode ser integrado a diferentes painéis que necessitem apresentar passo a passo de execuções PDA.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../core/algorithms/pda_simulator.dart';

--- a/lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Responsável por exibir traços de simulação de Máquinas de Turing em formato legível, destacando passos, fita e transições utilizadas. Normaliza o resultado para reutilizar componentes compartilhados de visualização.
+/// Contexto: Converte resultados específicos do simulador de TM em SimulationResult genérico para consumo pelo BaseTraceViewer. Permite integração com serviços de destaque para sincronização com o canvas correspondente.
+/// Observações: Realiza tratamento especial para cenários de timeout, laço infinito e rejeição garantindo mensagens adequadas. Pode ser reutilizado em qualquer página que precise apresentar execuções de TM de maneira consistente.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../core/algorithms/tm_simulator.dart';

--- a/lib/presentation/widgets/transition_editors/pda_transition_editor.dart
+++ b/lib/presentation/widgets/transition_editors/pda_transition_editor.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/transition_editors/pda_transition_editor.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Fornece formulário interativo para configurar transições de autômatos de pilha com suporte a símbolos λ. Permite editar leitura, pop e push além de alternar rapidamente o uso de operações vazias.
+/// Contexto: Utilizado pelos editores de PDA para captar ajustes detalhados das regras de transição diretamente do usuário. Combina campos de texto, interruptores adaptativos e botões alinhados ao Material Design.
+/// Observações: Garante limpeza dos campos quando modos λ são ativados evitando inconsistências de entrada. Pode ser reutilizado em diálogos ou menus contextuais mantendo integração simples com callbacks do chamador.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 class PdaTransitionEditor extends StatefulWidget {

--- a/lib/presentation/widgets/transition_editors/tm_transition_operations_editor.dart
+++ b/lib/presentation/widgets/transition_editors/tm_transition_operations_editor.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/transition_editors/tm_transition_operations_editor.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Permite editar operações de transições de Máquina de Turing, incluindo símbolos de leitura/escrita e direção da cabeça. Apresenta formulário compacto ideal para popovers ou diálogos rápidos.
+/// Contexto: Alimenta provedores e canvas ao coletar dados atualizados de transições diretamente do usuário. Utiliza controles Material padrão e valida submissões com retorno estruturado para o chamador.
+/// Observações: Mantém estado local mínimo, simplificando extensões como validações customizadas ou rótulos internacionalizados. Pode ser integrado a fluxos de edição inline sem exigir reestruturações na interface principal.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 
 import '../../../core/models/tm_transition.dart';

--- a/lib/presentation/widgets/transition_editors/transition_label_editor.dart
+++ b/lib/presentation/widgets/transition_editors/transition_label_editor.dart
@@ -1,3 +1,11 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/presentation/widgets/transition_editors/transition_label_editor.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Componente reutilizável para editar rótulos de transições com suporte a teclado, acessibilidade e otimizações para toque. Encapsula lógica de submissão, cancelamento e feedback sem exigir dependências externas.
+/// Contexto: Utilizado por diferentes editores de autômatos para permitir ajustes rápidos em transições diretamente no canvas. Integra atalhos de teclado padrão e semântica configurável para melhorar a experiência do usuário.
+/// Observações: Ajusta layout para contextos desktop e mobile oferecendo botões dimensionados conforme necessidade. Pode ser estendido com validações adicionais ou máscaras mantendo a mesma estrutura de formulário.
+/// ---------------------------------------------------------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 


### PR DESCRIPTION
## Summary
- add the standard Portuguese documentation header to every provider in the presentation layer
- document all presentation widgets and pages with detailed summaries to clarify their responsibilities

## Testing
- dart format lib/presentation *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e515d85d08832eb77cdab2db0f576f