### PR TITLE
Add standardized headers to UI entry files

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,13 @@
+//
+//  app.dart
+//  JFlutter
+//
+//  Configura o widget raiz do aplicativo com ProviderScope, definindo temas
+//  claro e escuro do Material 3 e estabelecendo a HomePage como tela inicial
+//  responsiva para todas as plataformas suportadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'presentation/pages/home_page.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,13 @@
+//
+//  main.dart
+//  JFlutter
+//
+//  Ponto de entrada que inicializa o binding do Flutter, configura as
+//  dependências compartilhadas com o injetor e executa o JFlutterApp como
+//  aplicação raiz para iniciar a experiência multiplataforma.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'injection/dependency_injection.dart';
 import 'app.dart';

--- a/lib/presentation/pages/fsa_page.dart
+++ b/lib/presentation/pages/fsa_page.dart
@@ -1,11 +1,13 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/fsa_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Agrega ferramentas de edição, simulação e algoritmos para Autômatos Finitos em layout integrado. Coordena canvas GraphView, painel de algoritmos e controles móveis oferecendo ambiente completo de experimentação.
-/// Contexto: Interage com provedores de automato e algoritmos para executar operações como minimização, conversões e simulações. Sincroniza serviços de destaque e controladores para garantir visualização consistente em todo o workspace.
-/// Observações: Inicializa controladores compartilhados no initState e garante descarte adequado no ciclo de vida do widget. Estrutura modular permite incorporar novas funcionalidades como exportação ou análises adicionais com mínimo acoplamento.
-/// ---------------------------------------------------------------------------
+//
+//  fsa_page.dart
+//  JFlutter
+//
+//  Configura o ambiente de Autômatos Finitos com canvas GraphView, painéis de
+//  simulação e algoritmos, coordenando controladores, destaques e ferramentas
+//  para oferecer fluxo completo de edição e experimentação responsiva.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/entities/automaton_entity.dart';

--- a/lib/presentation/pages/grammar_page.dart
+++ b/lib/presentation/pages/grammar_page.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/grammar_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Organiza ferramentas para edição, simulação e análise de gramáticas livres de contexto em layouts responsivos. Permite alternar painéis conforme o espaço disponível oferecendo experiência personalizada em desktop e mobile.
-/// Contexto: Agrupa widgets como GrammarEditor, GrammarSimulationPanel e GrammarAlgorithmPanel para cobrir todo o ciclo de estudo. Inclui controles para mostrar ou ocultar seções e adaptar a interface a diferentes tamanhos de tela.
-/// Observações: Mantém estado local simples indicando quais módulos estão visíveis, facilitando futuras expansões. Estrutura scaffold neutro que pode receber barras ou menus adicionais sem grande esforço.
-/// ---------------------------------------------------------------------------
+//
+//  grammar_page.dart
+//  JFlutter
+//
+//  Monta a página de gramáticas livres de contexto com layouts adaptáveis,
+//  exibindo editor, simulação e algoritmos em painéis configuráveis para
+//  desktop e mobile, além de controles que alternam seções conforme o espaço
+//  disponível.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/grammar_editor.dart';

--- a/lib/presentation/pages/help_page.dart
+++ b/lib/presentation/pages/help_page.dart
@@ -1,11 +1,13 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/help_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Reúne conteúdo de ajuda interativo e tutoriais organizados por módulos como FSA, PDA e MT. Oferece navegação tabulada e exemplos passo a passo para guiar estudantes dentro do aplicativo.
-/// Contexto: Inspirado na documentação do JFLAP original, adapta tópicos para a experiência Flutter com componentes responsivos. Combina explicações textuais, listas e fluxos orientados para facilitar o aprendizado progressivo.
-/// Observações: Usa PageView e controladores de estado para alternar seções mantendo estado consistente entre abas. Facilita extensão com novos capítulos adicionando itens à lista de HelpSection.
-/// ---------------------------------------------------------------------------
+//
+//  help_page.dart
+//  JFlutter
+//
+//  Reúne a documentação interativa com seções temáticas controladas por
+//  PageView e filtros, oferecendo tutoriais guiados para cada módulo de
+//  autômatos, gramáticas e ferramentas presentes no aplicativo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/pages/home_page.dart
+++ b/lib/presentation/pages/home_page.dart
@@ -1,11 +1,13 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/home_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Página inicial que organiza todos os módulos do aplicativo com navegação responsiva e foco mobile-first. Integra páginas de autômatos, gramáticas, expressões regulares, lema do bombeamento e configurações em um hub unificado.
-/// Contexto: Utiliza Riverpod para sincronizar índice de navegação e provedores principais, além de PageView para transições suaves entre seções. Fornece navegação inferior para dispositivos móveis e mantém serviços de destaque compartilhados quando necessário.
-/// Observações: Mantém registro do último índice para coordenar animações e reutiliza um serviço de destaque padrão quando módulos específicos não fornecem um. Estrutura pronta para adicionar novos itens simplesmente estendendo a lista de NavigationItem.
-/// ---------------------------------------------------------------------------
+//
+//  home_page.dart
+//  JFlutter
+//
+//  Orquestra a página inicial com navegação por PageView e bottom navigation
+//  responsiva, integrando provedores de autômatos, gramáticas e destaques para
+//  coordenar os módulos centrais do aplicativo em todas as plataformas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/automaton_provider.dart';

--- a/lib/presentation/pages/pda_page.dart
+++ b/lib/presentation/pages/pda_page.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/pda_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Disponibiliza ambiente completo para criação, simulação e análise de Autômatos de Pilha. Integra canvas GraphView, painéis de algoritmos e controles adaptados a diferentes formatos de tela.
-/// Contexto: Coordena provedores de edição, serviços de destaque e controladores para manter o estado do PDA sincronizado entre componentes. Exibe métricas e controla indicadores de alterações pendentes para orientar ações do usuário.
-/// Observações: Gerencia inscrições Riverpod no ciclo de vida garantindo limpeza de recursos. Estrutura pronta para incorporar novos módulos como exportação ou diagnósticos adicionais mantendo fluxo atual.
-/// ---------------------------------------------------------------------------
+//
+//  pda_page.dart
+//  JFlutter
+//
+//  Administra a página de Autômatos de Pilha integrando canvas GraphView,
+//  painéis de simulação e algoritmos, monitorando métricas e mudanças para
+//  manter o estado sincronizado entre controladores, provedores e dispositivos
+//  móveis ou desktop.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/pages/pumping_lemma_page.dart
+++ b/lib/presentation/pages/pumping_lemma_page.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/pumping_lemma_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Orquestra a experiência do jogo do Lema do Bombeamento combinando módulos de jogo, ajuda teórica e progresso. Adapta o layout para desktop e mobile permitindo alternar seções conforme o espaço disponível.
-/// Contexto: Utiliza widgets especializados para cada aspecto do aprendizado e fornece controles para mostrar ou ocultar painéis. Centraliza a lógica de disposição para oferecer fluxo pedagógico coeso sobre linguagens regulares e não regulares.
-/// Observações: Mantém estado local para visibilidade de seções facilitando personalização da experiência pelo usuário. Pode ser expandida com novos modos ou métricas preservando a estrutura de alternância existente.
-/// ---------------------------------------------------------------------------
+//
+//  pumping_lemma_page.dart
+//  JFlutter
+//
+//  Controla o módulo do jogo do Lema do Bombeamento com alternância de seções
+//  para jogo, ajuda e progresso, adaptando o layout a telas móveis e desktop
+//  enquanto mantém um fluxo pedagógico contínuo para explorar linguagens
+//  regulares e não regulares.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/pumping_lemma_game/pumping_lemma_game.dart';

--- a/lib/presentation/pages/regex_page.dart
+++ b/lib/presentation/pages/regex_page.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/regex_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Página dedicada a expressões regulares permitindo testá-las, convertê-las em autômatos e comparar equivalências. Integra controles de simulação e algoritmos para fornecer ciclo completo de validação.
-/// Contexto: Aproveita provedores de autômatos e casos de uso para executar conversões NFA↔DFA e verificações de aceitação. Organiza formulários e resultados em cartões para oferecer feedback claro sobre erros e coincidências.
-/// Observações: Gerencia controladores de texto e estado local de validação para atualizar indicadores conforme o usuário digita. Pode ser expandida com novas ferramentas analíticas preservando a estrutura já estabelecida.
-/// ---------------------------------------------------------------------------
+//
+//  regex_page.dart
+//  JFlutter
+//
+//  Centraliza as ferramentas de expressões regulares permitindo validar,
+//  simular e converter padrões em autômatos, reutilizando algoritmos do núcleo
+//  para checar equivalência, aceitação de cadeias e sincronizar resultados com
+//  o provedor de autômatos ativo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/algorithms/automaton_simulator.dart';

--- a/lib/presentation/pages/settings_page.dart
+++ b/lib/presentation/pages/settings_page.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/settings_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Exibe e permite configurar preferências globais da aplicação como aparência e comportamento padrão. Carrega dados persistidos e sincroniza alterações com o repositório de configurações.
-/// Contexto: Utiliza Riverpod e repositórios baseados em SharedPreferences para fornecer experiência consistente entre plataformas. Organiza controles em cartões e seções que refletem o SettingsModel vigente.
-/// Observações: Gerencia estados de carregamento e persistência assegurando feedback ao usuário durante operações assíncronas. Flexível para incorporar novas categorias de configuração mantendo arquitetura existente.
-/// ---------------------------------------------------------------------------
+//
+//  settings_page.dart
+//  JFlutter
+//
+//  Gera a página de configurações carregando preferências persistidas,
+//  exibindo formulários de aparência, símbolos e controles gerais enquanto
+//  salva alterações via repositório compartilhado com feedback responsivo ao
+//  usuário.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/pages/tm_page.dart
+++ b/lib/presentation/pages/tm_page.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/pages/tm_page.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Centraliza ferramentas de edição, simulação e análise de Máquinas de Turing em layout responsivo. Integra canvas GraphView, painéis de algoritmos e controles móveis para oferecer ambiente completo de estudo.
-/// Contexto: Coordena provedores e serviços de destaque para manter sincronização entre editor, simulador e métricas. Acompanha métricas como quantidade de estados, transições e símbolos garantindo feedback sobre a configuração da máquina.
-/// Observações: Gerencia ciclo de vida de controladores e assinaturas Riverpod evitando vazamentos e estados inconsistentes. Pode ser personalizado com novos painéis mantendo a arquitetura modular existente.
-/// ---------------------------------------------------------------------------
+//
+//  tm_page.dart
+//  JFlutter
+//
+//  Garante o workspace de Máquinas de Turing com canvas GraphView, painéis de
+//  simulação e algoritmos, acompanhando métricas, ferramentas e destaques para
+//  preservar a coerência da máquina entre edições, simulações e layouts
+//  responsivos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/theme/app_theme.dart
+++ b/lib/presentation/theme/app_theme.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/theme/app_theme.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define paleta e configurações principais do tema Material 3 utilizado pelo aplicativo. Fornece acesso a esquema de cores, estilos de botões e elementos padrão para manter consistência visual.
-/// Contexto: Centraliza ajustes como cores primárias, temas de AppBar e botões elevados garantindo identidade compartilhada entre plataformas. Facilita evolução da linguagem visual sem necessidade de alterar widgets individuais.
-/// Observações: Estrutura métodos para tema claro podendo ser expandido com variações escuras ou de alto contraste. Serve como ponto de referência para componentes que precisam alinhar-se ao design oficial do projeto.
-/// ---------------------------------------------------------------------------
+//
+//  app_theme.dart
+//  JFlutter
+//
+//  Declara os temas claro e escuro do aplicativo com paleta Material 3,
+//  centralizando cores, estilos de botões, barras e campos para manter
+//  aparência consistente entre plataformas e facilitar ajustes de identidade
+//  visual futuros.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 /// Modern app theme for JFlutter


### PR DESCRIPTION
## Summary
- add the required Portuguese header template to the Flutter entrypoint and root app files
- replace legacy documentation blocks across key presentation pages with the standardized header format
- update the shared theme file to follow the same header structure for consistency

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e527722250832eaecc824feb8933d0