### PR TITLE
chore: padronizar cabecalhos dart

### DIFF
--- a/lib/core/algo_log.dart
+++ b/lib/core/algo_log.dart
@@ -1,3 +1,14 @@
+//
+//  algo_log.dart
+//  JFlutter
+//
+//  Mantém utilitários estáticos para registrar passos de execução de
+//  algoritmos, expondo ValueNotifiers que notificam interfaces sobre novas
+//  mensagens ou estados destacados. Fornece operações para adicionar linhas,
+//  limpar registros e acompanhar destaques durante simulações interativas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 
 /// Centralized logging for algorithm execution steps

--- a/lib/core/algorithms.dart
+++ b/lib/core/algorithms.dart
@@ -1,3 +1,14 @@
+//
+//  algorithms.dart
+//  JFlutter
+//
+//  Agrega exportações de algoritmos centrais do projeto, incluindo simuladores
+//  de autômatos e máquinas de Turing, conversores entre representações e
+//  ferramentas para gramáticas e lema do bombeamento. Facilita o consumo
+//  modular dessas rotinas pelas camadas de apresentação e casos de uso.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export all algorithm operations
 export 'algorithms/algorithm_operations.dart';
 export 'algorithms/automaton_simulator.dart';

--- a/lib/core/automaton.dart
+++ b/lib/core/automaton.dart
@@ -1,2 +1,13 @@
+//
+//  automaton.dart
+//  JFlutter
+//
+//  Expõe o modelo de autômato consolidado do núcleo para que camadas externas
+//  importem estruturas e utilitários de estados, transições e alfabetos a
+//  partir de um único arquivo, promovendo coesão entre representações da
+//  aplicação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export the automaton model
 export 'models/automaton.dart';

--- a/lib/core/dfa_algorithms.dart
+++ b/lib/core/dfa_algorithms.dart
@@ -1,3 +1,14 @@
+//
+//  dfa_algorithms.dart
+//  JFlutter
+//
+//  Organiza as exportações dos algoritmos especializados em autômatos
+//  determinísticos, incluindo simuladores, minimização e complementação, para
+//  que a camada de apresentação possa importar funcionalidades de análise de
+//  DFAs a partir de um único arquivo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export DFA-specific algorithms
 export 'algorithms/dfa_minimizer.dart';
 export 'algorithms/automaton_simulator.dart';

--- a/lib/core/equivalence_checking.dart
+++ b/lib/core/equivalence_checking.dart
@@ -1,2 +1,12 @@
+//
+//  equivalence_checking.dart
+//  JFlutter
+//
+//  Reúne as exportações das rotinas de verificação de equivalência entre
+//  autômatos, expondo o simulador compartilhado utilizado pelos fluxos de
+//  comparação e validação de linguagens dentro da aplicação principal.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export equivalence checking algorithms
 export 'algorithms/automaton_simulator.dart';

--- a/lib/core/error_handler.dart
+++ b/lib/core/error_handler.dart
@@ -1,3 +1,14 @@
+//
+//  error_handler.dart
+//  JFlutter
+//
+//  Reúne rotinas centralizadas de tratamento de erros e mensagens de feedback,
+//  expondo métodos estáticos para exibir SnackBars, diálogos de confirmação e
+//  registrar falhas no console. Atua como ponto único para padronizar a
+//  comunicação com o usuário e simplificar fluxos que consomem objetos Result.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'result.dart';

--- a/lib/core/grammar.dart
+++ b/lib/core/grammar.dart
@@ -1,3 +1,14 @@
+//
+//  grammar.dart
+//  JFlutter
+//
+//  Centraliza as exportações de modelos e algoritmos relacionados a gramáticas,
+//  permitindo que outras partes do aplicativo importem um único ponto para
+//  acessar entidades, analisadores, conversores para PDA e automatos
+//  associados às funcionalidades de teoria de linguagens formais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export grammar-related models and algorithms
 export 'models/grammar.dart';
 export 'algorithms/grammar_parser.dart';

--- a/lib/core/result.dart
+++ b/lib/core/result.dart
@@ -1,3 +1,15 @@
+//
+//  result.dart
+//  JFlutter
+//
+//  Define uma hierarquia selada Result usada em toda a aplicação para
+//  padronizar retornos de sucesso e falha, oferecendo utilitários para mapear
+//  dados, reagir a callbacks e trabalhar com coleções de resultados.
+//  Fornece extensões convenientes e fábricas nomeadas que simplificam a
+//  construção de respostas consistentes entre camadas de domínio e UI.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'entities/automaton_entity.dart';
 import 'entities/grammar_entity.dart';
 

--- a/lib/core/run.dart
+++ b/lib/core/run.dart
@@ -1,3 +1,14 @@
+//
+//  run.dart
+//  JFlutter
+//
+//  Agrupa exportações das rotinas de simulação utilizadas para executar
+//  autômatos finitos, pushdown automata e máquinas de Turing, permitindo que
+//  módulos consumidores acessem execuções e traços a partir de um único ponto
+//  de importação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export simulation and running algorithms
 export 'algorithms/automaton_simulator.dart';
 export 'algorithms/pda_simulator.dart';

--- a/lib/injection/dependency_injection.dart
+++ b/lib/injection/dependency_injection.dart
@@ -1,17 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/injection/dependency_injection.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Configura o contêiner GetIt registrando data sources, serviços,
-///             repositórios e providers necessários para o funcionamento da
-///             aplicação.
-/// Contexto: Centraliza a infraestrutura de injeção de dependências permitindo
-///           inicialização preguiçosa, reutilização de instâncias e fácil
-///           manutenção das ligações entre camadas.
-/// Observações: Prepara SharedPreferences para persistência de traços e
-///               registra implementações concretas mantendo o código preparado
-///               para testes e extensões futuras.
-/// ---------------------------------------------------------------------------
+//
+//  dependency_injection.dart
+//  JFlutter
+//
+//  Configura o contêiner de injeção de dependências com GetIt, registrando
+//  fontes de dados, serviços, repositórios e providers para manter o
+//  aplicativo desacoplado e com inicialização preguiçosa. Também prepara as
+//  instâncias de SharedPreferences utilizadas na persistência de traços para
+//  que camadas distintas compartilhem integrações consistentes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../core/repositories/automaton_repository.dart';


### PR DESCRIPTION
## Summary
- adiciona o cabeçalho padronizado ao registro de injeção de dependências
- documenta os módulos de reexportação do núcleo com o novo padrão de cabeçalho
- aplica o cabeçalho padronizado às utilidades de resultado, tratamento de erros e log de algoritmos

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e53d781e9c832e950130e457384bb3