### PR TITLE
Atualizar cabeçalhos padronizados em testes GraphView e IO

### DIFF
--- a/test/core/services/simulation_highlight_service_test.dart
+++ b/test/core/services/simulation_highlight_service_test.dart
@@ -1,14 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/core/services/simulation_highlight_service_test.dart
-// Objetivo: Verificar a comunicação do serviço de destaque de simulação com o
-// controlador GraphView.
-// Cenários cobertos:
-// - Emissão de destaques durante a simulação passo a passo.
-// - Limpeza de destaques ao encerrar ou reiniciar.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  simulation_highlight_service_test.dart
+//  JFlutter
+//
+//  Exercita o serviço responsável por enviar destaques de simulação ao canal do
+//  GraphView, garantindo que eventos sejam propagados, limpos e sincronizados
+//  com o controlador em cenários de execução passo a passo e reinicialização.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';

--- a/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_automaton_mapper_test.dart
-// Objetivo: Validar o mapeamento de autômatos para modelos GraphView usados no
-// canvas.
-// Cenários cobertos:
-// - Conversão de estados e transições em nós e arestas com posição.
-// - Tratamento de loops, transições múltiplas e estados iniciais/aceitadores.
-// - Atualização de dados ao sincronizar com GraphViewAutomatonMapper.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_automaton_mapper_test.dart
+//  JFlutter
+//
+//  Confere o GraphViewAutomatonMapper na tradução de autômatos finitos para nós e arestas, cobrindo
+//  casos com loops, transições múltiplas e estados especiais. Verifica se os cálculos de geometria
+//  e agrupamento resultam em modelos consistentes para o canvas interativo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_canvas_controller_test.dart
-// Objetivo: Verificar o controlador base GraphView de autômatos garantindo
-// interação com o provider e repositório de layout fake.
-// Cenários cobertos:
-// - Aplicação de layouts (auto, balanced, compact, hierarchical, spread).
-// - Manipulação de zoom, seleção e atualizações de transição.
-// - Uso de serviço de autômato para sincronização com o estado interno.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_canvas_controller_test.dart
+//  JFlutter
+//
+//  Testa o controlador base do canvas GraphView para autômatos, coordenando providers, repositórios
+//  de layout e atualizações de seleção. Inspeciona comandos de layout, zoom e sincronização de
+//  transições para garantir que o estado visual reflita o modelo lógico.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_canvas_models_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_models_test.dart
@@ -1,13 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_canvas_models_test.dart
-// Objetivo: Avaliar modelos de canvas usados pelo GraphView garantindo
-// imutabilidade e helpers consistentes.
-// Cenários cobertos:
-// - Atualização de metadados de arestas via `copyWith`.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_canvas_models_test.dart
+//  JFlutter
+//
+//  Verifica os modelos de dados utilizados pelo canvas GraphView, confirmando a imutabilidade e a
+//  correta propagação de metadados de transições. Exercita métodos utilitários como copyWith para
+//  garantir que updates mantenham integridade do grafo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
-// Objetivo: Validar o controlador GraphView específico de PDA, assegurando
-// sincronização com o provider e manipulação da pilha.
-// Cenários cobertos:
-// - Construção de grafos a partir de PDAs com transições de push/pop.
-// - Seleção e atualização de transições refletidas no editor.
-// - Descarte adequado do controlador após o uso.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_pda_canvas_controller_test.dart
+//  JFlutter
+//
+//  Avalia o GraphViewPdaCanvasController na mediação entre o editor de PDA e o canvas, garantindo
+//  sincronia das transições com a pilha. Exercita construção do grafo, seleção de elementos e
+//  descarte seguro dos recursos associados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_pda_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_mapper_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_pda_mapper_test.dart
-// Objetivo: Garantir que PDAs sejam convertidos corretamente para modelos de
-// canvas GraphView.
-// Cenários cobertos:
-// - Tradução de push/pop e símbolos λ em metadados visuais.
-// - Mapeamento de estados iniciais/aceitadores e transições múltiplas.
-// - Atualização do grafo ao sincronizar com GraphViewPdaMapper.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_pda_mapper_test.dart
+//  JFlutter
+//
+//  Valida o GraphViewPdaMapper ao converter autômatos de pilha em estruturas de grafo, assegurando
+//  que estados, transições e metadados de pilha sejam preservados. Exercita cenários com múltiplos
+//  símbolos e ajustes geométricos para garantir compatibilidade com a renderização do canvas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
-// Objetivo: Garantir que o controlador GraphView para MT sincronize estados,
-// transições e seleção com o provider.
-// Cenários cobertos:
-// - Construção de grafo a partir de máquinas de Turing e atualizações em tempo real.
-// - Seleção de transições e estados, emitindo eventos correspondentes.
-// - Descarte seguro de recursos após uso.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_tm_canvas_controller_test.dart
+//  JFlutter
+//
+//  Verifica o GraphViewTmCanvasController na orquestração do editor de máquinas de Turing,
+//  garantindo que o grafo responda a interações e eventos emitidos pelo provider. Analisa seleção
+//  de estados, atualização de transições e ciclo de vida do controlador.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_tm_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_mapper_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_tm_mapper_test.dart
-// Objetivo: Validar mapeamento de máquinas de Turing para estruturas GraphView
-// utilizadas no canvas.
-// Cenários cobertos:
-// - Conversão de estados, transições e direções de fita em modelos visuais.
-// - Suporte a múltiplas fitas e símbolos de leitura/escrita.
-// - Ajuste de nós e controle de curvas em representações gráficas.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_tm_mapper_test.dart
+//  JFlutter
+//
+//  Avalia o GraphViewTmMapper na geração de grafos de máquinas de Turing, incluindo estados,
+//  transições e direções de fita. Simula múltiplas fitas e anotações para assegurar que os dados
+//  renderizados representem fielmente as operações do simulador.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/integration/io/examples_roundtrip_test.dart
+++ b/test/integration/io/examples_roundtrip_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/examples_roundtrip_test.dart
-// Objetivo: Exercitar round-trips de exemplos canônicos passando por assets,
-// serviços de serialização e exportação.
-// Cenários cobertos:
-// - Conversão de autômatos, gramáticas e MTs entre entidades e arquivos.
-// - Exportação SVG e validação de estruturas serializadas.
-// - Verificação de consistência dos metadados da biblioteca Examples.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  examples_roundtrip_test.dart
+//  JFlutter
+//
+//  Realiza testes de integração de round-trip para os exemplos embarcados, percorrendo leitura de
+//  assets, serviços de serialização e exportação gráfica. Valida autômatos, gramáticas e máquinas
+//  de Turing para garantir consistência entre entidades e artefatos gerados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/integration/io/interoperability_roundtrip_test.dart
+++ b/test/integration/io/interoperability_roundtrip_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/interoperability_roundtrip_test.dart
-// Objetivo: Validar interoperabilidade entre formatos `.jff`, JSON e SVG,
-// garantindo round-trip sem perda.
-// Cenários cobertos:
-// - Conversões JFLAP↔modelos internos usando parser XML dedicado.
-// - Serialização JSON de autômatos, gramáticas e MTs.
-// - Exportação SVG para visualização preservando elementos-chave.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  interoperability_roundtrip_test.dart
+//  JFlutter
+//
+//  Examina a interoperabilidade entre formatos JFLAP, JSON e SVG garantindo round-trips sem perdas
+//  estruturais. Verifica conversões, serializações e exportações para assegurar compatibilidade
+//  entre o editor e ferramentas externas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';


### PR DESCRIPTION
## Summary
- aplicar o novo cabeçalho padronizado no teste de destaques de simulação
- alinhar os cabeçalhos dos testes GraphView com o resumo detalhado e autoria exigidos
- atualizar os cabeçalhos dos testes de integração de round-trip para descrever os fluxos cobertos

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53d781e9c832e950130e457384bb3