### PR TITLE
docs: padroniza cabeçalhos descritivos em camadas de dados

### DIFF
--- a/lib/data/models/automaton_dto.dart
+++ b/lib/data/models/automaton_dto.dart
@@ -1,4 +1,17 @@
-/// DTO for serializing automata data
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/data/models/automaton_dto.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Define os DTOs responsáveis por serializar autômatos, estados e
+///             estruturas JFLAP garantindo compatibilidade com armazenamento e
+///             troca de dados.
+/// Contexto: Serve como camada de transporte entre entidades do domínio,
+///           arquivos JSON e representações legadas do JFLAP, permitindo
+///           importar e exportar configurações completas de autômatos.
+/// Observações: Mantém coleções imutáveis para preservar integridade dos
+///               dados serializados e expõe fábricas de conversão para
+///               facilitar a reconstrução dos objetos.
+/// ---------------------------------------------------------------------------
 class AutomatonDto {
   final String id;
   final String name;

--- a/lib/data/models/automaton_model.dart
+++ b/lib/data/models/automaton_model.dart
@@ -1,3 +1,16 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/data/models/automaton_model.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Implementa o modelo de dados de autômatos utilizado para
+///             persistência, incluindo conversões entre entidades e estruturas
+///             serializáveis.
+/// Contexto: Atende a camada de dados facilitando o mapeamento bidirecional
+///           entre o domínio e o armazenamento local, garantindo consistência
+///           das coleções e metadados do autômato.
+/// Observações: Construtores aplicam coleções imutáveis e fábricas dedicadas,
+///               reduzindo risco de mutações acidentais em estados compartilhados.
+/// ---------------------------------------------------------------------------
 import '../../core/entities/automaton_entity.dart';
 
 /// Data model for automaton persistence

--- a/lib/data/models/grammar_dto.dart
+++ b/lib/data/models/grammar_dto.dart
@@ -1,4 +1,16 @@
-/// DTO for serializing grammar data
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/data/models/grammar_dto.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Define os DTOs das gramáticas e estruturas JFLAP responsáveis
+///             por serializar símbolos, produções e metadados associados.
+/// Contexto: Suporta importação e exportação de gramáticas entre o domínio e
+///           formatos JSON/JFLAP, assegurando compatibilidade com o ecossistema
+///           da aplicação e ferramentas externas.
+/// Observações: Construtores imutáveis e fábricas dedicadas simplificam a
+///               reconstrução das gramáticas mantendo a fidelidade dos dados
+///               originais.
+/// ---------------------------------------------------------------------------
 class GrammarDto {
   final String id;
   final String name;

--- a/lib/data/models/turing_machine_dto.dart
+++ b/lib/data/models/turing_machine_dto.dart
@@ -1,6 +1,19 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/data/models/turing_machine_dto.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Estruturas DTO responsáveis por serializar máquinas de Turing,
+///             transições e símbolos, mantendo compatibilidade com armazenamento
+///             local e formatos externos.
+/// Contexto: Faz a ponte entre entidades de domínio e representações JSON,
+///           permitindo importar, persistir e compartilhar configurações de
+///           máquinas de Turing completas.
+/// Observações: Usa conversões imutáveis e helpers para mapear transições
+///               aninhadas, garantindo consistência mesmo em estruturas
+///               complexas.
+/// ---------------------------------------------------------------------------
 import 'package:collection/collection.dart';
 
-/// DTO for serializing Turing machine data
 class TuringMachineDto {
   const TuringMachineDto({
     required this.id,

--- a/lib/data/storage/settings_storage.dart
+++ b/lib/data/storage/settings_storage.dart
@@ -1,3 +1,17 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/data/storage/settings_storage.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Define o contrato de armazenamento de preferências e a
+///             implementação baseada em SharedPreferences para persistir
+///             configurações do usuário.
+/// Contexto: Fornece abstração reutilizável para o repositório de configurações
+///           isolando detalhes da API de chave-valor e permitindo injeção em
+///           testes e camadas superiores.
+/// Observações: Suporta provedores customizados de SharedPreferences,
+///               facilitando mocks em testes e configurações específicas de
+///               plataforma.
+/// ---------------------------------------------------------------------------
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Key-value storage interface used by the settings repository.

--- a/lib/injection/dependency_injection.dart
+++ b/lib/injection/dependency_injection.dart
@@ -1,3 +1,17 @@
+/// ---------------------------------------------------------------------------
+/// Projeto: JFlutter
+/// Arquivo: lib/injection/dependency_injection.dart
+/// Autoria: Equipe de Engenharia JFlutter
+/// Descrição: Configura o contêiner GetIt registrando data sources, serviços,
+///             repositórios e providers necessários para o funcionamento da
+///             aplicação.
+/// Contexto: Centraliza a infraestrutura de injeção de dependências permitindo
+///           inicialização preguiçosa, reutilização de instâncias e fácil
+///           manutenção das ligações entre camadas.
+/// Observações: Prepara SharedPreferences para persistência de traços e
+///               registra implementações concretas mantendo o código preparado
+///               para testes e extensões futuras.
+/// ---------------------------------------------------------------------------
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../core/repositories/automaton_repository.dart';


### PR DESCRIPTION
## Summary
- adiciona o bloco de cabeçalho institucional aos DTOs de autômato, gramática e máquina de Turing
- padroniza o cabeçalho descritivo no storage de configurações e no setup de injeção de dependências

## Testing
- N/A

------
https://chatgpt.com/codex/tasks/task_e_68e53907f2ac832ebb3424f655c8cb6c