### PR TITLE
tests: padronizar cabecalhos de suites

### DIFF
--- a/test/core/services/simulation_highlight_service_test.dart
+++ b/test/core/services/simulation_highlight_service_test.dart
@@ -1,14 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/core/services/simulation_highlight_service_test.dart
-// Objetivo: Verificar a comunicação do serviço de destaque de simulação com o
-// controlador GraphView.
-// Cenários cobertos:
-// - Emissão de destaques durante a simulação passo a passo.
-// - Limpeza de destaques ao encerrar ou reiniciar.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: serviço de destaques de simulação conversa com GraphView.
+/// Resumo: Exercita a emissão e limpeza de destaques durante simulações para
+/// garantir que o canal encaminhe eventos ao controlador e restaure o estado.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';

--- a/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_automaton_mapper_test.dart
-// Objetivo: Validar o mapeamento de autômatos para modelos GraphView usados no
-// canvas.
-// Cenários cobertos:
-// - Conversão de estados e transições em nós e arestas com posição.
-// - Tratamento de loops, transições múltiplas e estados iniciais/aceitadores.
-// - Atualização de dados ao sincronizar com GraphViewAutomatonMapper.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: mapeamento de autômatos para modelos do GraphView.
+/// Resumo: Exercita a conversão de estados e transições em nós e arestas, com
+/// tratamento de loops, múltiplas ligações e sincronização com o mapper.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_canvas_controller_test.dart
-// Objetivo: Verificar o controlador base GraphView de autômatos garantindo
-// interação com o provider e repositório de layout fake.
-// Cenários cobertos:
-// - Aplicação de layouts (auto, balanced, compact, hierarchical, spread).
-// - Manipulação de zoom, seleção e atualizações de transição.
-// - Uso de serviço de autômato para sincronização com o estado interno.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: controlador base do canvas GraphView para autômatos.
+/// Resumo: Exercita aplicação de layouts, manipulação de zoom e seleção, além
+/// da sincronização com providers e repositório fake para validar interações.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_canvas_models_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_models_test.dart
@@ -1,13 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_canvas_models_test.dart
-// Objetivo: Avaliar modelos de canvas usados pelo GraphView garantindo
-// imutabilidade e helpers consistentes.
-// Cenários cobertos:
-// - Atualização de metadados de arestas via `copyWith`.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: modelos de canvas utilizados pelo GraphView.
+/// Resumo: Verifica operações de `copyWith` para garantir imutabilidade e
+/// atualização correta de metadados em arestas do canvas.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
-// Objetivo: Validar o controlador GraphView específico de PDA, assegurando
-// sincronização com o provider e manipulação da pilha.
-// Cenários cobertos:
-// - Construção de grafos a partir de PDAs com transições de push/pop.
-// - Seleção e atualização de transições refletidas no editor.
-// - Descarte adequado do controlador após o uso.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: controlador GraphView dedicado a autômatos com pilha.
+/// Resumo: Exercita a geração de grafos para PDAs, a seleção de transições com
+/// operações de pilha e o descarte seguro ao sincronizar com o provider.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_pda_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_mapper_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_pda_mapper_test.dart
-// Objetivo: Garantir que PDAs sejam convertidos corretamente para modelos de
-// canvas GraphView.
-// Cenários cobertos:
-// - Tradução de push/pop e símbolos λ em metadados visuais.
-// - Mapeamento de estados iniciais/aceitadores e transições múltiplas.
-// - Atualização do grafo ao sincronizar com GraphViewPdaMapper.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: mapeamento de PDAs para estruturas do canvas GraphView.
+/// Resumo: Avalia a conversão de operações de pilha, estados especiais e
+/// transições múltiplas em metadados visuais sincronizados com o mapper.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
-// Objetivo: Garantir que o controlador GraphView para MT sincronize estados,
-// transições e seleção com o provider.
-// Cenários cobertos:
-// - Construção de grafo a partir de máquinas de Turing e atualizações em tempo real.
-// - Seleção de transições e estados, emitindo eventos correspondentes.
-// - Descarte seguro de recursos após uso.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: controlador GraphView específico para máquinas de Turing.
+/// Resumo: Avalia a construção do grafo, a seleção de estados/transições e o
+/// descarte de recursos ao sincronizar o canvas com o provider de MT.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_tm_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_mapper_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_tm_mapper_test.dart
-// Objetivo: Validar mapeamento de máquinas de Turing para estruturas GraphView
-// utilizadas no canvas.
-// Cenários cobertos:
-// - Conversão de estados, transições e direções de fita em modelos visuais.
-// - Suporte a múltiplas fitas e símbolos de leitura/escrita.
-// - Ajuste de nós e controle de curvas em representações gráficas.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: mapeamento de máquinas de Turing para modelos GraphView.
+/// Resumo: Verifica a tradução de estados, transições e direções de fita para
+/// estruturas visuais, incluindo múltiplas fitas e ajuste geométrico.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/integration/io/examples_roundtrip_test.dart
+++ b/test/integration/io/examples_roundtrip_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/examples_roundtrip_test.dart
-// Objetivo: Exercitar round-trips de exemplos canônicos passando por assets,
-// serviços de serialização e exportação.
-// Cenários cobertos:
-// - Conversão de autômatos, gramáticas e MTs entre entidades e arquivos.
-// - Exportação SVG e validação de estruturas serializadas.
-// - Verificação de consistência dos metadados da biblioteca Examples.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: roundtrip de exemplos da biblioteca oficial.
+/// Resumo: Exercita a ida e volta de autômatos, gramáticas e MTs entre assets,
+/// serviços de serialização e exportação, validando consistência dos metadados.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/integration/io/interoperability_roundtrip_test.dart
+++ b/test/integration/io/interoperability_roundtrip_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/interoperability_roundtrip_test.dart
-// Objetivo: Validar interoperabilidade entre formatos `.jff`, JSON e SVG,
-// garantindo round-trip sem perda.
-// Cenários cobertos:
-// - Conversões JFLAP↔modelos internos usando parser XML dedicado.
-// - Serialização JSON de autômatos, gramáticas e MTs.
-// - Exportação SVG para visualização preservando elementos-chave.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: roundtrip de interoperabilidade entre `.jff`, JSON e SVG.
+/// Resumo: Exercita importação e exportação de autômatos, gramáticas e MTs
+/// convertendo entre formatos JFLAP, JSON e SVG sem perda de informação.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/unit/core/algorithms/pda_to_cfg_converter_test.dart
+++ b/test/unit/core/algorithms/pda_to_cfg_converter_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/algorithms/pda_to_cfg_converter_test.dart
-// Objetivo: Verificar a conversão de PDAs para gramáticas livres de contexto,
-// assegurando preservação da linguagem reconhecida.
-// Cenários cobertos:
-// - Construção de produções a partir de transições de empilha/desempilha.
-// - Geração de regras iniciais com estados intermediários e terminais.
-// - Tratamento de autômatos inválidos com feedback de erro estruturado.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: conversão de PDAs em gramáticas livres de contexto.
+/// Resumo: Verifica geração de produções baseadas em push/pop, regras iniciais
+/// intermediárias e tratamento de autômatos inválidos mantendo a linguagem.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/unit/core/automata/fa_algorithms_test.dart
+++ b/test/unit/core/automata/fa_algorithms_test.dart
@@ -1,12 +1,8 @@
-//
-//  fa_algorithms_test.dart
-//  JFlutter
-//
-//  Casos específicos que exercitam algoritmos utilitários de autômatos finitos como conversão AFN→AFD, minimização de Hopcroft e operações de linguagem.
-//  Os testes montam autômatos pequenos para confirmar fechos epsilon, equivalência de linguagem e composição via complemento, união e interseção.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: algoritmos de autômatos finitos (AFN→AFD, Hopcroft e linguagem).
+/// Resumo: Monta autômatos pequenos para validar fechos ε, conversões,
+/// minimização e operações de união/interseção/complemento mantendo linguagens.
+/// ---------------------------------------------------------------------------
 import 'dart:math' as math;
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/test/unit/core/cfg/cfg_toolkit_test.dart
+++ b/test/unit/core/cfg/cfg_toolkit_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/cfg/cfg_toolkit_test.dart
-// Objetivo: Validar o toolkit de GLC do JFlutter cobrindo normalizações e
-// verificações estruturais essenciais.
-// Cenários cobertos:
-// - Remoção de produções ε, unitárias e símbolos inúteis.
-// - Conversão para Forma Normal de Chomsky e checagem de validade.
-// - Garantia de preservação da linguagem ao aplicar transformações sucessivas.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: toolkit de GLC para limpezas e normalizações.
+/// Resumo: Valida remoções de ε, unitárias e símbolos inúteis, bem como a
+/// conversão para FNC preservando a linguagem após transformações encadeadas.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/cfg/cfg_toolkit.dart';

--- a/test/unit/core/cfg/cyk_parser_test.dart
+++ b/test/unit/core/cfg/cyk_parser_test.dart
@@ -1,12 +1,8 @@
-//
-//  cyk_parser_test.dart
-//  JFlutter
-//
-//  Conjunto de testes dedicado ao parser CYK da camada core verificando construção de tabela, árvores de derivação e integração com gramáticas normalizadas.
-//  Abrange cadeias válidas e inválidas, produções lambda e unitárias, além de assegurar o detalhamento do resultado retornado.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: parser CYK operando sobre gramáticas normalizadas.
+/// Resumo: Exercita construção de tabela, derivação e respostas detalhadas para
+/// cadeias válidas ou rejeitadas, incluindo produções λ e unitárias.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/cfg/cyk_parser.dart';
 import 'package:jflutter/core/models/grammar.dart';

--- a/test/unit/core/pda/pda_simulator_test.dart
+++ b/test/unit/core/pda/pda_simulator_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/pda/pda_simulator_test.dart
-// Objetivo: Avaliar o simulador interno de autômatos de pilha com variações de
-// critérios de aceitação e manipulação de pilha em diferentes linguagens.
-// Cenários cobertos:
-// - Aceitação por estado final e por pilha vazia com símbolos iniciais.
-// - Balanceamento de parênteses e controle de contagem através de push/pop.
-// - Rejeições em entradas inválidas e caminhos não determinísticos.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: simulador de autômatos de pilha do núcleo.
+/// Resumo: Exercita aceitação por estado final ou pilha vazia, balanceamento e
+/// rejeições de entradas inválidas em execuções potencialmente não determinísticas.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/pda_simulator.dart';

--- a/test/unit/core/regex/regex_pipeline_test.dart
+++ b/test/unit/core/regex/regex_pipeline_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/regex/regex_pipeline_test.dart
-// Objetivo: Validar o pipeline Regex→AST→AFN (Thompson) assegurando geração e
-// simulação coerentes com operações do automato.
-// Cenários cobertos:
-// - Construção de AFNs para literais, concatenação, união e estrela de Kleene.
-// - Agrupamentos, operadores opcionais e precedência correta na árvore sintática.
-// - Rejeição de expressões inválidas e propagação de erros do parser.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: pipeline regex → AST → AFN pelo algoritmo de Thompson.
+/// Resumo: Exercita a construção e simulação de AFNs para operadores clássicos,
+/// garantindo precedência correta e tratamento de entradas inválidas.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/algorithm_operations.dart';

--- a/test/unit/core/result_test.dart
+++ b/test/unit/core/result_test.dart
@@ -1,12 +1,8 @@
-//
-//  result_test.dart
-//  JFlutter
-//
-//  Testes unitários que asseguram o comportamento das extensões da classe Result ao propagar sucessos e falhas.
-//  Valida especialmente o método mapOrElse preservando mensagens de erro e tipos em cenários de falha.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: extensões da classe Result para mapear sucessos e falhas.
+/// Resumo: Garante que `mapOrElse` preserve mensagens de erro e tipos ao
+/// propagar falhas, além de mapear valores com segurança.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/result.dart';
 

--- a/test/unit/core/tm/tm_simulator_test.dart
+++ b/test/unit/core/tm/tm_simulator_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/tm/tm_simulator_test.dart
-// Objetivo: Exercitar o simulador interno de máquinas de Turing com cenários
-// determinísticos e não determinísticos, incluindo múltiplas fitas.
-// Cenários cobertos:
-// - Máquinas determinísticas que expandem cadeias unárias e reconhecem padrões.
-// - Construções não determinísticas com ramos concorrentes e rejeição.
-// - Operações multi-fita com movimentação independente e sincronização.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: simulador de máquinas de Turing para cenários determinísticos e NDT.
+/// Resumo: Avalia execução de MTs com múltiplas fitas, expansão de cadeias e
+/// ramos concorrentes garantindo rejeições corretas quando apropriado.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/tm_simulator.dart';

--- a/test/unit/cyk_validation_test.dart
+++ b/test/unit/cyk_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  cyk_validation_test.dart
-//  JFlutter
-//
-//  Conjunto de testes que garante a fidelidade do algoritmo CYK ao analisar gramáticas convertidas para forma normal de Chomsky em cadeias de diversos comprimentos.
-//  Os cenários cobrem construções de tabela, tratamentos de produções especiais, rejeições esperadas e comportamentos extremos para manter a consistência do analisador.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: algoritmo CYK analisando gramáticas em forma normal de Chomsky.
+/// Resumo: Exercita construção de tabela, produções especiais e rejeições
+/// esperadas com cadeias variadas para assegurar a consistência do parser.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';

--- a/test/unit/data/examples_asset_data_source_test.dart
+++ b/test/unit/data/examples_asset_data_source_test.dart
@@ -1,16 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/examples_asset_data_source_test.dart
-// Objetivo: Garantir a integridade das fixtures JSON de "Examples v1" ao
-// validar metadados, estruturas e round-trips necessários para o consumo no
-// aplicativo.
-// Cenários cobertos:
-// - Carregamento de arquivos de exemplo e validação do formato JSON esperado.
-// - Garantia de metadados obrigatórios para categorias, dificuldade e tags.
-// - Verificação de consistência entre metadados declarados e conteúdo serializado.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: fonte de dados de exemplos carregados via assets JSON.
+/// Resumo: Inspeciona fixtures da biblioteca para validar formato, metadados
+/// obrigatórios e consistência entre descrição e conteúdo serializado.
+/// ---------------------------------------------------------------------------
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/data/import_export_validation_test.dart
+++ b/test/unit/data/import_export_validation_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/import_export_validation_test.dart
-// Objetivo: Validar os fluxos de importação e exportação garantindo round-trip
-// consistente entre o modelo interno de AFD e os formatos JFLAP/JSON/SVG.
-// Cenários cobertos:
-// - Reconstrução fiel de autômatos após serialização JFLAP.
-// - Conversão JSON preservando estados, transições e alfabetos.
-// - Exportação SVG com feedback de sucesso e métricas de estrutura.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: serviços de importação e exportação para autômatos determinísticos.
+/// Resumo: Confere roundtrip entre modelo interno e formatos JFLAP/JSON/SVG,
+/// garantindo preservação de estrutura e relatórios de sucesso.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/test/unit/data/services/examples_library_stats_test.dart
+++ b/test/unit/data/services/examples_library_stats_test.dart
@@ -1,14 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/services/examples_library_stats_test.dart
-// Objetivo: Verificar a formatação segura de `ExamplesLibraryStats` garantindo
-// descrições coerentes mesmo com coleções vazias ou parciais.
-// Cenários cobertos:
-// - Representação textual de estatísticas vazias sem lançar exceções.
-// - Agregação de totais e rótulos quando apenas parte dos mapas está preenchida.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: formatação textual de `ExamplesLibraryStats`.
+/// Resumo: Confere geração de descrições consistentes para estatísticas vazias
+/// ou parciais, garantindo ausência de exceções e agregação correta de totais.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';

--- a/test/unit/data/services/import_export_validation_test.dart
+++ b/test/unit/data/services/import_export_validation_test.dart
@@ -1,16 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/services/import_export_validation_test.dart
-// Objetivo: Assegurar que o serviço de validação de importação/exportação
-// identifique inconsistências estruturais e rejeite autômatos inválidos antes
-// da serialização.
-// Cenários cobertos:
-// - Construção de autômato válido com estados e transições consistentes.
-// - Detecção de laços, símbolos ausentes e estados inválidos durante a validação.
-// - Consolidação de relatórios de erro para múltiplas violações.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: serviço de validação para importação e exportação de autômatos.
+/// Resumo: Confirma aprovação de modelos consistentes e rejeita estruturas com
+/// loops, símbolos faltantes ou estados inválidos antes da serialização.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/unit/data/settings_repository_impl_test.dart
+++ b/test/unit/data/settings_repository_impl_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/settings_repository_impl_test.dart
-// Objetivo: Confirmar que o repositório de configurações elimina chaves
-// legadas relacionadas ao canvas Draw2D ao carregar ou salvar preferências.
-// Cenários cobertos:
-// - Limpeza da flag `settings_use_draw2d_canvas` durante o carregamento das
-//   configurações.
-// - Remoção do mesmo sinalizador ao persistir novas preferências.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: limpeza de chaves legadas no repositório de configurações.
+/// Resumo: Garante que `settings_use_draw2d_canvas` seja removida ao carregar
+/// ou salvar preferências, mantendo o modelo livre de flags obsoletas.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/settings_model.dart';

--- a/test/unit/dfa_minimization_validation_test.dart
+++ b/test/unit/dfa_minimization_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  dfa_minimization_validation_test.dart
-//  JFlutter
-//
-//  Testes que verificam o algoritmo de minimização de DFAs assegurando redução correta de estados sem alterar a linguagem reconhecida.
-//  Englobam autômatos básicos, estruturas redundantes, casos já minimizados e máquinas sem estados de aceitação para checar diagnósticos.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: minimização de autômatos determinísticos.
+/// Resumo: Exercita DFAs com redundâncias, casos já reduzidos e máquinas sem
+/// aceitação para confirmar preservação de linguagem e diagnósticos.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/dfa_validation_test.dart
+++ b/test/unit/dfa_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  dfa_validation_test.dart
-//  JFlutter
-//
-//  Bateria que compara o simulador de DFAs e o minimizador do JFlutter com autômatos de referência para assegurar aceitação, rejeição e estabilidade da linguagem.
-//  Inclui verificações da cadeia vazia, de ciclos e da equivalência entre a máquina original e sua versão minimizada.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: simulador e minimizador de DFAs com casos canônicos.
+/// Resumo: Compara aceitação/rejeição e equivalência entre DFAs originais e
+/// minimizados, cobrindo cadeia vazia, ciclos e estabilidade da linguagem.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/equivalence_validation_test.dart
+++ b/test/unit/equivalence_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  equivalence_validation_test.dart
-//  JFlutter
-//
-//  Conjunto de testes que valida o EquivalenceChecker para DFAs e NFAs, cobrindo cenários equivalentes, não equivalentes e comparações cruzadas entre autômatos construídos de maneiras distintas.
-//  O arquivo monta máquinas de exemplo para assegurar diagnósticos coerentes e resultados consistentes mesmo em casos extremos e entradas malformadas.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: verificador de equivalência entre DFAs e NFAs.
+/// Resumo: Compara autômatos montados de formas distintas para confirmar
+/// diagnósticos em cenários equivalentes, divergentes e com entradas inválidas.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/glc_validation_test.dart
+++ b/test/unit/glc_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  glc_validation_test.dart
-//  JFlutter
-//
-//  Coleção de testes que examina o parser de gramáticas livres de contexto e utilitários associados para validar derivação, normalização e análise.
-//  Os cenários detectam recursões, ambiguidades, conversões para CNF e confrontam exemplos importados de bibliotecas de apoio.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: parser e utilitários de gramáticas livres de contexto.
+/// Resumo: Avalia detecção de recursões, ambiguidades e normalizações para CNF
+/// utilizando exemplos referenciais para validar derivação e análise.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';

--- a/test/unit/grammar_to_pda_validation_test.dart
+++ b/test/unit/grammar_to_pda_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  grammar_to_pda_validation_test.dart
-//  JFlutter
-//
-//  Suite que garante a fidelidade da conversão de gramáticas livres de contexto em autômatos de pilha mantendo equivalência de linguagem.
-//  Cobre gramáticas simples, produções lambda e estruturas complexas validando o PDA resultante por simulação.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: conversão de gramáticas livres de contexto em PDAs equivalentes.
+/// Resumo: Valida gramáticas simples, com lambda e complexas, simulando o
+/// autômato resultante para assegurar manutenção da linguagem reconhecida.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/grammar.dart';
 import 'package:jflutter/core/models/production.dart';

--- a/test/unit/nfa_to_dfa_validation_test.dart
+++ b/test/unit/nfa_to_dfa_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  nfa_to_dfa_validation_test.dart
-//  JFlutter
-//
-//  Testes focados na conversão de AFNs para DFAs garantindo que a linguagem e os diagnósticos permaneçam equivalentes após o processo.
-//  Abrange exemplos com transições lambda e epsilon, construções complexas e validação dos autômatos resultantes por simulação.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: conversão de autômatos não determinísticos para determinísticos.
+/// Resumo: Avalia AFNs com transições λ/ε e estruturas complexas, validando que
+/// o DFA resultante preserva a linguagem original em simulação.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/nfa_validation_test.dart
+++ b/test/unit/nfa_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  nfa_validation_test.dart
-//  JFlutter
-//
-//  Casos de teste que avaliam o simulador de AFNs e a conversão para DFAs garantindo alinhamento com os exemplos clássicos usados como referência.
-//  Os experimentos exploram caminhos não determinísticos, fechos epsilon, símbolos fora do alfabeto e verificações de aceitação versus rejeição.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: simulação de AFNs e checagens com conversão para DFAs.
+/// Resumo: Explora não determinismo, fechos ε, entradas inválidas e confirma
+/// aceitação ou rejeição alinhadas com exemplos canônicos.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/pda_validation_test.dart
+++ b/test/unit/pda_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  pda_validation_test.dart
-//  JFlutter
-//
-//  Conjunto de testes que confirma o comportamento do simulador de autômatos de pilha e da conversão de gramáticas livres de contexto para PDAs.
-//  Inclui cenários determinísticos e não determinísticos com manipulação de pilha, transições lambda e validação de linguagem contra a referência.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: simulador de PDAs e conversão de gramáticas para autômatos com pilha.
+/// Resumo: Exercita cenários determinísticos e NDT com transições λ e operações
+/// de pilha, comparando resultados com a referência de linguagem.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/pda.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/presentation/pumping_lemma_game_test.dart
+++ b/test/unit/presentation/pumping_lemma_game_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/presentation/pumping_lemma_game_test.dart
-// Objetivo: Validar o fluxo do modo jogo do lema do bombeamento, garantindo
-// progressão linear e registro de pontuação.
-// Cenários cobertos:
-// - Estado inicial sem desafios e contadores zerados.
-// - Registro de respostas corretas/incorretas com atualização de métricas.
-// - Reinício de jogo e descarte de recursos do provider.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: fluxo do modo jogo do lema do bombeamento.
+/// Resumo: Garante inicialização limpa, registro de respostas e reinício de
+/// partida mantendo métricas e descarte dos recursos do provider.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/unit/presentation/transition_label_updates_test.dart
+++ b/test/unit/presentation/transition_label_updates_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/presentation/transition_label_updates_test.dart
-// Objetivo: Garantir que provedores de edição atualizem rótulos de transições
-// de forma consistente entre autômatos finitos, PDAs e MTs.
-// Cenários cobertos:
-// - Atualização de rótulo e conjunto de símbolos em autômatos finitos.
-// - Sincronização de campos de pilha em transições de PDA.
-// - Ajustes de leitura, escrita e direção em transições de MT.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: atualização de rótulos de transições em editores de automatos.
+/// Resumo: Verifica sincronização dos providers ao alterar símbolos de FAs,
+/// pilha de PDAs e campos de leitura/escrita/direção em máquinas de Turing.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/unit/pumping_lemma_validation_test.dart
+++ b/test/unit/pumping_lemma_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  pumping_lemma_validation_test.dart
-//  JFlutter
-//
-//  Grupo de testes dedicado ao provador do lema do bombeamento avaliando demonstrações para linguagens regulares e diagnósticos para linguagens não regulares.
-//  As validações analisam decomposições bombeáveis, limites mínimos calculados e respostas para cenários de sucesso e falha.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: provador do lema do bombeamento para linguagens regulares.
+/// Resumo: Analisa decomposições bombeáveis, limites mínimos e diagnósticos
+/// gerados ao diferenciar linguagens regulares de não regulares.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/regex_validation_test.dart
+++ b/test/unit/regex_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  regex_validation_test.dart
-//  JFlutter
-//
-//  Suite que verifica as conversões entre expressões regulares e autômatos finitos cobrindo ida e volta no pipeline de linguagem formal.
-//  Os casos exercitam operadores avançados, simulam os autômatos gerados e confirmam consistência com a implementação de referência.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: roundtrip entre expressões regulares e autômatos finitos.
+/// Resumo: Exercita conversões regex→AFN→AFD e retorno para regex, simulando os
+/// autômatos gerados para garantir equivalência com a referência.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/fsa.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/unit/tm_validation_test.dart
+++ b/test/unit/tm_validation_test.dart
@@ -1,12 +1,8 @@
-//
-//  tm_validation_test.dart
-//  JFlutter
-//
-//  Bateria de testes que confronta o simulador de máquinas de Turing com casos reais de aceitação, rejeição e detecção de laços infinitos para validar respostas.
-//  As rotinas montam máquinas variadas, verificam transformações de fita e confirmam limites operacionais alinhados com a implementação de referência.
-//
-//  Thales Matheus Mendonça Santos - October 2025
-//
+/// ---------------------------------------------------------------------------
+/// Teste: simulador de máquinas de Turing com cenários diversos.
+/// Resumo: Confronta casos de aceitação, rejeição e laços infinitos verificando
+/// transformações de fita e limites alinhados à implementação de referência.
+/// ---------------------------------------------------------------------------
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/tm.dart';
 import 'package:jflutter/core/models/state.dart';

--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/automaton_graphview_canvas_test.dart
-// Objetivo: Certificar que o canvas GraphView de autômatos integra-se com os
-// provedores e serviços de layout simulados.
-// Cenários cobertos:
-// - Renderização de estados/transições e interação com ferramentas do canvas.
-// - Rotulagem inline e disparo de callbacks do controlador.
-// - Tratamento de layouts não suportados por repositório fake.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: canvas GraphView genérico para autômatos finitos.
+/// Resumo: Confere integração com providers e serviços de layout fake,
+/// exercitando renderização, rotulagem inline e tratamento de layouts inválidos.
+/// ---------------------------------------------------------------------------
 
 import 'dart:math' as math;
 

--- a/test/widget/presentation/graphview_canvas_toolbar_test.dart
+++ b/test/widget/presentation/graphview_canvas_toolbar_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/graphview_canvas_toolbar_test.dart
-// Objetivo: Verificar o toolbar do canvas GraphView garantindo que ações de
-// zoom, ajuste e undo/redo disparem o controlador.
-// Cenários cobertos:
-// - Execução de zoom in/out, fit e reset view.
-// - Ações de desfazer/refazer invocando o controlador especializado.
-// - Exposição de ferramentas adicionais (adicionar estado/transição).
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: toolbar do canvas GraphView e integração com controlador.
+/// Resumo: Exercita botões de zoom, ajuste e undo/redo, além de ferramentas de
+/// edição, confirmando o disparo das ações no controlador associado.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/graphview_label_field_editor_test.dart
+++ b/test/widget/presentation/graphview_label_field_editor_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/graphview_label_field_editor_test.dart
-// Objetivo: Validar interações do editor inline de rótulos do GraphView,
-// assegurando submissão e cancelamento corretos.
-// Cenários cobertos:
-// - Envio do novo valor ao pressionar Enter.
-// - Cancelamento via tecla Escape mantendo o valor original.
-// - Invocação de callbacks de confirmação e cancelamento.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: editor inline de rótulos no GraphView.
+/// Resumo: Verifica submissão com Enter, cancelamento com Escape e disparo de
+/// callbacks garantindo preservação do valor original quando descartado.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/test/widget/presentation/mobile_automaton_controls_test.dart
+++ b/test/widget/presentation/mobile_automaton_controls_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/mobile_automaton_controls_test.dart
-// Objetivo: Garantir que os controles móveis do canvas exponham ações e
-// callbacks de simulação, algoritmos e edição.
-// Cenários cobertos:
-// - Renderização de botões de ações principais.
-// - Disparo dos callbacks associados a cada ação.
-// - Exibição de mensagens de status na interface.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: controles móveis do canvas de autômatos.
+/// Resumo: Confere exibição de botões principais, disparo de callbacks de
+/// simulação/algoritmos/edição e mensagens de status ao usuário.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/pda_canvas_graphview_test.dart
+++ b/test/widget/presentation/pda_canvas_graphview_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/pda_canvas_graphview_test.dart
-// Objetivo: Validar a renderização do canvas de PDA com GraphView garantindo
-// sincronização entre provider e controlador.
-// Cenários cobertos:
-// - Desenho de estados e transições enviados pelo controlador.
-// - Reatividade do provider ao modificar o autômato de pilha.
-// - Liberação de recursos do controlador ao término do teste.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: widget de canvas GraphView para autômatos com pilha.
+/// Resumo: Valida renderização de estados/transições fornecidos pelo
+/// controlador, reatividade a mudanças do provider e descarte de recursos.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/tm_canvas_graphview_test.dart
+++ b/test/widget/presentation/tm_canvas_graphview_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/tm_canvas_graphview_test.dart
-// Objetivo: Validar a renderização do canvas de MT com GraphView, assegurando
-// integração com o provider e controle de transições.
-// Cenários cobertos:
-// - Exibição de estados e transições provenientes do controlador.
-// - Reatividade a modificações do editor de MT.
-// - Descarte correto do controlador após o teste.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: widget de canvas GraphView para máquinas de Turing.
+/// Resumo: Garante renderização dos estados e transições, reação a mudanças do
+/// editor e descarte apropriado do controlador durante o ciclo de vida.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/ux_error_handling_test.dart
+++ b/test/widget/presentation/ux_error_handling_test.dart
@@ -1,15 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/ux_error_handling_test.dart
-// Objetivo: Garantir a experiência de usuário ao lidar com erros de importação,
-// cobrindo banner inline, diálogo e ações de retry.
-// Cenários cobertos:
-// - Exibição do banner de erro e mensagem detalhada.
-// - Interação com diálogo de erro e botões auxiliares.
-// - Funcionamento do botão de tentar novamente e estado do provider.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: UX para tratamento de erros de importação.
+/// Resumo: Avalia apresentação do banner, diálogo e ação de tentar novamente
+/// garantindo mensagens detalhadas e integração com o estado do provider.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/visualizations_test.dart
+++ b/test/widget/presentation/visualizations_test.dart
@@ -1,13 +1,8 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/visualizations_test.dart
-// Objetivo: Reservar infraestrutura para testes de visualizações e goldens,
-// indicando trabalho pendente na fase 3.2.
-// Cenários cobertos:
-// - Registro de teste pendente sinalizando necessidade de configuração.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+/// ---------------------------------------------------------------------------
+/// Teste: placeholder para visualizações e goldens em fase futura.
+/// Resumo: Mantém teste sinalizando pendência de configuração para capturas e
+/// renderizações de visualizações na fase 3.2.
+/// ---------------------------------------------------------------------------
 
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Summary
- replace the legacy ascii-art headers in test suites with the standardized doc comment block that includes Portuguese summaries
- ensure each updated test file starts with the new block describing the exercised scenarios

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53908949c832ea9a2b62e382216bd