### PR TITLE
Padronizar cabeçalhos nos arquivos de dados

### DIFF
--- a/lib/data/data_sources/examples_asset_data_source.dart
+++ b/lib/data/data_sources/examples_asset_data_source.dart
@@ -1,3 +1,11 @@
+//
+//  examples_asset_data_source.dart
+//  JFlutter
+//
+//  Disponibiliza exemplos enriquecidos a partir de assets, combinando metadados de categoria com validação por tipo de máquina para montar AutomatonModel coerentes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';

--- a/lib/data/data_sources/examples_data_source.dart
+++ b/lib/data/data_sources/examples_data_source.dart
@@ -1,3 +1,11 @@
+//
+//  examples_data_source.dart
+//  JFlutter
+//
+//  Carrega exemplos básicos do pacote de assets, convertendo JSON em modelos de autômato, descrevendo cada item e agrupando-os por categorias simples.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'package:flutter/foundation.dart' as foundation;
 import 'package:flutter/services.dart';

--- a/lib/data/data_sources/local_storage_data_source.dart
+++ b/lib/data/data_sources/local_storage_data_source.dart
@@ -1,3 +1,11 @@
+//
+//  local_storage_data_source.dart
+//  JFlutter
+//
+//  Controla o armazenamento local de autômatos com SharedPreferences, cuidando de salvar, listar, remover, exportar e importar registros em JSON.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../models/automaton_model.dart';

--- a/lib/data/repositories/algorithm_repository_impl.dart
+++ b/lib/data/repositories/algorithm_repository_impl.dart
@@ -1,3 +1,11 @@
+//
+//  algorithm_repository_impl.dart
+//  JFlutter
+//
+//  Expõe operações de algoritmos sobre autômatos e gramáticas, convertendo entidades para os modelos do núcleo antes de orquestrar transformações, análises e simulações complexas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 import 'package:collection/collection.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/data/repositories/automaton_repository_impl.dart
+++ b/lib/data/repositories/automaton_repository_impl.dart
@@ -1,3 +1,11 @@
+//
+//  automaton_repository_impl.dart
+//  JFlutter
+//
+//  Implementa o repositório de autômatos traduzindo entidades para o serviço interno, cobrindo persistência, operações de exportação e validações com conversões de modelo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/data/repositories/examples_repository_impl.dart
+++ b/lib/data/repositories/examples_repository_impl.dart
@@ -1,3 +1,11 @@
+//
+//  examples_repository_impl.dart
+//  JFlutter
+//
+//  Reúne o carregamento e as consultas estendidas da biblioteca de exemplos ao compor o data source de assets com caching e métricas fornecidos pelo serviço especializado.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../core/result.dart';
 import '../../core/repositories/automaton_repository.dart';
 import '../data_sources/examples_asset_data_source.dart';

--- a/lib/data/repositories/settings_repository_impl.dart
+++ b/lib/data/repositories/settings_repository_impl.dart
@@ -1,3 +1,11 @@
+//
+//  settings_repository_impl.dart
+//  JFlutter
+//
+//  Persiste preferências de interface e símbolos no SharedPreferences por meio de uma camada de repositório que aplica padrões e sincroniza o modelo de configurações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:shared_preferences/shared_preferences.dart'
     show SharedPreferences;
 

--- a/lib/data/services/automaton_service.dart
+++ b/lib/data/services/automaton_service.dart
@@ -1,3 +1,11 @@
+//
+//  automaton_service.dart
+//  JFlutter
+//
+//  Mantém um armazenamento em memória de autômatos, fornecendo CRUD, geração de identificadores, importação e exportação em JSON e validações estruturais com ajustes de layout.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/data/services/conversion_service.dart
+++ b/lib/data/services/conversion_service.dart
@@ -1,3 +1,11 @@
+//
+//  conversion_service.dart
+//  JFlutter
+//
+//  Encapsula as conversões entre autômatos, gramáticas e expressões regulares, validando entradas e delegando para os algoritmos especializados de transformação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../core/models/fsa.dart';
 import '../../core/models/grammar.dart';
 import '../../core/models/pda.dart';

--- a/lib/data/services/examples_service.dart
+++ b/lib/data/services/examples_service.dart
@@ -1,3 +1,11 @@
+//
+//  examples_service.dart
+//  JFlutter
+//
+//  Orquestra o carregamento, cache e filtragem da biblioteca de exemplos, oferecendo buscas, recomendações e estatísticas por categoria, dificuldade e trilhas de aprendizado.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../core/result.dart';
 import '../../core/repositories/automaton_repository.dart';
 import '../data_sources/examples_asset_data_source.dart';

--- a/lib/data/services/file_operations_service.dart
+++ b/lib/data/services/file_operations_service.dart
@@ -1,3 +1,11 @@
+//
+//  file_operations_service.dart
+//  JFlutter
+//
+//  Centraliza a leitura e escrita de autômatos e gramáticas nos formatos JFLAP, além de gerar exportações em PNG e SVG desenhando o canvas com ajustes visuais consistentes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:io';
 import 'dart:math' as math;
 import 'dart:ui' as ui;

--- a/lib/data/services/import_export_validation_service.dart
+++ b/lib/data/services/import_export_validation_service.dart
@@ -1,3 +1,11 @@
+//
+//  import_export_validation_service.dart
+//  JFlutter
+//
+//  Valida ciclos de importação e exportação ao comparar XML, JSON e representações gráficas, aferindo integridade estrutural, contagens e mensagens de erro previstas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:ui';
 import 'dart:math';
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/data/services/serialization_service.dart
+++ b/lib/data/services/serialization_service.dart
@@ -1,3 +1,11 @@
+//
+//  serialization_service.dart
+//  JFlutter
+//
+//  Implementa serialização e desserialização de autômatos entre estruturas internas e XML JFLAP, tratando estados, transições e mapeamento seguro de dados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'package:xml/xml.dart';
 import '../../core/result.dart';

--- a/lib/data/services/simulation_service.dart
+++ b/lib/data/services/simulation_service.dart
@@ -1,3 +1,11 @@
+//
+//  simulation_service.dart
+//  JFlutter
+//
+//  Expõe operações de simulação para autômatos finitos determinísticos e não determinísticos, validando parâmetros e retornando resultados uniformizados do simulador central.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../core/models/fsa.dart';
 import '../../core/models/simulation_result.dart';
 import '../../core/result.dart';

--- a/lib/data/services/trace_persistence_service.dart
+++ b/lib/data/services/trace_persistence_service.dart
@@ -1,3 +1,11 @@
+//
+//  trace_persistence_service.dart
+//  JFlutter
+//
+//  Gerencia o armazenamento de históricos de simulação via SharedPreferences, preservando metadados, seleção atual e consultas segmentadas por autômato ou tipo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../core/models/simulation_result.dart';


### PR DESCRIPTION
## Summary
- addicionei o cabeçalho padronizado com resumo em português nos serviços de dados para documentar responsabilidades de conversão, simulação e persistência
- apliquei o mesmo padrão nos data sources e repositórios relacionados para manter a autoria e o contexto alinhados

## Testing
- not run (comentários apenas)


------
https://chatgpt.com/codex/tasks/task_e_68e52c265b54832e8c8a7d4d9a57ee93