### PR TITLE
Padroniza cabeçalhos das suítes de testes de autômatos

### DIFF
--- a/test/unit/core/automata/fa_algorithms_test.dart
+++ b/test/unit/core/automata/fa_algorithms_test.dart
@@ -1,16 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/automata/fa_algorithms_test.dart
-// Objetivo: Exercitar algoritmos de autômatos finitos (AFN→AFD, minimização e
-// operações de linguagem) em cenários controlados.
-// Cenários cobertos:
-// - Conversão AFN→AFD preservando fechos-ε e estados aceitando.
-// - Minimização Hopcroft com equivalência de linguagem.
-// - Operações de complemento, união e interseção aplicadas em DFAs.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
-
+//
+//  fa_algorithms_test.dart
+//  JFlutter
+//
+//  Casos específicos que exercitam algoritmos utilitários de autômatos finitos como conversão AFN→AFD, minimização de Hopcroft e operações de linguagem.
+//  Os testes montam autômatos pequenos para confirmar fechos epsilon, equivalência de linguagem e composição via complemento, união e interseção.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/test/unit/core/cfg/cyk_parser_test.dart
+++ b/test/unit/core/cfg/cyk_parser_test.dart
@@ -1,16 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/cfg/cyk_parser_test.dart
-// Objetivo: Testar o parser CYK assegurando construção de tabela, árvores de
-// derivação e integração com gramáticas em FNC.
-// Cenários cobertos:
-// - Aceitação e rejeição de cadeias válidas/ inválidas segundo gramáticas em CNF.
-// - Construção de árvores de derivação completas e parciais.
-// - Tratamento de produções λ e unitárias após normalização.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
-
+//
+//  cyk_parser_test.dart
+//  JFlutter
+//
+//  Conjunto de testes dedicado ao parser CYK da camada core verificando construção de tabela, árvores de derivação e integração com gramáticas normalizadas.
+//  Abrange cadeias válidas e inválidas, produções lambda e unitárias, além de assegurar o detalhamento do resultado retornado.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/cfg/cyk_parser.dart';
 import 'package:jflutter/core/models/grammar.dart';

--- a/test/unit/core/result_test.dart
+++ b/test/unit/core/result_test.dart
@@ -1,14 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/result_test.dart
-// Objetivo: Garantir o comportamento das extensões de `Result`, especialmente
-// a transformação segura entre sucesso e falha.
-// Cenários cobertos:
-// - Preservação de mensagens de erro ao aplicar `mapOrElse`.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
-
+//
+//  result_test.dart
+//  JFlutter
+//
+//  Testes unitários que asseguram o comportamento das extensões da classe Result ao propagar sucessos e falhas.
+//  Valida especialmente o método mapOrElse preservando mensagens de erro e tipos em cenários de falha.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/result.dart';
 

--- a/test/unit/cyk_validation_test.dart
+++ b/test/unit/cyk_validation_test.dart
@@ -1,16 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/cyk_validation_test.dart
-// Objetivo: Validar o algoritmo CYK garantindo reconhecimento correto de
-// linguagens após conversão para FNC.
-// Cenários cobertos:
-// - Construção de tabela e aceitação/rejeição de cadeias em CNF.
-// - Conversão de gramáticas e tratamento de produções especiais.
-// - Casos extremos relacionados a cadeias vazias e entradas curtas.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
-
+//
+//  cyk_validation_test.dart
+//  JFlutter
+//
+//  Conjunto de testes que garante a fidelidade do algoritmo CYK ao analisar gramáticas convertidas para forma normal de Chomsky em cadeias de diversos comprimentos.
+//  Os cenários cobrem construções de tabela, tratamentos de produções especiais, rejeições esperadas e comportamentos extremos para manter a consistência do analisador.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';

--- a/test/unit/dfa_minimization_validation_test.dart
+++ b/test/unit/dfa_minimization_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/dfa_minimization_validation_test.dart
-// Objetivo: Validar o algoritmo de minimização de AFD do JFlutter com base na
-// suíte de referência.
-// Cenários cobertos:
-// - Redução de autômatos básicos e complexos com estados redundantes.
-// - Garantia de invariância para AFDs já minimizados ou sem estados finais.
-// - Comparação de linguagem entre versões originais e minimizadas.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_dfa.py.
-// ============================================================================
-
+//
+//  dfa_minimization_validation_test.dart
+//  JFlutter
+//
+//  Testes que verificam o algoritmo de minimização de DFAs assegurando redução correta de estados sem alterar a linguagem reconhecida.
+//  Englobam autômatos básicos, estruturas redundantes, casos já minimizados e máquinas sem estados de aceitação para checar diagnósticos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/dfa_validation_test.dart
+++ b/test/unit/dfa_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/dfa_validation_test.dart
-// Objetivo: Validar o simulador e a minimização de AFDs comparando com a base
-// de referência em Python.
-// Cenários cobertos:
-// - Aceitação, rejeição e tratamento da cadeia vazia.
-// - Detecção de ciclos e consistência em complementação.
-// - Equivalência pós-minimização em relação ao autômato original.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_dfa.py.
-// ============================================================================
-
+//
+//  dfa_validation_test.dart
+//  JFlutter
+//
+//  Bateria que compara o simulador de DFAs e o minimizador do JFlutter com autômatos de referência para assegurar aceitação, rejeição e estabilidade da linguagem.
+//  Inclui verificações da cadeia vazia, de ciclos e da equivalência entre a máquina original e sua versão minimizada.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/equivalence_validation_test.dart
+++ b/test/unit/equivalence_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/equivalence_validation_test.dart
-// Objetivo: Verificar o comparador de equivalência de autômatos frente à
-// implementação de referência da pasta automata-main.
-// Cenários cobertos:
-// - Equivalência entre DFAs e NFAs com construções distintas.
-// - Diferenciação de autômatos não equivalentes com diagnósticos.
-// - Tratamento de casos extremos e entradas malformadas.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_dfa.py.
-// ============================================================================
-
+//
+//  equivalence_validation_test.dart
+//  JFlutter
+//
+//  Conjunto de testes que valida o EquivalenceChecker para DFAs e NFAs, cobrindo cenários equivalentes, não equivalentes e comparações cruzadas entre autômatos construídos de maneiras distintas.
+//  O arquivo monta máquinas de exemplo para assegurar diagnósticos coerentes e resultados consistentes mesmo em casos extremos e entradas malformadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/glc_validation_test.dart
+++ b/test/unit/glc_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/glc_validation_test.dart
-// Objetivo: Validar o parser de gramáticas livres de contexto e operações
-// associadas comparando com a implementação de referência.
-// Cenários cobertos:
-// - Derivações válidas e inválidas para gramáticas representativas.
-// - Detecção de recursão à esquerda, ambiguidades e normalização para CNF/CYK.
-// - Integração com exemplos de `jflutter_js` e cobertura de casos limite.
-// Autoria: Equipe de Qualidade JFlutter — baseado na suíte teórica de
-// References/automata-main.
-// ============================================================================
-
+//
+//  glc_validation_test.dart
+//  JFlutter
+//
+//  Coleção de testes que examina o parser de gramáticas livres de contexto e utilitários associados para validar derivação, normalização e análise.
+//  Os cenários detectam recursões, ambiguidades, conversões para CNF e confrontam exemplos importados de bibliotecas de apoio.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';

--- a/test/unit/grammar_to_pda_validation_test.dart
+++ b/test/unit/grammar_to_pda_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/grammar_to_pda_validation_test.dart
-// Objetivo: Validar a conversão de gramáticas livres de contexto em autômatos
-// de pilha, garantindo equivalência de linguagem entre o artefato original e o
-// PDA resultante.
-// Cenários cobertos:
-// - Conversão de gramática simples com produções básicas e aceitação esperada.
-// - Suporte a produções lambda/ε preservando a linguagem reconhecida.
-// - Estruturas complexas com múltiplas produções e tratamento de erros.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
-
+//
+//  grammar_to_pda_validation_test.dart
+//  JFlutter
+//
+//  Suite que garante a fidelidade da conversão de gramáticas livres de contexto em autômatos de pilha mantendo equivalência de linguagem.
+//  Cobre gramáticas simples, produções lambda e estruturas complexas validando o PDA resultante por simulação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';

--- a/test/unit/nfa_to_dfa_validation_test.dart
+++ b/test/unit/nfa_to_dfa_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/nfa_to_dfa_validation_test.dart
-// Objetivo: Confirmar que a conversão de AFN para AFD mantém a linguagem e
-// reproduz os resultados da implementação de referência.
-// Cenários cobertos:
-// - Casos simples e complexos de conversão com múltiplos estados.
-// - Tratamento de transições λ, inclusive a partir do estado inicial.
-// - Verificação de equivalência entre o AFN original e o AFD convertido.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_dfa.py.
-// ============================================================================
-
+//
+//  nfa_to_dfa_validation_test.dart
+//  JFlutter
+//
+//  Testes focados na conversão de AFNs para DFAs garantindo que a linguagem e os diagnósticos permaneçam equivalentes após o processo.
+//  Abrange exemplos com transições lambda e epsilon, construções complexas e validação dos autômatos resultantes por simulação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/nfa_validation_test.dart
+++ b/test/unit/nfa_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/nfa_validation_test.dart
-// Objetivo: Validar o simulador de AFN e a conversão AFN→AFD garantindo
-// alinhamento com a implementação canônica da pasta References.
-// Cenários cobertos:
-// - Caminhos não determinísticos e transições múltiplas por símbolo.
-// - Processamento de transições λ e construção de fecho-epsilon.
-// - Aceitação, rejeição e símbolos fora do alfabeto esperado.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_nfa.py.
-// ============================================================================
-
+//
+//  nfa_validation_test.dart
+//  JFlutter
+//
+//  Casos de teste que avaliam o simulador de AFNs e a conversão para DFAs garantindo alinhamento com os exemplos clássicos usados como referência.
+//  Os experimentos exploram caminhos não determinísticos, fechos epsilon, símbolos fora do alfabeto e verificações de aceitação versus rejeição.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/pda_validation_test.dart
+++ b/test/unit/pda_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/pda_validation_test.dart
-// Objetivo: Validar o simulador de autômatos de pilha e o conversor de
-// gramáticas, garantindo paridade com a implementação de referência.
-// Cenários cobertos:
-// - Aceitação e rejeição em PDAs determinísticos e não determinísticos.
-// - Conversão de gramáticas livres de contexto para PDAs equivalentes.
-// - Manipulação da pilha (push, pop e transições λ) em cenários complexos.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_pda.py.
-// ============================================================================
-
+//
+//  pda_validation_test.dart
+//  JFlutter
+//
+//  Conjunto de testes que confirma o comportamento do simulador de autômatos de pilha e da conversão de gramáticas livres de contexto para PDAs.
+//  Inclui cenários determinísticos e não determinísticos com manipulação de pilha, transições lambda e validação de linguagem contra a referência.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/pda.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/pumping_lemma_validation_test.dart
+++ b/test/unit/pumping_lemma_validation_test.dart
@@ -1,16 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/pumping_lemma_validation_test.dart
-// Objetivo: Avaliar o provador do lema do bombeamento, confirmando cenários de
-// prova, refutação e cálculo do comprimento mínimo de bombeamento.
-// Cenários cobertos:
-// - Linguagens regulares com decomposição válida e strings bombeáveis.
-// - Linguagens não regulares com detecção de violações.
-// - Determinação de regularidade e cálculo de limites de bombeamento.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
-
+//
+//  pumping_lemma_validation_test.dart
+//  JFlutter
+//
+//  Grupo de testes dedicado ao provador do lema do bombeamento avaliando demonstrações para linguagens regulares e diagnósticos para linguagens não regulares.
+//  As validações analisam decomposições bombeáveis, limites mínimos calculados e respostas para cenários de sucesso e falha.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/regex_validation_test.dart
+++ b/test/unit/regex_validation_test.dart
@@ -1,17 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/regex_validation_test.dart
-// Objetivo: Confrontar os conversores regex↔autômato do JFlutter com o
-// comportamento da implementação de referência.
-// Cenários cobertos:
-// - Conversão Regex→AFN via construção de Thompson.
-// - Conversão AF→Regex por eliminação de estados e verificação de equivalência.
-// - Manipulação de operadores avançados (união, concatenação, estrela, opcional).
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_regex.py.
-// ============================================================================
-
+//
+//  regex_validation_test.dart
+//  JFlutter
+//
+//  Suite que verifica as conversões entre expressões regulares e autômatos finitos cobrindo ida e volta no pipeline de linguagem formal.
+//  Os casos exercitam operadores avançados, simulam os autômatos gerados e confirmam consistência com a implementação de referência.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/tm_validation_test.dart
+++ b/test/unit/tm_validation_test.dart
@@ -1,18 +1,12 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/tm_validation_test.dart
-// Objetivo: Comparar o simulador de máquinas de Turing do JFlutter com a
-// implementação de referência para garantir equivalência de resultados e
-// diagnósticos.
-// Cenários cobertos:
-// - Cadeias aceitas e rejeitadas com diferentes configurações de fita.
-// - Detecção de laços infinitos e validação de limites da fita.
-// - Transformações de fita e comportamentos com autômatos triviais.
-// Autoria: Equipe de Qualidade JFlutter — baseado em
-// References/automata-main/tests/test_tm.py.
-// ============================================================================
-
+//
+//  tm_validation_test.dart
+//  JFlutter
+//
+//  Bateria de testes que confronta o simulador de máquinas de Turing com casos reais de aceitação, rejeição e detecção de laços infinitos para validar respostas.
+//  As rotinas montam máquinas variadas, verificam transformações de fita e confirmam limites operacionais alinhados com a implementação de referência.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/tm.dart';
 import 'package:jflutter/core/models/state.dart';


### PR DESCRIPTION
## Summary
- aplica o cabeçalho padronizado nos arquivos de testes de autômatos em `test/unit` e `test/unit/core`
- descreve em português o propósito de cada suíte cobrindo validações de equivalência, conversões e simuladores

## Testing
- not run (comentários apenas)


------
https://chatgpt.com/codex/tasks/task_e_68e528b85660832e881ff64cc52255e4