### PR TITLE
Add documentation headers to core services and utilities

### DIFF
--- a/lib/core/algo_log.dart
+++ b/lib/core/algo_log.dart
@@ -1,3 +1,15 @@
+//
+//  algo_log.dart
+//  JFlutter
+//
+//  Mantém um registro centralizado das mensagens produzidas durante a execução
+//  de algoritmos, expondo coleções reativas para linhas de log e destaques de
+//  estados. Permite adicionar lotes de eventos, limpar o histórico e controlar
+//  os identificadores destacados, servindo como fonte única para widgets que
+//  acompanham o passo a passo das simulações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 
 /// Centralized logging for algorithm execution steps

--- a/lib/core/entities/grammar_entity.dart
+++ b/lib/core/entities/grammar_entity.dart
@@ -1,3 +1,15 @@
+//
+//  grammar_entity.dart
+//  JFlutter
+//
+//  Define as estruturas imutáveis que representam gramáticas formais dentro do
+//  núcleo, incluindo identificadores, conjuntos de terminais e não terminais,
+//  símbolo inicial e produções completas. Estabelece também o modelo de cada
+//  produção, permitindo que algoritmos de análise, transformação e conversão
+//  manipulem dados consistentes em toda a plataforma.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 class GrammarEntity {
   final String id;
   final String name;

--- a/lib/core/error_handler.dart
+++ b/lib/core/error_handler.dart
@@ -1,3 +1,15 @@
+//
+//  error_handler.dart
+//  JFlutter
+//
+//  Concentra utilitários de feedback visual para erros, avisos, sucessos e
+//  confirmações na interface Flutter, garantindo mensagens consistentes em toda
+//  a aplicação. Expõe uma chave global para o ScaffoldMessenger e integra-se ao
+//  tipo Result para apresentar respostas adequadas às operações. Também oferece
+//  diálogos modais e registro simplificado de falhas para apoiar a depuração.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'result.dart';

--- a/lib/core/parsers/jflap_xml_parser.dart
+++ b/lib/core/parsers/jflap_xml_parser.dart
@@ -1,3 +1,16 @@
+//
+//  jflap_xml_parser.dart
+//  JFlutter
+//
+//  Responsável por interpretar arquivos JFLAP no formato XML, verificando
+//  estrutura e tipo do autômato antes de construir entidades compatíveis com o
+//  núcleo da aplicação. Implementa leitura detalhada de estados, transições e
+//  alfabeto de autômatos finitos, convertendo-os em objetos de domínio e
+//  reportando falhas claras quando encontrar entradas inválidas ou recursos não
+//  suportados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:xml/xml.dart';
 import '../entities/automaton_entity.dart';
 import '../result.dart';

--- a/lib/core/result.dart
+++ b/lib/core/result.dart
@@ -1,3 +1,16 @@
+//
+//  result.dart
+//  JFlutter
+//
+//  Padroniza os retornos das camadas de domínio com um tipo selado que
+//  diferencia sucesso e falha, expondo acesso direto aos dados ou às mensagens
+//  de erro sem depender de exceções. Disponibiliza operações de mapeamento e
+//  encadeamento para tratar fluxos de processamento de forma funcional e
+//  extensões utilitárias para criar instâncias específicas de autômatos e
+//  gramáticas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'entities/automaton_entity.dart';
 import 'entities/grammar_entity.dart';
 

--- a/lib/core/services/diagnostic_service.dart
+++ b/lib/core/services/diagnostic_service.dart
@@ -1,3 +1,16 @@
+//
+//  diagnostic_service.dart
+//  JFlutter
+//
+//  Oferece uma análise aprofundada de autômatos finitos, classificando problemas
+//  estruturais, semânticos, de desempenho e usabilidade em listas de issues,
+//  avisos e sugestões acionáveis. Implementa rotinas auxiliares para detectar
+//  estados inacessíveis, transições inválidas, comportamentos não
+//  determinísticos e gargalos potenciais, atribuindo severidade consolidada às
+//  descobertas para orientar correções prioritárias.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/state.dart' as automaton_state;
 import '../models/fsa_transition.dart';

--- a/lib/core/services/diagnostics_service.dart
+++ b/lib/core/services/diagnostics_service.dart
@@ -1,3 +1,16 @@
+//
+//  diagnostics_service.dart
+//  JFlutter
+//
+//  Reúne verificações inteligentes para autômatos finitos, analisando estados,
+//  transições e componentes desconectados para produzir mensagens de erro,
+//  aviso e informação contextualizadas. Fornece diagnósticos para falhas de
+//  simulação, sugerindo correções práticas e identificando símbolos inválidos ou
+//  comportamentos não determinísticos. Também normaliza coleções para facilitar
+//  comparações consistentes entre estruturas equivalentes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/fsa_transition.dart';
 import '../models/state.dart' as automaton_state;

--- a/lib/core/services/simulation_highlight_service.dart
+++ b/lib/core/services/simulation_highlight_service.dart
@@ -1,3 +1,16 @@
+//
+//  simulation_highlight_service.dart
+//  JFlutter
+//
+//  Coordena o cálculo e a difusão de destaques visuais para simulações,
+//  convertendo resultados e passos em conjuntos imutáveis de estados e
+//  transições relevantes. Disponibiliza provedores Riverpod, canais de
+//  comunicação e adaptadores para callbacks legados, além de registrar eventos
+//  durante o despacho. Permite limpar, acompanhar e reaproveitar o último
+//  destaque emitido pela interface interativa.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/core/services/trace_persistence_service.dart
+++ b/lib/core/services/trace_persistence_service.dart
@@ -1,3 +1,16 @@
+//
+//  trace_persistence_service.dart
+//  JFlutter
+//
+//  Administra o salvamento, carregamento e exportação de rastros de simulação,
+//  combinando SharedPreferences e arquivos locais para preservar histórico entre
+//  sessões. Controla limites de armazenamento, gera identificadores exclusivos
+//  para cada execução e oferece utilitários para buscar, excluir e limpar
+//  registros. Define ainda modelos auxiliares e exceções que padronizam erros de
+//  persistência expostos à interface.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';

--- a/lib/core/validators/input_validators.dart
+++ b/lib/core/validators/input_validators.dart
@@ -1,3 +1,16 @@
+//
+//  input_validators.dart
+//  JFlutter
+//
+//  Centraliza verificações estáticas para autômatos finitos, de pilha, máquinas
+//  de Turing e gramáticas, garantindo que estruturas carregadas respeitem
+//  restrições básicas antes de serem simuladas ou convertidas. Inspeciona
+//  alfabetos, estados, transições e símbolos iniciais, reportando códigos de
+//  problema descritivos para cada inconsistência encontrada. Serve como camada
+//  de defesa que orienta correções na modelagem dos objetos acadêmicos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/fsa_transition.dart';
 import '../models/pda.dart';


### PR DESCRIPTION
## Summary
- add the standardized project header to core result, logging, and error handling utilities
- document parser, diagnostics, and highlight services with Portuguese summaries that follow the agreed format
- describe grammar entities, persistence, and validation modules in the new header comments

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e53d5370ec832e8d58f90f04a04072