### PR TITLE
Add project-standard headers to models and providers

### DIFF
--- a/lib/data/models/automaton_dto.dart
+++ b/lib/data/models/automaton_dto.dart
@@ -1,17 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/automaton_dto.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define os DTOs responsáveis por serializar autômatos, estados e
-///             estruturas JFLAP garantindo compatibilidade com armazenamento e
-///             troca de dados.
-/// Contexto: Serve como camada de transporte entre entidades do domínio,
-///           arquivos JSON e representações legadas do JFLAP, permitindo
-///           importar e exportar configurações completas de autômatos.
-/// Observações: Mantém coleções imutáveis para preservar integridade dos
-///               dados serializados e expõe fábricas de conversão para
-///               facilitar a reconstrução dos objetos.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_dto.dart
+//  JFlutter
+//
+//  Reúne os DTOs responsáveis por serializar autômatos, estados e estruturas
+//  compatíveis com o JFLAP, oferecendo conversões imutáveis para JSON e mapas
+//  aninhados que preservam transições, estados e metadados durante importações
+//  e exportações entre o aplicativo e formatos legados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 class AutomatonDto {
   final String id;
   final String name;

--- a/lib/data/models/automaton_model.dart
+++ b/lib/data/models/automaton_model.dart
@@ -1,16 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/automaton_model.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Implementa o modelo de dados de autômatos utilizado para
-///             persistência, incluindo conversões entre entidades e estruturas
-///             serializáveis.
-/// Contexto: Atende a camada de dados facilitando o mapeamento bidirecional
-///           entre o domínio e o armazenamento local, garantindo consistência
-///           das coleções e metadados do autômato.
-/// Observações: Construtores aplicam coleções imutáveis e fábricas dedicadas,
-///               reduzindo risco de mutações acidentais em estados compartilhados.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_model.dart
+//  JFlutter
+//
+//  Estrutura o modelo de dados de autômatos persistidos, oferecendo
+//  construtores imutáveis e fábricas para converter entre entidades de domínio,
+//  JSON e coleções especializadas, mantendo estados, transições e metadados
+//  coerentes durante importação, edição e salvamento.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../core/entities/automaton_entity.dart';
 
 /// Data model for automaton persistence

--- a/lib/data/models/grammar_dto.dart
+++ b/lib/data/models/grammar_dto.dart
@@ -1,16 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/grammar_dto.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define os DTOs das gramáticas e estruturas JFLAP responsáveis
-///             por serializar símbolos, produções e metadados associados.
-/// Contexto: Suporta importação e exportação de gramáticas entre o domínio e
-///           formatos JSON/JFLAP, assegurando compatibilidade com o ecossistema
-///           da aplicação e ferramentas externas.
-/// Observações: Construtores imutáveis e fábricas dedicadas simplificam a
-///               reconstrução das gramáticas mantendo a fidelidade dos dados
-///               originais.
-/// ---------------------------------------------------------------------------
+//
+//  grammar_dto.dart
+//  JFlutter
+//
+//  Define os objetos de transferência de dados que representam gramáticas e
+//  suas variantes em formato JFLAP, convertendo símbolos, produções e metadados
+//  entre JSON e estruturas imutáveis para garantir compatibilidade com a camada
+//  de domínio, importações externas e ferramentas legadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 class GrammarDto {
   final String id;
   final String name;

--- a/lib/data/models/turing_machine_dto.dart
+++ b/lib/data/models/turing_machine_dto.dart
@@ -1,17 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/turing_machine_dto.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Estruturas DTO responsáveis por serializar máquinas de Turing,
-///             transições e símbolos, mantendo compatibilidade com armazenamento
-///             local e formatos externos.
-/// Contexto: Faz a ponte entre entidades de domínio e representações JSON,
-///           permitindo importar, persistir e compartilhar configurações de
-///           máquinas de Turing completas.
-/// Observações: Usa conversões imutáveis e helpers para mapear transições
-///               aninhadas, garantindo consistência mesmo em estruturas
-///               complexas.
-/// ---------------------------------------------------------------------------
+//
+//  turing_machine_dto.dart
+//  JFlutter
+//
+//  Este arquivo define as estruturas imutáveis TuringMachineDto e
+//  TuringTransitionDto, responsáveis por traduzir máquinas de Turing entre o
+//  domínio e representações JSON, preservando alfabetos, estados e transições
+//  aninhadas para importação e persistência confiáveis.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:collection/collection.dart';
 
 class TuringMachineDto {

--- a/lib/data/storage/settings_storage.dart
+++ b/lib/data/storage/settings_storage.dart
@@ -1,17 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/storage/settings_storage.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define o contrato de armazenamento de preferências e a
-///             implementação baseada em SharedPreferences para persistir
-///             configurações do usuário.
-/// Contexto: Fornece abstração reutilizável para o repositório de configurações
-///           isolando detalhes da API de chave-valor e permitindo injeção em
-///           testes e camadas superiores.
-/// Observações: Suporta provedores customizados de SharedPreferences,
-///               facilitando mocks em testes e configurações específicas de
-///               plataforma.
-/// ---------------------------------------------------------------------------
+//
+//  settings_storage.dart
+//  JFlutter
+//
+//  Define a abstração SettingsStorage e suas implementações baseada em
+//  SharedPreferences e em memória, permitindo que o repositório de
+//  configurações leia e persista preferências do usuário sem acoplar detalhes
+//  de plataforma, além de facilitar testes com provedores customizados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Key-value storage interface used by the settings repository.

--- a/lib/presentation/providers/algorithm_provider.dart
+++ b/lib/presentation/providers/algorithm_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/algorithm_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Centraliza a chamada dos casos de uso de algoritmos formais expostos na interface. Garante que operações de conversão, minimização e equivalência emitam estados coerentes para feedback ao usuário.
-/// Contexto: Implementa um StateNotifier Riverpod que encadeia repositórios e casos de uso definidos no domínio. Padroniza os ciclos de carregamento e propagação de erros para componentes de UI que consomem resultados de algoritmos.
-/// Observações: Mantém o último resultado ou falha para reutilização em painéis subsequentes. Facilita a extensão futura adicionando novos casos de uso sem alterar a superfície pública dos widgets.
-/// ---------------------------------------------------------------------------
+//
+//  algorithm_provider.dart
+//  JFlutter
+//
+//  Coordena a execução dos casos de uso de algoritmos formais expostos na
+//  interface, emitindo estados Riverpod que encapsulam carregamento, sucesso e
+//  falhas ao invocar operações de conversão, minimização e equivalência sobre
+//  autômatos e gramáticas consumidos pelos widgets.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/use_cases/algorithm_use_cases.dart';
 import '../../core/entities/automaton_entity.dart';

--- a/lib/presentation/providers/automaton_provider.dart
+++ b/lib/presentation/providers/automaton_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/automaton_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Orquestra a criação, edição e persistência de autômatos no editor visual. Expõe estado reativo com informações de layout, dados de transições e indicadores de carregamento para a interface.
-/// Contexto: Encapsula integrações com serviços de automaton, algoritmos de conversão e o repositório de layout para manter consistência entre domínio e canvas. Coordena operações de simulação, conversão e minimização respeitando a infraestrutura de GraphView.
-/// Observações: Registra mutações relevantes para depuração e alimenta históricos de traços quando persistência está habilitada. Fornece métodos para atualizar estados, transições e propriedades estruturais sincronizando widgets e provedores auxiliares.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_provider.dart
+//  JFlutter
+//
+//  Centraliza a gestão reativa dos autômatos exibidos no editor visual,
+//  integrando serviços de domínio, algoritmos e persistência para manter
+//  estados, transições, layouts e indicadores de carregamento coerentes com as
+//  interações do usuário, incluindo operações de simulação e conversão.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math';
 import 'package:collection/collection.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/presentation/providers/fa_trace_provider.dart
+++ b/lib/presentation/providers/fa_trace_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/fa_trace_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Controla o estado imutável das simulações de autômatos finitos determinísticos e não determinísticos. Centraliza a seleção do autômato ativo, o progresso da execução e os resultados em memória.
-/// Contexto: Expõe uma StateNotifier do Riverpod que dispara execuções via SimulationService e atualiza histórico de traços. Fornece operações para alternar modos, executar simulações passo a passo e armazenar falhas de forma apresentável.
-/// Observações: Inclui utilitários de navegação entre passos para sincronizar os painéis de visualização. Mantém histórico de execuções para que telas e widgets possam reabrir traços anteriores.
-/// ---------------------------------------------------------------------------
+//
+//  fa_trace_provider.dart
+//  JFlutter
+//
+//  Mantém o estado das simulações de autômatos finitos, acompanhando a seleção
+//  do autômato ativo, o progresso de execução e os resultados expostos à
+//  interface enquanto coordena chamadas ao serviço de simulação e o histórico
+//  de traços reaproveitado pelos painéis de visualização.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/fsa.dart';
 import '../../core/models/simulation_result.dart';

--- a/lib/presentation/providers/grammar_provider.dart
+++ b/lib/presentation/providers/grammar_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/grammar_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Controla a edição de gramáticas formais e as conversões disponíveis no workspace dedicado. Mantém estado com produções, símbolo inicial, tipo selecionado e resultados recentes de transformações para automatos.
-/// Contexto: Usa um StateNotifier que integra o ConversionService para executar pipelines como Gramática→AF e Gramática→AP. Organiza identificadores e ordem das produções garantindo edição previsível para componentes visuais.
-/// Observações: Expõe métodos para adicionar, atualizar, excluir e limpar produções além de lidar com feedback de erros. Permite rastrear conversões ativas e resultados de PDA para que widgets exibam progresso e mensagens de sucesso ou falha.
-/// ---------------------------------------------------------------------------
+//
+//  grammar_provider.dart
+//  JFlutter
+//
+//  Administra a edição de gramáticas formais no workspace, mantendo produções,
+//  símbolo inicial, tipo selecionado e resultados recentes de conversões enquanto
+//  integra serviços de transformação para gerar autômatos e PDAs consumidos por
+//  widgets e feedback visual.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../../core/models/fsa.dart';

--- a/lib/presentation/providers/pda_editor_provider.dart
+++ b/lib/presentation/providers/pda_editor_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/pda_editor_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Administra o autômato de pilha editado no canvas e metadados derivados como transições lambda ou não determinísticas. Garante que alterações interativas sejam refletidas em modelos consistentes com o domínio.
-/// Contexto: Utiliza um StateNotifier para consolidar mutações de estados, transições e configurações básicas do PDA. Serve de ponte entre eventos de interface e os objetos imutáveis usados por simuladores e exportadores.
-/// Observações: Fornece operações utilitárias para criação, movimentação e remoção de elementos mantendo integridade referencial. Atualiza conjuntos auxiliares que alimentam destaques visuais e diagnósticos pedagógicos.
-/// ---------------------------------------------------------------------------
+//
+//  pda_editor_provider.dart
+//  JFlutter
+//
+//  Declara o estado e o StateNotifier responsáveis por controlar o autômato de
+//  pilha editado no canvas, mantendo transições lambda, escolhas
+//  não determinísticas e sincronizando as mutações de estados com estruturas
+//  imutáveis usadas por simuladores, exportadores e destaques visuais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/presentation/providers/pda_simulation_provider.dart
+++ b/lib/presentation/providers/pda_simulation_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/pda_simulation_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Controla execuções de autômatos de pilha expondo estado e resultados para a interface. Permite alternar entre modos de aceitação e executar simulações passo a passo.
-/// Contexto: Reutiliza a fachada de simulação do domínio para encapsular regras de aceitação por estado final ou pilha vazia. Atua como camada intermediária entre os widgets e os modelos de PDA mantendo o último insumo processado.
-/// Observações: Propaga falhas como resultados estruturados garantindo feedback consistente em painéis. Pode ser combinado com outros provedores de edição para atualizar o autômato monitorado em tempo real.
-/// ---------------------------------------------------------------------------
+//
+//  pda_simulation_provider.dart
+//  JFlutter
+//
+//  Orquestra simulações de autômatos de pilha na interface, permitindo alternar
+//  entre modos de aceitação, executar passos incrementais e publicar resultados
+//  estruturados obtidos da fachada de simulação do domínio para feedback
+//  consistente entre widgets e painéis.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
 import '../../core/algorithms/pda/pda_simulator_facade.dart' as pda;

--- a/lib/presentation/providers/pda_trace_provider.dart
+++ b/lib/presentation/providers/pda_trace_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/pda_trace_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Administra o estado das simulações de autômatos de pilha, incluindo histórico persistente e navegação por passos. Fornece feedback sobre execuções bem-sucedidas e falhas para os painéis de visualização.
-/// Contexto: Utiliza o PDASimulatorFacade do domínio para executar cadeias e traduzir respostas em objetos Riverpod reativos. Mantém indicadores de carregamento, modo passo a passo e última entrada processada para sincronizar controles interativos.
-/// Observações: Disponibiliza utilitários de navegação para avançar, retroceder ou saltar a passos específicos da simulação. Registra erros como resultados estruturados permitindo tratamento uniforme em widgets consumidores.
-/// ---------------------------------------------------------------------------
+//
+//  pda_trace_provider.dart
+//  JFlutter
+//
+//  Controla as simulações de autômatos de pilha, armazenando histórico, modo
+//  passo a passo e resultados estruturados enquanto coordena execuções via
+//  PDASimulatorFacade e fornece feedback consistente para os widgets de
+//  visualização e navegação entre etapas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/pda.dart';
 import '../../core/models/simulation_step.dart';

--- a/lib/presentation/providers/settings_provider.dart
+++ b/lib/presentation/providers/settings_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/settings_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Disponibiliza configurações persistidas para a árvore de widgets por meio de um StateNotifier Riverpod. Realiza leitura inicial e sincronizações subsequentes com a fonte de dados padrão baseada em SharedPreferences.
-/// Contexto: Encapsula o repositório de configurações para abstrair detalhes de persistência e facilitar substituições em testes. Garante que alterações de modelo sejam gravadas com tratamento de erros e preservação de ciclo de vida.
-/// Observações: Oferece métodos para atualização, recarregamento e restauração dos valores padrão do SettingsModel. Controla descarte seguro para evitar escrituras após a liberação do provedor.
-/// ---------------------------------------------------------------------------
+//
+//  settings_provider.dart
+//  JFlutter
+//
+//  Expõe um StateNotifier responsável por carregar, atualizar e persistir o
+//  SettingsModel da aplicação, abstraindo o repositório subjacente baseado em
+//  SharedPreferences e garantindo sincronização segura das preferências com a
+//  árvore de widgets e seus testes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/providers/tm_editor_provider.dart
+++ b/lib/presentation/providers/tm_editor_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/tm_editor_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Garante a construção consistente das Máquinas de Turing manipuladas no canvas, acompanhando estados, transições e símbolos de fita. Traduz interações do usuário em modelos imutáveis consumidos por simuladores e exportadores.
-/// Contexto: Mantém caches mutáveis internos para aplicar transformações incrementais e gerar uma TM consolidada sempre que o editor sofre alterações. Fornece metadados úteis como direções de movimento e transições não determinísticas para destacar regras específicas.
-/// Observações: Oferece métodos abrangentes para adicionar, mover e renomear estados ou transições preservando integridade de ligações. Atualiza o estado Riverpod com coleções clonadas para evitar efeitos colaterais em widgets observadores.
-/// ---------------------------------------------------------------------------
+//
+//  tm_editor_provider.dart
+//  JFlutter
+//
+//  Gerencia o estado do editor de máquinas de Turing no canvas, convertendo
+//  interações do usuário em estruturas imutáveis que preservam estados,
+//  transições, símbolos de fita e direções de movimento enquanto fornece
+//  metadados auxiliares para simuladores, exportadores e destaques visuais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/lib/presentation/providers/unified_trace_provider.dart
+++ b/lib/presentation/providers/unified_trace_provider.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/unified_trace_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Consolida o gerenciamento de traços de simulação para todos os tipos de autômatos em uma interface única. Controla o contexto ativo, histórico persistido e estatísticas agregadas para compartilhamento entre módulos.
-/// Contexto: Opera como StateNotifier que integra serviços de persistência, carregamento lazily e navegação por passos de execução. Permite resgatar execuções anteriores com base em identificadores e tipos registrados.
-/// Observações: Trata erros de I/O exibindo mensagens amigáveis e mantém coerência entre preferências e dados carregados. Automatiza salvamentos após novas simulações garantindo continuidade entre sessões.
-/// ---------------------------------------------------------------------------
+//
+//  unified_trace_provider.dart
+//  JFlutter
+//
+//  Consolida a gestão de traços de simulação para diferentes autômatos,
+//  administrando histórico persistido, contexto ativo e estatísticas
+//  compartilhadas entre módulos enquanto coordena carregamento lazily, navegação
+//  por passos e tratamento de erros de persistência.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:get_it/get_it.dart';


### PR DESCRIPTION
## Summary
- replace legacy comment blocks with the mandated JFlutter header in four data model files
- document seven provider modules and related simulation helpers with the new Portuguese summary header
- align the shared settings storage abstraction with the standardized header format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e5400768a4832eb493cad919ef19ae