### PR TITLE
Add standardized headers to core utilities

### DIFF
--- a/lib/core/algo_log.dart
+++ b/lib/core/algo_log.dart
@@ -1,3 +1,15 @@
+//
+//  algo_log.dart
+//  JFlutter
+//
+//  Centraliza logs de execução de algoritmos com notifiers reativos para linhas e
+//  destaques, permitindo adicionar entradas, limpar estado e sincronizar interfaces
+//  que acompanham o passo a passo das simulações.
+//  A classe também expõe instantâneos atuais para consumo direto de widgets e testes,
+//  facilitando painéis que respondem a mudanças em tempo real.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 
 /// Centralized logging for algorithm execution steps

--- a/lib/core/entities/grammar_entity.dart
+++ b/lib/core/entities/grammar_entity.dart
@@ -1,3 +1,14 @@
+//
+//  grammar_entity.dart
+//  JFlutter
+//
+//  Estruturas imutáveis que representam gramáticas formais com identificador,
+//  conjuntos terminais e não terminais, símbolo inicial e produções associadas.
+//  As produções encapsulam lados esquerdo e direito como listas ordenadas, facilitando
+//  a integração com conversões de autômatos e renderização de editores especializados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 class GrammarEntity {
   final String id;
   final String name;

--- a/lib/core/error_handler.dart
+++ b/lib/core/error_handler.dart
@@ -1,3 +1,14 @@
+//
+//  error_handler.dart
+//  JFlutter
+//
+//  Provedor central de tratamento de erros que apresenta mensagens nas interfaces via
+//  SnackBars, diálogos de confirmação e utilidades de log para depuração controlada.
+//  Inclui rotinas para traduzir Result em feedback contextual e uma extensão que
+//  simplifica o consumo direto desses fluxos dentro de widgets e fluxos assíncronos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'result.dart';

--- a/lib/core/parsers/jflap_xml_parser.dart
+++ b/lib/core/parsers/jflap_xml_parser.dart
@@ -1,3 +1,15 @@
+//
+//  jflap_xml_parser.dart
+//  JFlutter
+//
+//  Parser dedicado a arquivos JFLAP em XML que valida a estrutura, identifica o tipo
+//  de autômato e instancia entidades internas a partir de estados, transições e
+//  alfabetos extraídos do documento.
+//  Atualmente cobre autômatos finitos, convertendo dados em AutomatonEntity e
+//  retornando Result para sinalizar erros de leitura ou formatos não suportados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:xml/xml.dart';
 import '../entities/automaton_entity.dart';
 import '../result.dart';

--- a/lib/core/result.dart
+++ b/lib/core/result.dart
@@ -1,3 +1,15 @@
+//
+//  result.dart
+//  JFlutter
+//
+//  Define o tipo Result selado com variantes Success e Failure para padronizar fluxos de
+//  retorno e mensagens de erro na aplicação, expondo utilitários de mapeamento e
+//  callbacks para manipular sucessos ou falhas de forma composável.
+//  Também adiciona extensões, apelidos tipados e fábricas estáticas que simplificam
+//  coleções de resultados e conversões frequentes entre entidades e mensagens.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'entities/automaton_entity.dart';
 import 'entities/grammar_entity.dart';
 

--- a/lib/core/services/diagnostic_service.dart
+++ b/lib/core/services/diagnostic_service.dart
@@ -1,3 +1,14 @@
+//
+//  diagnostic_service.dart
+//  JFlutter
+//
+//  Implementa análise avançada de autômatos produzindo issues, avisos e sugestões em
+//  múltiplas dimensões estruturais, semânticas, de desempenho e usabilidade.
+//  Calcula severidade agregada, identifica padrões problemáticos e recomenda ações
+//  corretivas detalhadas através de modelos de resultado especializados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/state.dart' as automaton_state;
 import '../models/fsa_transition.dart';

--- a/lib/core/services/diagnostics_service.dart
+++ b/lib/core/services/diagnostics_service.dart
@@ -1,3 +1,15 @@
+//
+//  diagnostics_service.dart
+//  JFlutter
+//
+//  Serviço estático que avalia autômatos finitos e produz diagnósticos detalhados,
+//  cobrindo estados iniciais, alcançabilidade, transições, componentes e padrões de
+//  epsilon ou não determinismo.
+//  Também interpreta falhas de simulação para gerar mensagens específicas e sugestões
+//  acionáveis, promovendo orientações para correção dentro da interface.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/fsa_transition.dart';
 import '../models/state.dart' as automaton_state;

--- a/lib/core/services/simulation_highlight_service.dart
+++ b/lib/core/services/simulation_highlight_service.dart
@@ -1,3 +1,14 @@
+//
+//  simulation_highlight_service.dart
+//  JFlutter
+//
+//  Orquestra a emissão de destaques de simulação com suporte a canais plugáveis e
+//  dispatchers legados, oferecendo provedores Riverpod para integração com o canvas.
+//  Constrói conjuntos de estados e transições relevantes por passo, registra eventos
+//  em modo debug e disponibiliza utilidades para reemitir ou limpar seleções.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/core/services/trace_persistence_service.dart
+++ b/lib/core/services/trace_persistence_service.dart
@@ -1,3 +1,14 @@
+//
+//  trace_persistence_service.dart
+//  JFlutter
+//
+//  Gerencia persistência de rastros de simulação com SharedPreferences e sistema de
+//  arquivos, mantendo histórico, exportação e importação de execuções monitoradas.
+//  Fornece operações de limpeza, limites configuráveis e tratamento de erros com
+//  exceções dedicadas para garantir resiliência entre sessões do usuário.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:convert';
 import 'dart:io';
 import 'package:path_provider/path_provider.dart';

--- a/lib/core/use_cases/algorithm_use_cases.dart
+++ b/lib/core/use_cases/algorithm_use_cases.dart
@@ -1,3 +1,14 @@
+//
+//  algorithm_use_cases.dart
+//  JFlutter
+//
+//  Coleção de casos de uso que delegam ao repositório de algoritmos operações de
+//  conversão, minimização e análise sobre autômatos, expressões regulares e gramáticas.
+//  Cada classe encapsula um fluxo assíncrono específico, expondo métodos execute
+//  para reutilização em camadas de apresentação e orquestração da aplicação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../entities/automaton_entity.dart';
 import '../result.dart';
 import '../repositories/automaton_repository.dart';


### PR DESCRIPTION
## Summary
- add standardized ownership headers to core result, entity, and parser files
- document services and algorithm use cases with Portuguese summaries describing responsibilities

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e53d781e9c832e950130e457384bb3