### PR TITLE
docs: aplicar cabeçalhos padronizados em arquivos dart

### DIFF
--- a/lib/core/constants/automaton_canvas.dart
+++ b/lib/core/constants/automaton_canvas.dart
@@ -1,2 +1,13 @@
+//
+//  automaton_canvas.dart
+//  JFlutter
+//
+//  Armazena constantes de layout utilizadas pelos widgets do canvas de
+//  autômatos, padronizando dimensões e espaçamentos entre plataformas e
+//  garantindo uma experiência consistente na renderização interativa.
+//  Valores fixos centralizam ajustes e reduzem duplicidade de configurações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 /// Shared layout constants for the automaton canvas widgets.
 const double kAutomatonStateDiameter = 96;

--- a/lib/core/dfa_algorithms.dart
+++ b/lib/core/dfa_algorithms.dart
@@ -1,3 +1,14 @@
+//
+//  dfa_algorithms.dart
+//  JFlutter
+//
+//  Reúne as principais ferramentas voltadas a autômatos determinísticos,
+//  reexportando minimização, simulação e complementação para consumo externo
+//  sem expor a estrutura detalhada do diretório de algoritmos.
+//  Facilita o acesso centralizado a rotinas de DFA para widgets e casos de uso.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 // Re-export DFA-specific algorithms
 export 'algorithms/dfa_minimizer.dart';
 export 'algorithms/automaton_simulator.dart';

--- a/lib/core/models/automaton.dart
+++ b/lib/core/models/automaton.dart
@@ -1,3 +1,15 @@
+//
+//  automaton.dart
+//  JFlutter
+//
+//  Classe base abstrata que representa autômatos no domínio do aplicativo,
+//  mantendo coleções imutáveis de estados, transições, alfabetos e metadados de
+//  visualização. Define contratos de clonagem, serialização e validação comum
+//  para FSA, PDA e TM, além de oferecer fábricas que instanciam tipos concretos
+//  a partir de descrições JSON.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 import 'state.dart';

--- a/lib/core/models/parse_table.dart
+++ b/lib/core/models/parse_table.dart
@@ -1,3 +1,14 @@
+//
+//  parse_table.dart
+//  JFlutter
+//
+//  Representa tabelas de análise sintática para algoritmos LL e LR, mantendo
+//  ações, movimentos goto e referência à gramática associada. Disponibiliza
+//  operações de cópia, serialização e inspeção que suportam verificações de
+//  conflitos e navegação em simuladores de parsing.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'grammar.dart';
 import 'production.dart';
 

--- a/lib/core/models/pumping_lemma_game.dart
+++ b/lib/core/models/pumping_lemma_game.dart
@@ -1,3 +1,14 @@
+//
+//  pumping_lemma_game.dart
+//  JFlutter
+//
+//  Estrutura de domínio que modela o minigame do lema do bombeamento,
+//  relacionando autômatos finitos, tentativas do usuário, pontuação e estados
+//  de progresso. Fornece fábricas para iniciar desafios, métodos para registrar
+//  tentativas e utilidades que calculam métricas, status e igualdade profunda.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'fsa.dart';
 import 'pumping_attempt.dart';
 import 'dart:math' as math;

--- a/lib/core/models/settings_model.dart
+++ b/lib/core/models/settings_model.dart
@@ -1,3 +1,14 @@
+//
+//  settings_model.dart
+//  JFlutter
+//
+//  Estrutura leve que representa as preferências persistidas do aplicativo,
+//  controlando símbolos especiais, preferências de interface e tamanhos de
+//  elementos. Garante valores padrão coesos, permite cópias imutáveis e facilita
+//  comparações para atualizar provedores de configuração.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 /// Model representing persisted application settings.
 class SettingsModel {
   /// Symbol used to represent the empty string.

--- a/lib/core/models/simulation_result.dart
+++ b/lib/core/models/simulation_result.dart
@@ -1,3 +1,14 @@
+//
+//  simulation_result.dart
+//  JFlutter
+//
+//  Modela o resultado das simulações de autômatos, armazenando entrada,
+//  aceitação, passos detalhados, mensagens de erro e métricas de execução.
+//  Oferece fábricas para diferentes cenários (sucesso, falha, timeout ou laço)
+//  além de utilidades de serialização e análises auxiliares usadas em painéis.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'simulation_step.dart';
 
 class SimulationResult {

--- a/lib/core/models/state.dart
+++ b/lib/core/models/state.dart
@@ -1,3 +1,14 @@
+//
+//  state.dart
+//  JFlutter
+//
+//  Define o modelo imutável de estados de autômatos com coordenadas, marcadores
+//  de inicialização, aceitação e propriedades adicionais para cada tipo de
+//  máquina. Inclui rotinas de serialização, validação e utilitários voltados a
+//  interações no canvas móvel, garantindo consistência nas simulações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 
 /// Represents a state in an automaton

--- a/lib/core/models/touch_interaction.dart
+++ b/lib/core/models/touch_interaction.dart
@@ -1,3 +1,14 @@
+//
+//  touch_interaction.dart
+//  JFlutter
+//
+//  Representa interações táteis capturadas na interface móvel, armazenando
+//  tipo de gesto, posição, seleções e carimbo temporal para reagir a ações do
+//  usuário no canvas. Inclui utilidades de serialização, fábricas para gestos
+//  comuns e métricas que orientam feedback visual e lógica de seleção.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 
 /// Touch interaction model for mobile UI

--- a/lib/data/models/automaton_dto.dart
+++ b/lib/data/models/automaton_dto.dart
@@ -1,17 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/automaton_dto.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define os DTOs responsáveis por serializar autômatos, estados e
-///             estruturas JFLAP garantindo compatibilidade com armazenamento e
-///             troca de dados.
-/// Contexto: Serve como camada de transporte entre entidades do domínio,
-///           arquivos JSON e representações legadas do JFLAP, permitindo
-///           importar e exportar configurações completas de autômatos.
-/// Observações: Mantém coleções imutáveis para preservar integridade dos
-///               dados serializados e expõe fábricas de conversão para
-///               facilitar a reconstrução dos objetos.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_dto.dart
+//  JFlutter
+//
+//  Define DTOs de autômatos, estados e estruturas JFLAP que encapsulam
+//  alfabetos, transições e metadados necessários para transportar configurações
+//  completas entre camadas de dados e arquivos externos.
+//  As fábricas convertem de e para JSON ou XML do JFLAP preservando
+//  imutabilidade e compatibilidade com importações e exportações do aplicativo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 class AutomatonDto {
   final String id;
   final String name;

--- a/lib/data/models/automaton_model.dart
+++ b/lib/data/models/automaton_model.dart
@@ -1,16 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/automaton_model.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Implementa o modelo de dados de autômatos utilizado para
-///             persistência, incluindo conversões entre entidades e estruturas
-///             serializáveis.
-/// Contexto: Atende a camada de dados facilitando o mapeamento bidirecional
-///           entre o domínio e o armazenamento local, garantindo consistência
-///           das coleções e metadados do autômato.
-/// Observações: Construtores aplicam coleções imutáveis e fábricas dedicadas,
-///               reduzindo risco de mutações acidentais em estados compartilhados.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_model.dart
+//  JFlutter
+//
+//  Modelo de dados responsável por persistir autômatos com coleções imutáveis
+//  e mapeamentos completos de estados, transições, alfabetos e metadados.
+//  Fornece fábricas bidirecionais para converter entre entidades de domínio,
+//  estruturas serializáveis e representações JSON utilizadas pelo armazenamento.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../core/entities/automaton_entity.dart';
 
 /// Data model for automaton persistence

--- a/lib/data/models/grammar_dto.dart
+++ b/lib/data/models/grammar_dto.dart
@@ -1,16 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/grammar_dto.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define os DTOs das gramáticas e estruturas JFLAP responsáveis
-///             por serializar símbolos, produções e metadados associados.
-/// Contexto: Suporta importação e exportação de gramáticas entre o domínio e
-///           formatos JSON/JFLAP, assegurando compatibilidade com o ecossistema
-///           da aplicação e ferramentas externas.
-/// Observações: Construtores imutáveis e fábricas dedicadas simplificam a
-///               reconstrução das gramáticas mantendo a fidelidade dos dados
-///               originais.
-/// ---------------------------------------------------------------------------
+//
+//  grammar_dto.dart
+//  JFlutter
+//
+//  Conjunto de DTOs que representam gramáticas e produções no formato JFLAP,
+//  oferecendo fábricas e serialização para importar e exportar símbolos,
+//  regras e estruturas associadas às gramáticas dentro do aplicativo.
+//  As classes também garantem coleções imutáveis para preservar consistência
+//  dos dados ao trafegar entre armazenamento local e formatos externos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 class GrammarDto {
   final String id;
   final String name;

--- a/lib/data/models/turing_machine_dto.dart
+++ b/lib/data/models/turing_machine_dto.dart
@@ -1,17 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/models/turing_machine_dto.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Estruturas DTO responsáveis por serializar máquinas de Turing,
-///             transições e símbolos, mantendo compatibilidade com armazenamento
-///             local e formatos externos.
-/// Contexto: Faz a ponte entre entidades de domínio e representações JSON,
-///           permitindo importar, persistir e compartilhar configurações de
-///           máquinas de Turing completas.
-/// Observações: Usa conversões imutáveis e helpers para mapear transições
-///               aninhadas, garantindo consistência mesmo em estruturas
-///               complexas.
-/// ---------------------------------------------------------------------------
+//
+//  turing_machine_dto.dart
+//  JFlutter
+//
+//  Estruturas de transporte que descrevem máquinas de Turing completas,
+//  incluindo alfabetos, estados, transições aninhadas e símbolos especiais para
+//  serialização confiável em JSON ou formatos derivados do JFLAP.
+//  Utiliza coleções imutáveis, igualdade profunda e fábricas de conversão para
+//  garantir consistência durante importações, exportações e persistência local.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:collection/collection.dart';
 
 class TuringMachineDto {

--- a/lib/data/storage/settings_storage.dart
+++ b/lib/data/storage/settings_storage.dart
@@ -1,17 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/data/storage/settings_storage.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define o contrato de armazenamento de preferências e a
-///             implementação baseada em SharedPreferences para persistir
-///             configurações do usuário.
-/// Contexto: Fornece abstração reutilizável para o repositório de configurações
-///           isolando detalhes da API de chave-valor e permitindo injeção em
-///           testes e camadas superiores.
-/// Observações: Suporta provedores customizados de SharedPreferences,
-///               facilitando mocks em testes e configurações específicas de
-///               plataforma.
-/// ---------------------------------------------------------------------------
+//
+//  settings_storage.dart
+//  JFlutter
+//
+//  Declara a interface de armazenamento de preferências da aplicação e
+//  implementações concretas com SharedPreferences e mapas em memória para
+//  persistir símbolos, temas e demais ajustes controlados pelo usuário.
+//  A abstração permite injeção de dependências, facilita testes unitários e
+//  esconde detalhes específicos da plataforma ao manipular chave-valor.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:shared_preferences/shared_preferences.dart';
 
 /// Key-value storage interface used by the settings repository.

--- a/lib/injection/dependency_injection.dart
+++ b/lib/injection/dependency_injection.dart
@@ -1,17 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/injection/dependency_injection.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Configura o contêiner GetIt registrando data sources, serviços,
-///             repositórios e providers necessários para o funcionamento da
-///             aplicação.
-/// Contexto: Centraliza a infraestrutura de injeção de dependências permitindo
-///           inicialização preguiçosa, reutilização de instâncias e fácil
-///           manutenção das ligações entre camadas.
-/// Observações: Prepara SharedPreferences para persistência de traços e
-///               registra implementações concretas mantendo o código preparado
-///               para testes e extensões futuras.
-/// ---------------------------------------------------------------------------
+//
+//  dependency_injection.dart
+//  JFlutter
+//
+//  Configura o contêiner GetIt registrando data sources, serviços,
+//  repositórios, provedores e auxiliares necessários para inicializar o
+//  aplicativo. Padroniza a criação de dependências, habilita instâncias
+//  preguiçosas e prepara integrações como SharedPreferences e serviços de
+//  simulação para consumo pelas camadas de apresentação e domínio.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../core/repositories/automaton_repository.dart';


### PR DESCRIPTION
## Summary
- apply the mandated header template to the dependency injection bootstrap file
- add the new comment header to data layer DTOs, models, and storage abstractions
- document core models, constants, and DFA exports with the standardized header format

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e5400768a4832eb493cad919ef19ae