### PR TITLE
Add standardized headers to test suites

### DIFF
--- a/test/core/services/simulation_highlight_service_test.dart
+++ b/test/core/services/simulation_highlight_service_test.dart
@@ -1,3 +1,15 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/core/services/simulation_highlight_service_test.dart
+// Objetivo: Verificar a comunicação do serviço de destaque de simulação com o
+// controlador GraphView.
+// Cenários cobertos:
+// - Emissão de destaques durante a simulação passo a passo.
+// - Limpeza de destaques ao encerrar ou reiniciar.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';
 import 'package:jflutter/core/models/simulation_step.dart';

--- a/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_automaton_mapper_test.dart
+// Objetivo: Validar o mapeamento de autômatos para modelos GraphView usados no
+// canvas.
+// Cenários cobertos:
+// - Conversão de estados e transições em nós e arestas com posição.
+// - Tratamento de loops, transições múltiplas e estados iniciais/aceitadores.
+// - Atualização de dados ao sincronizar com GraphViewAutomatonMapper.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:test/test.dart';

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_canvas_controller_test.dart
+// Objetivo: Verificar o controlador base GraphView de autômatos garantindo
+// interação com o provider e repositório de layout fake.
+// Cenários cobertos:
+// - Aplicação de layouts (auto, balanced, compact, hierarchical, spread).
+// - Manipulação de zoom, seleção e atualizações de transição.
+// - Uso de serviço de autômato para sincronização com o estado interno.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/test/features/canvas/graphview/graphview_canvas_models_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_models_test.dart
@@ -1,3 +1,14 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_canvas_models_test.dart
+// Objetivo: Avaliar modelos de canvas usados pelo GraphView garantindo
+// imutabilidade e helpers consistentes.
+// Cenários cobertos:
+// - Atualização de metadados de arestas via `copyWith`.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';

--- a/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+// Objetivo: Validar o controlador GraphView específico de PDA, assegurando
+// sincronização com o provider e manipulação da pilha.
+// Cenários cobertos:
+// - Construção de grafos a partir de PDAs com transições de push/pop.
+// - Seleção e atualização de transições refletidas no editor.
+// - Descarte adequado do controlador após o uso.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/test/features/canvas/graphview/graphview_pda_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_mapper_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_pda_mapper_test.dart
+// Objetivo: Garantir que PDAs sejam convertidos corretamente para modelos de
+// canvas GraphView.
+// Cenários cobertos:
+// - Tradução de push/pop e símbolos λ em metadados visuais.
+// - Mapeamento de estados iniciais/aceitadores e transições múltiplas.
+// - Atualização do grafo ao sincronizar com GraphViewPdaMapper.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:test/test.dart';

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+// Objetivo: Garantir que o controlador GraphView para MT sincronize estados,
+// transições e seleção com o provider.
+// Cenários cobertos:
+// - Construção de grafo a partir de máquinas de Turing e atualizações em tempo real.
+// - Seleção de transições e estados, emitindo eventos correspondentes.
+// - Descarte seguro de recursos após uso.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/test/features/canvas/graphview/graphview_tm_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_mapper_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/features/canvas/graphview/graphview_tm_mapper_test.dart
+// Objetivo: Validar mapeamento de máquinas de Turing para estruturas GraphView
+// utilizadas no canvas.
+// Cenários cobertos:
+// - Conversão de estados, transições e direções de fita em modelos visuais.
+// - Suporte a múltiplas fitas e símbolos de leitura/escrita.
+// - Ajuste de nós e controle de curvas em representações gráficas.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:test/test.dart';

--- a/test/integration/io/examples_roundtrip_test.dart
+++ b/test/integration/io/examples_roundtrip_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/integration/io/examples_roundtrip_test.dart
+// Objetivo: Exercitar round-trips de exemplos canônicos passando por assets,
+// serviços de serialização e exportação.
+// Cenários cobertos:
+// - Conversão de autômatos, gramáticas e MTs entre entidades e arquivos.
+// - Exportação SVG e validação de estruturas serializadas.
+// - Verificação de consistência dos metadados da biblioteca Examples.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';
 

--- a/test/integration/io/interoperability_roundtrip_test.dart
+++ b/test/integration/io/interoperability_roundtrip_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/integration/io/interoperability_roundtrip_test.dart
+// Objetivo: Validar interoperabilidade entre formatos `.jff`, JSON e SVG,
+// garantindo round-trip sem perda.
+// Cenários cobertos:
+// - Conversões JFLAP↔modelos internos usando parser XML dedicado.
+// - Serialização JSON de autômatos, gramáticas e MTs.
+// - Exportação SVG para visualização preservando elementos-chave.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';
 import 'package:jflutter/core/entities/automaton_entity.dart';
@@ -9,15 +22,6 @@ import 'package:jflutter/core/parsers/jflap_xml_parser.dart';
 import 'package:jflutter/data/data_sources/local_storage_data_source.dart';
 import 'package:jflutter/data/models/automaton_model.dart';
 import 'package:flutter/material.dart';
-
-/// Interoperability and Round-trip Tests for .jff/JSON/SVG formats
-///
-/// This test suite validates the complete interoperability between different
-/// file formats and ensures data integrity through round-trip conversions.
-///
-/// Test cases cover:
-/// 1. JFF (JFLAP) format round-trip testing
-/// 2. JSON format round-trip testing
 /// 3. SVG export/import testing
 /// 4. Cross-format conversion testing
 /// 5. Data integrity validation

--- a/test/unit/core/algorithms/pda_to_cfg_converter_test.dart
+++ b/test/unit/core/algorithms/pda_to_cfg_converter_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/algorithms/pda_to_cfg_converter_test.dart
+// Objetivo: Verificar a conversão de PDAs para gramáticas livres de contexto,
+// assegurando preservação da linguagem reconhecida.
+// Cenários cobertos:
+// - Construção de produções a partir de transições de empilha/desempilha.
+// - Geração de regras iniciais com estados intermediários e terminais.
+// - Tratamento de autômatos inválidos com feedback de erro estruturado.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:test/test.dart';

--- a/test/unit/core/automata/fa_algorithms_test.dart
+++ b/test/unit/core/automata/fa_algorithms_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/automata/fa_algorithms_test.dart
+// Objetivo: Exercitar algoritmos de autômatos finitos (AFN→AFD, minimização e
+// operações de linguagem) em cenários controlados.
+// Cenários cobertos:
+// - Conversão AFN→AFD preservando fechos-ε e estados aceitando.
+// - Minimização Hopcroft com equivalência de linguagem.
+// - Operações de complemento, união e interseção aplicadas em DFAs.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/test/unit/core/cfg/cfg_toolkit_test.dart
+++ b/test/unit/core/cfg/cfg_toolkit_test.dart
@@ -1,17 +1,21 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/cfg/cfg_toolkit_test.dart
+// Objetivo: Validar o toolkit de GLC do JFlutter cobrindo normalizações e
+// verificações estruturais essenciais.
+// Cenários cobertos:
+// - Remoção de produções ε, unitárias e símbolos inúteis.
+// - Conversão para Forma Normal de Chomsky e checagem de validade.
+// - Garantia de preservação da linguagem ao aplicar transformações sucessivas.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/cfg/cfg_toolkit.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';
 import 'package:jflutter/core/result.dart';
-
-/// CFG Toolkit Validation Tests
-///
-/// This test suite validates CFG toolkit algorithms for:
-/// 1. ε-removal (lambda production elimination)
-/// 2. Unit production elimination
-/// 3. Useless symbol removal
-/// 4. CNF conversion
-/// 5. CNF validation
 void main() {
   group('CFG toolkit (CNF and cleanups)', () {
     late Grammar simpleGrammar;

--- a/test/unit/core/cfg/cyk_parser_test.dart
+++ b/test/unit/core/cfg/cyk_parser_test.dart
@@ -1,17 +1,21 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/cfg/cyk_parser_test.dart
+// Objetivo: Testar o parser CYK assegurando construção de tabela, árvores de
+// derivação e integração com gramáticas em FNC.
+// Cenários cobertos:
+// - Aceitação e rejeição de cadeias válidas/ inválidas segundo gramáticas em CNF.
+// - Construção de árvores de derivação completas e parciais.
+// - Tratamento de produções λ e unitárias após normalização.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/cfg/cyk_parser.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';
 import 'package:jflutter/core/result.dart';
-
-/// CYK Parser Validation Tests
-///
-/// This test suite validates CYK parser algorithms for:
-/// 1. Parse table construction
-/// 2. Derivation tree construction
-/// 3. Language acceptance/rejection
-/// 4. CNF conversion integration
-/// 5. Edge cases (empty strings, single characters)
 void main() {
   group('CYK parser', () {
     late Grammar simpleCNFGrammar;

--- a/test/unit/core/pda/pda_simulator_test.dart
+++ b/test/unit/core/pda/pda_simulator_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/pda/pda_simulator_test.dart
+// Objetivo: Avaliar o simulador interno de autômatos de pilha com variações de
+// critérios de aceitação e manipulação de pilha em diferentes linguagens.
+// Cenários cobertos:
+// - Aceitação por estado final e por pilha vazia com símbolos iniciais.
+// - Balanceamento de parênteses e controle de contagem através de push/pop.
+// - Rejeições em entradas inválidas e caminhos não determinísticos.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/pda_simulator.dart';
 import 'package:jflutter/core/models/pda.dart';

--- a/test/unit/core/regex/regex_pipeline_test.dart
+++ b/test/unit/core/regex/regex_pipeline_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/regex/regex_pipeline_test.dart
+// Objetivo: Validar o pipeline Regex→AST→AFN (Thompson) assegurando geração e
+// simulação coerentes com operações do automato.
+// Cenários cobertos:
+// - Construção de AFNs para literais, concatenação, união e estrela de Kleene.
+// - Agrupamentos, operadores opcionais e precedência correta na árvore sintática.
+// - Rejeição de expressões inválidas e propagação de erros do parser.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/algorithm_operations.dart';
 import 'package:jflutter/core/algorithms/regex_to_nfa_converter.dart';

--- a/test/unit/core/result_test.dart
+++ b/test/unit/core/result_test.dart
@@ -1,3 +1,14 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/result_test.dart
+// Objetivo: Garantir o comportamento das extensões de `Result`, especialmente
+// a transformação segura entre sucesso e falha.
+// Cenários cobertos:
+// - Preservação de mensagens de erro ao aplicar `mapOrElse`.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/result.dart';
 

--- a/test/unit/core/tm/tm_simulator_test.dart
+++ b/test/unit/core/tm/tm_simulator_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/core/tm/tm_simulator_test.dart
+// Objetivo: Exercitar o simulador interno de máquinas de Turing com cenários
+// determinísticos e não determinísticos, incluindo múltiplas fitas.
+// Cenários cobertos:
+// - Máquinas determinísticas que expandem cadeias unárias e reconhecem padrões.
+// - Construções não determinísticas com ramos concorrentes e rejeição.
+// - Operações multi-fita com movimentação independente e sincronização.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/tm_simulator.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/cyk_validation_test.dart
+++ b/test/unit/cyk_validation_test.dart
@@ -1,20 +1,21 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/cyk_validation_test.dart
+// Objetivo: Validar o algoritmo CYK garantindo reconhecimento correto de
+// linguagens após conversão para FNC.
+// Cenários cobertos:
+// - Construção de tabela e aceitação/rejeição de cadeias em CNF.
+// - Conversão de gramáticas e tratamento de produções especiais.
+// - Casos extremos relacionados a cadeias vazias e entradas curtas.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';
 import 'package:jflutter/core/algorithms/grammar_parser.dart';
 import 'package:jflutter/core/result.dart';
-
-/// CYK (Cocke-Younger-Kasami) Validation Tests against References/automata-main
-///
-/// This test suite validates CYK algorithm implementation against theoretical expectations
-/// and reference implementations to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. CNF parsing (Chomsky Normal Form parsing)
-/// 2. Derivation testing (valid and invalid derivations)
-/// 3. CYK algorithm correctness
-/// 4. Grammar conversion to CNF
-/// 5. Performance and edge cases
 void main() {
   group('CYK Validation Tests', () {
     late Grammar balancedParenthesesGrammar;

--- a/test/unit/data/examples_asset_data_source_test.dart
+++ b/test/unit/data/examples_asset_data_source_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/data/examples_asset_data_source_test.dart
+// Objetivo: Garantir a integridade das fixtures JSON de "Examples v1" ao
+// validar metadados, estruturas e round-trips necessários para o consumo no
+// aplicativo.
+// Cenários cobertos:
+// - Carregamento de arquivos de exemplo e validação do formato JSON esperado.
+// - Garantia de metadados obrigatórios para categorias, dificuldade e tags.
+// - Verificação de consistência entre metadados declarados e conteúdo serializado.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:convert';
 import 'dart:io';
 

--- a/test/unit/data/import_export_validation_test.dart
+++ b/test/unit/data/import_export_validation_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/data/import_export_validation_test.dart
+// Objetivo: Validar os fluxos de importação e exportação garantindo round-trip
+// consistente entre o modelo interno de AFD e os formatos JFLAP/JSON/SVG.
+// Cenários cobertos:
+// - Reconstrução fiel de autômatos após serialização JFLAP.
+// - Conversão JSON preservando estados, transições e alfabetos.
+// - Exportação SVG com feedback de sucesso e métricas de estrutura.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;

--- a/test/unit/data/services/examples_library_stats_test.dart
+++ b/test/unit/data/services/examples_library_stats_test.dart
@@ -1,3 +1,15 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/data/services/examples_library_stats_test.dart
+// Objetivo: Verificar a formatação segura de `ExamplesLibraryStats` garantindo
+// descrições coerentes mesmo com coleções vazias ou parciais.
+// Cenários cobertos:
+// - Representação textual de estatísticas vazias sem lançar exceções.
+// - Agregação de totais e rótulos quando apenas parte dos mapas está preenchida.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';
 import 'package:jflutter/data/services/examples_service.dart';

--- a/test/unit/data/services/import_export_validation_test.dart
+++ b/test/unit/data/services/import_export_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/data/services/import_export_validation_test.dart
+// Objetivo: Assegurar que o serviço de validação de importação/exportação
+// identifique inconsistências estruturais e rejeite autômatos inválidos antes
+// da serialização.
+// Cenários cobertos:
+// - Construção de autômato válido com estados e transições consistentes.
+// - Detecção de laços, símbolos ausentes e estados inválidos durante a validação.
+// - Consolidação de relatórios de erro para múltiplas violações.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/test/unit/data/settings_repository_impl_test.dart
+++ b/test/unit/data/settings_repository_impl_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/data/settings_repository_impl_test.dart
+// Objetivo: Confirmar que o repositório de configurações elimina chaves
+// legadas relacionadas ao canvas Draw2D ao carregar ou salvar preferências.
+// Cenários cobertos:
+// - Limpeza da flag `settings_use_draw2d_canvas` durante o carregamento das
+//   configurações.
+// - Remoção do mesmo sinalizador ao persistir novas preferências.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/settings_model.dart';
 import 'package:jflutter/data/repositories/settings_repository_impl.dart';

--- a/test/unit/dfa_minimization_validation_test.dart
+++ b/test/unit/dfa_minimization_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/dfa_minimization_validation_test.dart
+// Objetivo: Validar o algoritmo de minimização de AFD do JFlutter com base na
+// suíte de referência.
+// Cenários cobertos:
+// - Redução de autômatos básicos e complexos com estados redundantes.
+// - Garantia de invariância para AFDs já minimizados ou sem estados finais.
+// - Comparação de linguagem entre versões originais e minimizadas.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_dfa.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -7,18 +21,6 @@ import 'dart:math' as math;
 import 'package:jflutter/core/algorithms/automaton_simulator.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
-
-/// DFA Minimization Validation Tests against References/automata-main
-///
-/// This test suite validates DFA minimization implementation against
-/// reference implementations to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Basic DFA minimization
-/// 2. Complex DFA minimization with redundant states
-/// 3. Already minimal DFA minimization
-/// 4. DFA with no final states minimization
-/// 5. Equivalence testing between original and minimized DFA
 void main() {
   group('DFA Minimization Validation Tests', () {
     late FSA basicDFA;

--- a/test/unit/dfa_validation_test.dart
+++ b/test/unit/dfa_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/dfa_validation_test.dart
+// Objetivo: Validar o simulador e a minimização de AFDs comparando com a base
+// de referência em Python.
+// Cenários cobertos:
+// - Aceitação, rejeição e tratamento da cadeia vazia.
+// - Detecção de ciclos e consistência em complementação.
+// - Equivalência pós-minimização em relação ao autômato original.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_dfa.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -7,18 +21,6 @@ import 'package:jflutter/core/algorithms/dfa_minimizer.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// DFA Validation Tests against References/automata-main
-///
-/// This test suite validates DFA algorithms against the Python reference implementation
-/// from References/automata-main/tests/test_dfa.py to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Acceptance scenarios (strings that should be accepted)
-/// 2. Rejection scenarios (strings that should be rejected)
-/// 3. Empty string handling
-/// 4. Cycle detection and handling
-/// 5. Complementation operations
 void main() {
   group('DFA Validation Tests', () {
     late FSA binaryDivisibleBy3DFA;

--- a/test/unit/equivalence_validation_test.dart
+++ b/test/unit/equivalence_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/equivalence_validation_test.dart
+// Objetivo: Verificar o comparador de equivalência de autômatos frente à
+// implementação de referência da pasta automata-main.
+// Cenários cobertos:
+// - Equivalência entre DFAs e NFAs com construções distintas.
+// - Diferenciação de autômatos não equivalentes com diagnósticos.
+// - Tratamento de casos extremos e entradas malformadas.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_dfa.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -6,17 +20,6 @@ import 'package:jflutter/core/algorithms/equivalence_checker.dart';
 import 'package:jflutter/core/algorithms/automaton_simulator.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// Equivalence Checker Validation Tests against References/automata-main
-///
-/// This test suite validates equivalence checking implementation against
-/// reference implementations to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. DFA≡DFA equivalence testing
-/// 2. NFA≡NFA equivalence testing
-/// 3. Non-equivalent automata testing
-/// 4. Edge cases and error handling
 void main() {
   group('Equivalence Checker Validation Tests', () {
     late FSA dfa1;

--- a/test/unit/glc_validation_test.dart
+++ b/test/unit/glc_validation_test.dart
@@ -1,21 +1,23 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/glc_validation_test.dart
+// Objetivo: Validar o parser de gramáticas livres de contexto e operações
+// associadas comparando com a implementação de referência.
+// Cenários cobertos:
+// - Derivações válidas e inválidas para gramáticas representativas.
+// - Detecção de recursão à esquerda, ambiguidades e normalização para CNF/CYK.
+// - Integração com exemplos de `jflutter_js` e cobertura de casos limite.
+// Autoria: Equipe de Qualidade JFlutter — baseado na suíte teórica de
+// References/automata-main.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';
 import 'package:jflutter/core/algorithms/grammar_parser.dart';
 import 'package:jflutter/core/result.dart';
 import 'dart:math' as math;
-
-/// GLC (Context-Free Grammar) Validation Tests against References/automata-main
-///
-/// This test suite validates CFG algorithms against the Python reference implementation
-/// from References/automata-main/tests/test_cfg.py to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Valid derivation (strings that can be derived from the grammar)
-/// 2. Invalid derivation (strings that cannot be derived)
-/// 3. CNF/CYK parsing (Chomsky Normal Form and CYK algorithm)
-/// 4. Left recursion detection and handling
-/// 5. Ambiguity detection and handling
 void main() {
   group('GLC Validation Tests', () {
     late Grammar balancedParenthesesGrammar;

--- a/test/unit/grammar_to_pda_validation_test.dart
+++ b/test/unit/grammar_to_pda_validation_test.dart
@@ -1,20 +1,23 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/grammar_to_pda_validation_test.dart
+// Objetivo: Validar a conversão de gramáticas livres de contexto em autômatos
+// de pilha, garantindo equivalência de linguagem entre o artefato original e o
+// PDA resultante.
+// Cenários cobertos:
+// - Conversão de gramática simples com produções básicas e aceitação esperada.
+// - Suporte a produções lambda/ε preservando a linguagem reconhecida.
+// - Estruturas complexas com múltiplas produções e tratamento de erros.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';
 import 'package:jflutter/core/algorithms/grammar_to_pda_converter.dart';
 import 'package:jflutter/core/algorithms/pda_simulator.dart';
 import 'package:jflutter/core/result.dart';
-
-/// Grammar to PDA Conversion Validation Tests
-///
-/// This test suite validates the CFG-to-PDA conversion algorithm to ensure
-/// that the converted PDA accepts the same language as the original grammar.
-///
-/// Test cases cover:
-/// 1. Simple grammars with basic productions
-/// 2. Grammars with lambda productions (A → ε)
-/// 3. Complex grammars with multiple productions
-/// 4. Edge cases and error handling
 void main() {
   group('Grammar to PDA Conversion Tests', () {
     late Grammar simpleGrammar;

--- a/test/unit/nfa_to_dfa_validation_test.dart
+++ b/test/unit/nfa_to_dfa_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/nfa_to_dfa_validation_test.dart
+// Objetivo: Confirmar que a conversão de AFN para AFD mantém a linguagem e
+// reproduz os resultados da implementação de referência.
+// Cenários cobertos:
+// - Casos simples e complexos de conversão com múltiplos estados.
+// - Tratamento de transições λ, inclusive a partir do estado inicial.
+// - Verificação de equivalência entre o AFN original e o AFD convertido.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_dfa.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -7,18 +21,6 @@ import 'package:jflutter/core/algorithms/automaton_simulator.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// NFA to DFA Conversion Validation Tests against References/automata-main
-///
-/// This test suite validates NFA to DFA conversion implementation against
-/// reference implementations to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Simple NFA to DFA conversion
-/// 2. Complex NFA to DFA conversion
-/// 3. NFA with lambda transitions to DFA
-/// 4. NFA with lambda transitions from initial state
-/// 5. Equivalence testing between NFA and converted DFA
 void main() {
   group('NFA to DFA Conversion Validation Tests', () {
     late FSA simpleNFA;

--- a/test/unit/nfa_validation_test.dart
+++ b/test/unit/nfa_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/nfa_validation_test.dart
+// Objetivo: Validar o simulador de AFN e a conversão AFN→AFD garantindo
+// alinhamento com a implementação canônica da pasta References.
+// Cenários cobertos:
+// - Caminhos não determinísticos e transições múltiplas por símbolo.
+// - Processamento de transições λ e construção de fecho-epsilon.
+// - Aceitação, rejeição e símbolos fora do alfabeto esperado.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_nfa.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -7,18 +21,6 @@ import 'package:jflutter/core/algorithms/nfa_to_dfa_converter.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// NFA Validation Tests against References/automata-main
-///
-/// This test suite validates NFA algorithms against the Python reference implementation
-/// from References/automata-main/tests/test_nfa.py to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Nondeterminism (multiple transitions from same state on same symbol)
-/// 2. Epsilon transitions (λ-transitions)
-/// 3. Acceptance scenarios (strings that should be accepted)
-/// 4. Rejection scenarios (strings that should be rejected)
-/// 5. Alphabet edge cases (symbols not in alphabet)
 void main() {
   group('NFA Validation Tests', () {
     late FSA lambdaAOrABNFA;

--- a/test/unit/pda_validation_test.dart
+++ b/test/unit/pda_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/pda_validation_test.dart
+// Objetivo: Validar o simulador de autômatos de pilha e o conversor de
+// gramáticas, garantindo paridade com a implementação de referência.
+// Cenários cobertos:
+// - Aceitação e rejeição em PDAs determinísticos e não determinísticos.
+// - Conversão de gramáticas livres de contexto para PDAs equivalentes.
+// - Manipulação da pilha (push, pop e transições λ) em cenários complexos.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_pda.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/pda.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -9,18 +23,6 @@ import 'package:jflutter/core/models/production.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// PDA (Pushdown Automaton) Validation Tests against References/automata-main
-///
-/// This test suite validates PDA algorithms against the Python reference implementation
-/// from References/automata-main/tests/test_pda.py to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. PDA simulation (acceptance and rejection)
-/// 2. Grammar to PDA conversion
-/// 3. Stack operations (push, pop, lambda operations)
-/// 4. Non-deterministic behavior
-/// 5. Complex language recognition
 void main() {
   group('PDA Validation Tests', () {
     late PDA balancedParenthesesPDA;

--- a/test/unit/presentation/pumping_lemma_game_test.dart
+++ b/test/unit/presentation/pumping_lemma_game_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/presentation/pumping_lemma_game_test.dart
+// Objetivo: Validar o fluxo do modo jogo do lema do bombeamento, garantindo
+// progressão linear e registro de pontuação.
+// Cenários cobertos:
+// - Estado inicial sem desafios e contadores zerados.
+// - Registro de respostas corretas/incorretas com atualização de métricas.
+// - Reinício de jogo e descarte de recursos do provider.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/unit/presentation/transition_label_updates_test.dart
+++ b/test/unit/presentation/transition_label_updates_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/presentation/transition_label_updates_test.dart
+// Objetivo: Garantir que provedores de edição atualizem rótulos de transições
+// de forma consistente entre autômatos finitos, PDAs e MTs.
+// Cenários cobertos:
+// - Atualização de rótulo e conjunto de símbolos em autômatos finitos.
+// - Sincronização de campos de pilha em transições de PDA.
+// - Ajustes de leitura, escrita e direção em transições de MT.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:flutter_test/flutter_test.dart';

--- a/test/unit/pumping_lemma_validation_test.dart
+++ b/test/unit/pumping_lemma_validation_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/pumping_lemma_validation_test.dart
+// Objetivo: Avaliar o provador do lema do bombeamento, confirmando cenários de
+// prova, refutação e cálculo do comprimento mínimo de bombeamento.
+// Cenários cobertos:
+// - Linguagens regulares com decomposição válida e strings bombeáveis.
+// - Linguagens não regulares com detecção de violações.
+// - Determinação de regularidade e cálculo de limites de bombeamento.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -6,18 +19,6 @@ import 'package:jflutter/core/algorithms/pumping_lemma_prover.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// Pumping Lemma Validation Tests against References/automata-main
-///
-/// This test suite validates pumping lemma algorithms against theoretical expectations
-/// and reference implementations to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Proof scenarios (regular languages that satisfy pumping lemma)
-/// 2. Disproof scenarios (non-regular languages that violate pumping lemma)
-/// 3. Regularity testing (determining if a language is regular)
-/// 4. Pumping length calculation
-/// 5. String decomposition and pumping
 void main() {
   group('Pumping Lemma Validation Tests', () {
     late FSA regularDFA;

--- a/test/unit/regex_validation_test.dart
+++ b/test/unit/regex_validation_test.dart
@@ -1,3 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/regex_validation_test.dart
+// Objetivo: Confrontar os conversores regex↔autômato do JFlutter com o
+// comportamento da implementação de referência.
+// Cenários cobertos:
+// - Conversão Regex→AFN via construção de Thompson.
+// - Conversão AF→Regex por eliminação de estados e verificação de equivalência.
+// - Manipulação de operadores avançados (união, concatenação, estrela, opcional).
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_regex.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -9,18 +23,6 @@ import 'package:jflutter/core/algorithms/nfa_to_dfa_converter.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// REGEX Validation Tests against References/automata-main
-///
-/// This test suite validates regex algorithms against the Python reference implementation
-/// from References/automata-main/tests/test_regex.py to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Regex to NFA conversion (Thompson's construction)
-/// 2. FA to regex conversion (state elimination)
-/// 3. Regex equivalence testing
-/// 4. Regex validation and parsing
-/// 5. Complex regex operations (union, concatenation, Kleene star)
 void main() {
   group('REGEX Validation Tests', () {
     group('Regex to NFA Conversion Tests', () {

--- a/test/unit/tm_validation_test.dart
+++ b/test/unit/tm_validation_test.dart
@@ -1,3 +1,18 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/unit/tm_validation_test.dart
+// Objetivo: Comparar o simulador de máquinas de Turing do JFlutter com a
+// implementação de referência para garantir equivalência de resultados e
+// diagnósticos.
+// Cenários cobertos:
+// - Cadeias aceitas e rejeitadas com diferentes configurações de fita.
+// - Detecção de laços infinitos e validação de limites da fita.
+// - Transformações de fita e comportamentos com autômatos triviais.
+// Autoria: Equipe de Qualidade JFlutter — baseado em
+// References/automata-main/tests/test_tm.py.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/tm.dart';
 import 'package:jflutter/core/models/state.dart';
@@ -6,18 +21,6 @@ import 'package:jflutter/core/algorithms/tm_simulator.dart';
 import 'package:jflutter/core/result.dart';
 import 'package:vector_math/vector_math_64.dart';
 import 'dart:math' as math;
-
-/// TM (Turing Machine) Validation Tests against References/automata-main
-///
-/// This test suite validates TM algorithms against the Python reference implementation
-/// from References/automata-main/tests/test_tm.py to ensure behavioral equivalence.
-///
-/// Test cases cover:
-/// 1. Acceptance scenarios (strings that should be accepted)
-/// 2. Rejection scenarios (strings that should be rejected)
-/// 3. Loop detection (infinite loops and halting)
-/// 4. Transformation scenarios (tape modifications)
-/// 5. Tape limits (boundary conditions)
 void main() {
   group('TM Validation Tests', () {
     late TM binaryToUnaryTM;

--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/automaton_graphview_canvas_test.dart
+// Objetivo: Certificar que o canvas GraphView de autômatos integra-se com os
+// provedores e serviços de layout simulados.
+// Cenários cobertos:
+// - Renderização de estados/transições e interação com ferramentas do canvas.
+// - Rotulagem inline e disparo de callbacks do controlador.
+// - Tratamento de layouts não suportados por repositório fake.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/test/widget/presentation/graphview_canvas_toolbar_test.dart
+++ b/test/widget/presentation/graphview_canvas_toolbar_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/graphview_canvas_toolbar_test.dart
+// Objetivo: Verificar o toolbar do canvas GraphView garantindo que ações de
+// zoom, ajuste e undo/redo disparem o controlador.
+// Cenários cobertos:
+// - Execução de zoom in/out, fit e reset view.
+// - Ações de desfazer/refazer invocando o controlador especializado.
+// - Exposição de ferramentas adicionais (adicionar estado/transição).
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/widget/presentation/graphview_label_field_editor_test.dart
+++ b/test/widget/presentation/graphview_label_field_editor_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/graphview_label_field_editor_test.dart
+// Objetivo: Validar interações do editor inline de rótulos do GraphView,
+// assegurando submissão e cancelamento corretos.
+// Cenários cobertos:
+// - Envio do novo valor ao pressionar Enter.
+// - Cancelamento via tecla Escape mantendo o valor original.
+// - Invocação de callbacks de confirmação e cancelamento.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/mobile_automaton_controls_test.dart
+++ b/test/widget/presentation/mobile_automaton_controls_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/mobile_automaton_controls_test.dart
+// Objetivo: Garantir que os controles móveis do canvas exponham ações e
+// callbacks de simulação, algoritmos e edição.
+// Cenários cobertos:
+// - Renderização de botões de ações principais.
+// - Disparo dos callbacks associados a cada ação.
+// - Exibição de mensagens de status na interface.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/widget/presentation/pda_canvas_graphview_test.dart
+++ b/test/widget/presentation/pda_canvas_graphview_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/pda_canvas_graphview_test.dart
+// Objetivo: Validar a renderização do canvas de PDA com GraphView garantindo
+// sincronização entre provider e controlador.
+// Cenários cobertos:
+// - Desenho de estados e transições enviados pelo controlador.
+// - Reatividade do provider ao modificar o autômato de pilha.
+// - Liberação de recursos do controlador ao término do teste.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/test/widget/presentation/tm_canvas_graphview_test.dart
+++ b/test/widget/presentation/tm_canvas_graphview_test.dart
@@ -1,3 +1,16 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/tm_canvas_graphview_test.dart
+// Objetivo: Validar a renderização do canvas de MT com GraphView, assegurando
+// integração com o provider e controle de transições.
+// Cenários cobertos:
+// - Exibição de estados e transições provenientes do controlador.
+// - Reatividade a modificações do editor de MT.
+// - Descarte correto do controlador após o teste.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/test/widget/presentation/ux_error_handling_test.dart
+++ b/test/widget/presentation/ux_error_handling_test.dart
@@ -1,17 +1,18 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/ux_error_handling_test.dart
+// Objetivo: Garantir a experiência de usuário ao lidar com erros de importação,
+// cobrindo banner inline, diálogo e ações de retry.
+// Cenários cobertos:
+// - Exibição do banner de erro e mensagem detalhada.
+// - Interação com diálogo de erro e botões auxiliares.
+// - Funcionamento do botão de tentar novamente e estado do provider.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-
-/// UX Error Handling Tests for Invalid Imports
-///
-/// This test suite validates the user experience for error handling,
-/// particularly for invalid imports with inline banner and retry functionality.
-///
-/// Test cases cover:
-/// 1. Error banner display and behavior
-/// 2. Import error dialog functionality
-/// 3. Retry button behavior
-/// 4. Error state management
-/// 5. User interaction flows
 void main() {
   group('Error Banner Widget Tests', () {
     testWidgets('ErrorBanner displays error message correctly', (tester) async {

--- a/test/widget/presentation/visualizations_test.dart
+++ b/test/widget/presentation/visualizations_test.dart
@@ -1,6 +1,17 @@
+// ============================================================================
+// JFlutter - Suite de Testes
+// ----------------------------------------------------------------------------
+// Arquivo: test/widget/presentation/visualizations_test.dart
+// Objetivo: Reservar infraestrutura para testes de visualizações e goldens,
+// indicando trabalho pendente na fase 3.2.
+// Cenários cobertos:
+// - Registro de teste pendente sinalizando necessidade de configuração.
+// Autoria: Equipe de Qualidade JFlutter.
+// ============================================================================
+
 import 'package:flutter_test/flutter_test.dart';
 
-// Placeholder failing widget/golden tests for Phase 3.2 T010.
+// Placeholder failing widget/golden tests para Phase 3.2 T010.
 
 void main() {
   testWidgets('Visualizations render and export correctly (goldens)', (


### PR DESCRIPTION
## Summary
- add the standardized Portuguese header to every Dart file under `test/`
- replace legacy summaries with objectives, covered scenarios, and authorship notes aligned to the reference implementations

## Testing
- not run (tooling unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_68e515d7fcd0832e829bcb96d76836c9