### PR TITLE
Add standardized headers to graphview and widget files

### DIFF
--- a/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/base_graphview_canvas_controller.dart
@@ -1,9 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/base_graphview_canvas_controller.dart
-/// Descrição: Implementa o controlador base do GraphView, lidando com histórico
-///            de snapshots, animações de camera e integrações de destaque.
-/// ---------------------------------------------------------------------------
+//
+//  base_graphview_canvas_controller.dart
+//  JFlutter
+//
+//  Classe base que centraliza infraestrutura comum aos controladores GraphView,
+//  incluindo caches de nós e arestas, histórico para undo/redo, animações de
+//  viewport e conversões entre coordenadas de tela e mundo. Também integra o
+//  suporte a destaques de simulação e garante descarte adequado dos recursos de
+//  transformação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:graphview/GraphView.dart';

--- a/lib/features/canvas/graphview/graphview_all_nodes_builder.dart
+++ b/lib/features/canvas/graphview/graphview_all_nodes_builder.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_all_nodes_builder.dart
-/// Descrição: Estende o GraphView padrão para renderizar todos os nós do
-///            canvas, respeitando animações e ajustes de zoom personalizados.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_all_nodes_builder.dart
+//  JFlutter
+//
+//  Extensão do widget GraphView que garante a renderização de todos os nós do
+//  grafo, mesmo quando a biblioteca base tenta otimizar a exibição. A classe
+//  adapta o delegate interno para preservar animações e configurações de zoom
+//  personalizadas do canvas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/widgets.dart';
 import 'package:graphview/GraphView.dart';
 

--- a/lib/features/canvas/graphview/graphview_automaton_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_automaton_mapper.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_automaton_mapper.dart
-/// Descrição: Converte autômatos finitos em snapshots do GraphView,
-///            traduzindo estados e transições para o modelo visual do canvas.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_automaton_mapper.dart
+//  JFlutter
+//
+//  Utilitário que traduz autômatos finitos para snapshots consumidos pelo
+//  GraphView e reconstrói instâncias do domínio a partir do resultado da
+//  edição visual. Ele cria nós, arestas, metadados e trata consistência de
+//  estados durante merges de template.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/fsa.dart';

--- a/lib/features/canvas/graphview/graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_controller.dart
@@ -1,9 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_canvas_controller.dart
-/// Descrição: Gerencia o canvas GraphView para autômatos finitos, sincronizando
-///            o grafo renderizado com o provedor e eventos de interação.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_canvas_controller.dart
+//  JFlutter
+//
+//  Controlador responsável por manter o canvas GraphView de autômatos finitos
+//  sincronizado com o AutomatonProvider, coordenando criação de estados,
+//  transições e rótulos conforme o usuário interage. O componente também gera
+//  identificadores previsíveis, trata undo/redo e aplica snapshots recebidos do
+//  domínio para atualizar o grafo exibido.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/canvas/graphview/graphview_canvas_models.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_models.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_canvas_models.dart
-/// Descrição: Define modelos imutáveis usados pelo canvas GraphView para
-///            representar metadados, nós e transições durante a renderização.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_canvas_models.dart
+//  JFlutter
+//
+//  Declara os modelos imutáveis utilizados pelo canvas GraphView para
+//  transportar metadados do autômato, nós e arestas renderizadas, além de
+//  serializações auxiliares. Essas estruturas intermediam a comunicação entre o
+//  domínio e a camada de apresentação durante snapshots e exportações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:collection/collection.dart';
 
 import '../../../core/models/tm_transition.dart';

--- a/lib/features/canvas/graphview/graphview_highlight_channel.dart
+++ b/lib/features/canvas/graphview/graphview_highlight_channel.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_highlight_channel.dart
-/// Descrição: Encaminha realces do serviço de simulação para controladores
-///            GraphView, mantendo o canvas alinhado com o estado da execução.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_highlight_channel.dart
+//  JFlutter
+//
+//  Canal que recebe realces do SimulationHighlightService e os encaminha para o
+//  controlador GraphView responsável pelo canvas, garantindo que o estado
+//  visual acompanhe cada etapa da simulação e permitindo limpar o destaque
+//  ativo quando necessário.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../../core/models/simulation_highlight.dart';
 import '../../../core/services/simulation_highlight_service.dart';
 import 'graphview_highlight_controller.dart';

--- a/lib/features/canvas/graphview/graphview_highlight_controller.dart
+++ b/lib/features/canvas/graphview/graphview_highlight_controller.dart
@@ -1,9 +1,13 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_highlight_controller.dart
-/// Descrição: Define o contrato de controle de destaques de simulação para o
-///            canvas GraphView, padronizando aplicação e limpeza de realces.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_highlight_controller.dart
+//  JFlutter
+//
+//  Contrato compartilhado pelos controladores GraphView que lidam com
+//  destaques de simulação, padronizando a aplicação de realces vindos dos
+//  serviços de execução e a remoção segura desses efeitos do canvas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../../core/models/simulation_highlight.dart';
 
 /// Common contract exposed by GraphView canvas controllers that support

--- a/lib/features/canvas/graphview/graphview_label_field_editor.dart
+++ b/lib/features/canvas/graphview/graphview_label_field_editor.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_label_field_editor.dart
-/// Descrição: Fornece o overlay de edição de rótulos de transição no GraphView,
-///            mediando entrada do usuário e confirmação/cancelamento no canvas.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_label_field_editor.dart
+//  JFlutter
+//
+//  Widget de overlay que permite editar rótulos de transições diretamente no
+//  GraphView, coordenando foco, confirmação e cancelamento com o canvas. A
+//  implementação lida com ciclo de vida dos FocusNodes e invoca o formulário de
+//  edição compartilhado para padronizar a experiência.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../../presentation/widgets/transition_editors/transition_label_editor.dart';

--- a/lib/features/canvas/graphview/graphview_link_overlay_utils.dart
+++ b/lib/features/canvas/graphview/graphview_link_overlay_utils.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_link_overlay_utils.dart
-/// Descrição: Calcula âncoras e posições de sobreposição para arestas no
-///            GraphView, garantindo alinhamento visual consistente no canvas.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_link_overlay_utils.dart
+//  JFlutter
+//
+//  Conjunto de utilitários que calcula âncoras e posições para sobreposições de
+//  arestas no GraphView, normalizando pontos de controle e loops para manter o
+//  alinhamento visual do canvas. As funções auxiliam widgets a posicionar
+//  indicadores e editores diretamente sobre as ligações renderizadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../../core/constants/automaton_canvas.dart';

--- a/lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
+++ b/lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_node_editor_event_shims.dart
-/// Descrição: Define payloads leves para eventos do editor GraphView, como
-///            seleção por arrasto e destaques de links durante edições.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_node_editor_event_shims.dart
+//  JFlutter
+//
+//  Coleção de payloads e ajudantes que padronizam eventos emitidos pelos
+//  editores GraphView, como seleção por arrasto, destaque de ligações e remoção
+//  de transições. As funções convertem coleções brutas em estruturas
+//  imutáveis consumidas pelos widgets da camada de apresentação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:ui';
 
 /// Lightweight payload describing the result of a drag-selection gesture within

--- a/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
@@ -1,9 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
-/// Descrição: Coordena o canvas GraphView para autômatos de pilha, gerenciando
-///            sincronização, seleção e manipulação visual das estruturas PDA.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_pda_canvas_controller.dart
+//  JFlutter
+//
+//  Controlador dedicado aos autômatos de pilha que sincroniza o GraphView com o
+//  estado do PDAEditorNotifier, lidando com criação, movimentação e rótulos dos
+//  nós, além de manter transições configuradas com símbolos de pilha. Também
+//  orquestra snapshots vindos do domínio e registra logs úteis durante
+//  mutações do grafo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/canvas/graphview/graphview_pda_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_pda_mapper.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_pda_mapper.dart
-/// Descrição: Transforma autômatos de pilha em snapshots consumidos pelo
-///            GraphView, organizando estados, pilha e transições para o canvas.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_pda_mapper.dart
+//  JFlutter
+//
+//  Utilitário que traduz autômatos de pilha para snapshots manipulados pelo
+//  GraphView e recompõe modelos do domínio durante salvamentos do canvas. O
+//  código mantém estados, símbolos de entrada e de pilha, além de inferir
+//  marcadores lambda ao reconstruir as transições.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/pda.dart';

--- a/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
@@ -1,9 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
-/// Descrição: Administra o canvas GraphView para Turing Machines, mantendo
-///            sincronismo entre o grafo, o provedor e interações de edição.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_tm_canvas_controller.dart
+//  JFlutter
+//
+//  Controlador que mantém o canvas GraphView alinhado ao estado de edição de
+//  máquinas de Turing, sincronizando nós e transições com o TMEditorNotifier e
+//  oferecendo operações de criação, movimentação, rótulo e flags. Também cuida
+//  da geração de identificadores estáveis, da aplicação de snapshots vindos do
+//  domínio e do registro de telemetria útil durante mutações do grafo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/canvas/graphview/graphview_tm_mapper.dart
+++ b/lib/features/canvas/graphview/graphview_tm_mapper.dart
@@ -1,9 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_tm_mapper.dart
-/// Descrição: Faz a ponte entre Turing Machines do domínio e snapshots do
-///            GraphView, mapeando estados, transições e fitas para o canvas.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_tm_mapper.dart
+//  JFlutter
+//
+//  Utilitário que converte máquinas de Turing em snapshots compatíveis com o
+//  GraphView e reidrata modelos do domínio a partir de edições visuais. O
+//  mapeamento preserva estados, transições, direção de fita e alfabetos para
+//  garantir consistência entre a camada visual e os dados centrais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 
 import '../../../core/models/state.dart';

--- a/lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
+++ b/lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
@@ -1,9 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/canvas/graphview/graphview_viewport_highlight_mixin.dart
-/// Descrição: Reúne utilidades de viewport e destaque para controladores
-///            GraphView, incluindo enquadramento automático e animações de foco.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_viewport_highlight_mixin.dart
+//  JFlutter
+//
+//  Mixin que reúne utilidades de viewport e de destaque para controladores do
+//  GraphView, oferecendo animações de zoom, centralização, ajuste automático ao
+//  conteúdo e rastreamento dos realces ativos. Ele também expõe notifiers
+//  reutilizáveis que acionam repaints e permitem observar mudanças de transições
+//  destacadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:flutter/foundation.dart';

--- a/lib/features/layout/layout_repository_impl.dart
+++ b/lib/features/layout/layout_repository_impl.dart
@@ -1,10 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/features/layout/layout_repository_impl.dart
-/// Descrição: Implementa heurísticas de auto layout para autômatos, calculando
-///            posições dos estados com distribuição radial e espaçamentos
-///            seguros no canvas.
-/// ---------------------------------------------------------------------------
+//
+//  layout_repository_impl.dart
+//  JFlutter
+//
+//  Implementação do LayoutRepository que aplica diferentes heurísticas de
+//  posicionamento automático para autômatos, incluindo distribuições radiais,
+//  grade balanceada, padrões compactos em espiral e organização hierárquica.
+//  O repositório calcula áreas seguras, mescla estados reposicionados e retorna
+//  resultados encapsulados em AutomatonResult.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:collection';
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/presentation/widgets/export/svg_exporter.dart
+++ b/lib/presentation/widgets/export/svg_exporter.dart
@@ -1,11 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/export/svg_exporter.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Implementa gerador de SVGs para autômatos, gramáticas e máquinas de Turing convertendo modelos em diagramas vetoriais. Fornece opções de personalização e estilos padrão alinhados à identidade visual do projeto.
-/// Contexto: Atua como utilitário compartilhado entre widgets de exportação permitindo distribuir representações em arquivos externos. Realiza conversões auxiliares para reuso de layouts e simplifica renderizações ao aplicar algoritmos básicos de posicionamento.
-/// Observações: Estrutura saída com cabeçalhos SVG, definições de marcadores e máscaras para estados de aceitação. Serve de base para extensões futuras como suporte a estilos adicionais ou integração com exportadores específicos de plataforma.
-/// ---------------------------------------------------------------------------
+//
+//  svg_exporter.dart
+//  JFlutter
+//
+//  Utilitário responsável por gerar representações SVG de autômatos, gramáticas
+//  e máquinas de Turing, convertendo entidades do domínio em diagramas vetoriais
+//  com estilos consistentes. A classe oferece opções de personalização, monta
+//  cabeçalhos e definições gráficas e encapsula rotinas de layout para estados,
+//  transições e fitas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 import 'package:flutter/material.dart' hide Colors;
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/presentation/widgets/file_operations_panel.dart
+++ b/lib/presentation/widgets/file_operations_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/file_operations_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Centraliza ações de salvar, carregar e exportar autômatos ou gramáticas em formatos suportados, incluindo JFLAP e SVG. Fornece botões agrupados por tipo de estrutura para facilitar o fluxo do usuário.
-/// Contexto: Utiliza FileOperationsService e FilePicker para manipular arquivos locais, atualizando provedores através de callbacks. Apresenta indicadores de carregamento para sinalizar operações assíncronas em andamento.
-/// Observações: Organização modular permite habilitar seções de acordo com os dados disponíveis, evitando opções inválidas. Ideal para ser incorporado a painéis laterais ou janelas de diálogo mantendo coesão visual com o restante da aplicação.
-/// ---------------------------------------------------------------------------
+//
+//  file_operations_panel.dart
+//  JFlutter
+//
+//  Painel de interface que agrupa ações de salvar, carregar e exportar
+//  autômatos ou gramáticas nos formatos suportados, apresentando botões
+//  contextualizados conforme os dados disponíveis. O widget orquestra o
+//  FileOperationsService, interage com o FilePicker e exibe indicadores de
+//  progresso para operações assíncronas, atualizando callbacks fornecidos pela
+//  tela hospedeira.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:file_picker/file_picker.dart';
 import '../../core/models/fsa.dart';

--- a/lib/presentation/widgets/grammar_algorithm_panel.dart
+++ b/lib/presentation/widgets/grammar_algorithm_panel.dart
@@ -1,11 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/grammar_algorithm_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Concentra botões e fluxos de algoritmos relacionados a gramáticas como conversões, fatoração e análise LL. Fornece feedback textual sobre execuções para orientar ajustes e próximas ações.
-/// Contexto: Interage com diversos provedores para disparar conversões para AF, AP e atualizações de navegabilidade entre espaços de trabalho. Exibe resultados produzidos pelos serviços do domínio garantindo continuidade entre edições e simulações.
-/// Observações: Controla estado interno simples de carregamento e resultado para evitar bloqueio do restante da interface. Pode ser expandido com novos algoritmos mantendo a estrutura modular de seções e descrições.
-/// ---------------------------------------------------------------------------
+//
+//  grammar_algorithm_panel.dart
+//  JFlutter
+//
+//  Painel que centraliza algoritmos de gramáticas, oferecendo botões para
+//  conversões, remoção de recursão à esquerda, fatoração e cálculos de FIRST e
+//  FOLLOW, além da construção de tabelas de análise. O widget integra múltiplos
+//  providers para disparar operações, gerencia estados de carregamento e exibe
+//  resultados textuais que orientam a próxima ação do usuário.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 


### PR DESCRIPTION
## Summary
- add the required Portuguese header block to GraphView controllers, mappers, and supporting utilities
- align layout and presentation widgets with the standardized comment header format

## Testing
- not run (comment-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e52dbca464832e87d53899c0605f33