### PR TITLE
style: padroniza cabeçalhos de testes e widgets

### DIFF
--- a/lib/presentation/widgets/automaton_canvas_tool.dart
+++ b/lib/presentation/widgets/automaton_canvas_tool.dart
@@ -1,11 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/automaton_canvas_tool.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define os modos de edição disponíveis no canvas de autômatos e fornece controlador observável para alterná-los. Facilita integração com toolbars e componentes que precisam reagir a mudanças de ferramenta.
-/// Contexto: Utiliza ChangeNotifier para propagar eventos de seleção permitindo múltiplos ouvintes sincronizados. Mantém estado simples com valor padrão focado na ferramenta de seleção para edições comuns.
-/// Observações: Pode ser expandido com novos modos sem alterar contratos existentes. Ideal para coordenação entre painéis e gestos do canvas que dependem da ferramenta ativa.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_canvas_tool.dart
+//  JFlutter
+//
+//  Definição dos modos de edição disponíveis no canvas de autômatos e de um
+//  controlador baseado em ChangeNotifier que propaga alterações da ferramenta
+//  ativa. O módulo oferece integração simples com toolbars e componentes que
+//  reagem às trocas de modo, mantendo estado enxuto e extensível para futuros
+//  tipos de interação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 import 'package:flutter/foundation.dart';
 
 /// Editing tools supported by the automaton canvas.

--- a/lib/presentation/widgets/mobile_automaton_controls.dart
+++ b/lib/presentation/widgets/mobile_automaton_controls.dart
@@ -1,11 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/mobile_automaton_controls.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Agrupa os principais controles do editor de autômatos em uma superfície otimizada para toque. Combina ações de simulação, algoritmos, métricas e ferramentas de canvas em um único painel configurável.
-/// Contexto: Facilita o uso em dispositivos móveis ao substituir botões flutuantes dispersos por uma barra organizada com ícones e rótulos. Integra-se ao AutomatonCanvasToolController para refletir a ferramenta ativa e habilitar alternâncias.
-/// Observações: Aceita callbacks opcionais permitindo adaptar o conjunto de ações às capacidades da página hospedeira. Oferece feedback visual sobre disponibilidade e seleção para orientar usuários durante a edição.
-/// ---------------------------------------------------------------------------
+//
+//  mobile_automaton_controls.dart
+//  JFlutter
+//
+//  Widget que consolida os principais controles de edição de autômatos em uma
+//  superfície otimizada para toque, combinando ações de simulação, algoritmos,
+//  métricas e ferramentas de canvas em um painel único e configurável. A
+//  implementação sincroniza o AutomatonCanvasToolController, reflete estados de
+//  habilitação e permite personalizar callbacks para se adaptar às capacidades
+//  da página hospedeira.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 import 'package:flutter/material.dart';
 
 import 'automaton_canvas_tool.dart';

--- a/lib/presentation/widgets/tm_canvas_graphview.dart
+++ b/lib/presentation/widgets/tm_canvas_graphview.dart
@@ -1,16 +1,14 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/tm_canvas_graphview.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Renderiza o canvas de Máquinas de Turing utilizando o arcabouço
-///            unificado de automatos, delegando gestos, destaques e edições de
-///            transições para `AutomatonGraphViewCanvas`.
-/// Contexto: Integra o controlador GraphView específico de TM com provedores
-///           Riverpod e editores de transições em fita, oferecendo experiência
-///           consistente com os demais editores de autômatos.
-/// Observações: Centraliza sincronização e listeners, expondo customização de
-///              ferramentas e formulários inline para operações de fita.
-/// ---------------------------------------------------------------------------
+//
+//  tm_canvas_graphview.dart
+//  JFlutter
+//
+//  Widget que encapsula o canvas de Máquinas de Turing sobre a infraestrutura
+//  compartilhada de automatos, delegando gestos, destaques e edições de
+//  transições ao AutomatonGraphViewCanvas. A classe conecta o controlador
+//  específico de TM aos provedores Riverpod, expõe ganchos para personalizar
+//  ferramentas e habilita formulários inline para operações de fita.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_canvas_controller_test.dart
-// Objetivo: Verificar o controlador base GraphView de autômatos garantindo
-// interação com o provider e repositório de layout fake.
-// Cenários cobertos:
-// - Aplicação de layouts (auto, balanced, compact, hierarchical, spread).
-// - Manipulação de zoom, seleção e atualizações de transição.
-// - Uso de serviço de autômato para sincronização com o estado interno.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_canvas_controller_test.dart
+//  JFlutter
+//
+//  Testes unitários focados no GraphViewCanvasController, assegurando que a
+//  integração com AutomatonProvider, serviço de autômatos e repositório de
+//  layout falso cubra operações de zoom, seleção e atualização de transições.
+//  A suíte também confirma o disparo correto dos métodos de layout para manter o
+//  estado gráfico sincronizado.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_canvas_models_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_models_test.dart
@@ -1,13 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_canvas_models_test.dart
-// Objetivo: Avaliar modelos de canvas usados pelo GraphView garantindo
-// imutabilidade e helpers consistentes.
-// Cenários cobertos:
-// - Atualização de metadados de arestas via `copyWith`.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_canvas_models_test.dart
+//  JFlutter
+//
+//  Testes unitários que asseguram a imutabilidade e os utilitários de cópia dos
+//  modelos de canvas empregados pelo GraphView. Os casos verificam atualização
+//  de metadados específicos de PDAs por meio de copyWith, garantindo coerência
+//  entre símbolos de pilha e indicadores de transições λ.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/features/canvas/graphview/graphview_pda_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_mapper_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_pda_mapper_test.dart
-// Objetivo: Garantir que PDAs sejam convertidos corretamente para modelos de
-// canvas GraphView.
-// Cenários cobertos:
-// - Tradução de push/pop e símbolos λ em metadados visuais.
-// - Mapeamento de estados iniciais/aceitadores e transições múltiplas.
-// - Atualização do grafo ao sincronizar com GraphViewPdaMapper.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_pda_mapper_test.dart
+//  JFlutter
+//
+//  Suíte de testes que avalia o GraphViewPdaMapper responsável por converter
+//  autômatos de pilha em modelos de canvas. Os cenários conferem o mapeamento de
+//  estados iniciais e de aceitação, traduções de símbolos de pilha (incluindo λ)
+//  e a atualização do grafo resultante ao sincronizar múltiplas transições.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
-// Objetivo: Garantir que o controlador GraphView para MT sincronize estados,
-// transições e seleção com o provider.
-// Cenários cobertos:
-// - Construção de grafo a partir de máquinas de Turing e atualizações em tempo real.
-// - Seleção de transições e estados, emitindo eventos correspondentes.
-// - Descarte seguro de recursos após uso.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_tm_canvas_controller_test.dart
+//  JFlutter
+//
+//  Testes unitários que exercitam o GraphViewTmCanvasController, garantindo a
+//  sincronização de estados, transições e seleção com o TMEditorNotifier durante
+//  operações típicas de edição de máquinas de Turing. Os cenários cobrem
+//  construção inicial do grafo, atualizações reativas e descarte seguro dos
+//  recursos associados ao controlador.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'dart:math' as math;
 

--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -1,15 +1,15 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/automaton_graphview_canvas_test.dart
-// Objetivo: Certificar que o canvas GraphView de autômatos integra-se com os
-// provedores e serviços de layout simulados.
-// Cenários cobertos:
-// - Renderização de estados/transições e interação com ferramentas do canvas.
-// - Rotulagem inline e disparo de callbacks do controlador.
-// - Tratamento de layouts não suportados por repositório fake.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  automaton_graphview_canvas_test.dart
+//  JFlutter
+//
+//  Suite abrangente que examina o AutomatonGraphViewCanvas, garantindo
+//  integração com provedores simulados, controlador personalizado e repositório
+//  de layout em cenários de interação por gestos. Os testes validam adição e
+//  movimentação de estados, edição inline de transições e respostas a layouts
+//  não suportados, assegurando consistência entre a interface e o estado do
+//  autômato.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'dart:math' as math;
 

--- a/test/widget/presentation/graphview_canvas_toolbar_test.dart
+++ b/test/widget/presentation/graphview_canvas_toolbar_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/graphview_canvas_toolbar_test.dart
-// Objetivo: Verificar o toolbar do canvas GraphView garantindo que ações de
-// zoom, ajuste e undo/redo disparem o controlador.
-// Cenários cobertos:
-// - Execução de zoom in/out, fit e reset view.
-// - Ações de desfazer/refazer invocando o controlador especializado.
-// - Exposição de ferramentas adicionais (adicionar estado/transição).
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_canvas_toolbar_test.dart
+//  JFlutter
+//
+//  Conjunto de testes de widget que exercita o GraphViewCanvasToolbar,
+//  validando exibição de mensagens de status e disparo dos callbacks de zoom,
+//  enquadramento, reset e histórico no controlador falso durante interações.
+//  Os cenários confirmam que botões opcionais e ferramentas adicionais aparecem
+//  apenas quando fornecidos, mantendo o contrato da interface responsiva.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/graphview_label_field_editor_test.dart
+++ b/test/widget/presentation/graphview_label_field_editor_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/graphview_label_field_editor_test.dart
-// Objetivo: Validar interações do editor inline de rótulos do GraphView,
-// assegurando submissão e cancelamento corretos.
-// Cenários cobertos:
-// - Envio do novo valor ao pressionar Enter.
-// - Cancelamento via tecla Escape mantendo o valor original.
-// - Invocação de callbacks de confirmação e cancelamento.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_label_field_editor_test.dart
+//  JFlutter
+//
+//  Testes de widget que avaliam o editor inline de rótulos do GraphView,
+//  garantindo que submissões por teclado e cancelamentos preservem os valores
+//  esperados. As provas verificam interação com mudança de foco, teclas Enter e
+//  Escape, além de assegurar que callbacks fornecidos sejam acionados conforme o
+//  contrato do componente.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';

--- a/test/widget/presentation/mobile_automaton_controls_test.dart
+++ b/test/widget/presentation/mobile_automaton_controls_test.dart
@@ -1,15 +1,15 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/mobile_automaton_controls_test.dart
-// Objetivo: Garantir que os controles móveis do canvas exponham ações e
-// callbacks de simulação, algoritmos e edição.
-// Cenários cobertos:
-// - Renderização de botões de ações principais.
-// - Disparo dos callbacks associados a cada ação.
-// - Exibição de mensagens de status na interface.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  mobile_automaton_controls_test.dart
+//  JFlutter
+//
+//  Conjunto de testes de widget que confirma o comportamento do
+//  MobileAutomatonControls, cobrindo renderização dos botões principais e
+//  habilitação condicional de simulação, algoritmos, métricas e ferramentas do
+//  canvas. As verificações monitoram callbacks disparados e mensagens de status
+//  para assegurar que o painel móvel responda corretamente a diferentes
+//  configurações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/pda_canvas_graphview_test.dart
+++ b/test/widget/presentation/pda_canvas_graphview_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/pda_canvas_graphview_test.dart
-// Objetivo: Validar a renderização do canvas de PDA com GraphView garantindo
-// sincronização entre provider e controlador.
-// Cenários cobertos:
-// - Desenho de estados e transições enviados pelo controlador.
-// - Reatividade do provider ao modificar o autômato de pilha.
-// - Liberação de recursos do controlador ao término do teste.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  pda_canvas_graphview_test.dart
+//  JFlutter
+//
+//  Suite de testes de widget dedicada ao PDACanvasGraphView, certificando que o
+//  controlador GraphView de autômatos de pilha sincronize estados, transições e
+//  callbacks com o provider durante interações de edição. Os cenários incluem
+//  criação incremental de nós, atualização de transições com símbolos de pilha e
+//  descarte correto de recursos após cada execução.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/tm_canvas_graphview_test.dart
+++ b/test/widget/presentation/tm_canvas_graphview_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/tm_canvas_graphview_test.dart
-// Objetivo: Validar a renderização do canvas de MT com GraphView, assegurando
-// integração com o provider e controle de transições.
-// Cenários cobertos:
-// - Exibição de estados e transições provenientes do controlador.
-// - Reatividade a modificações do editor de MT.
-// - Descarte correto do controlador após o teste.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  tm_canvas_graphview_test.dart
+//  JFlutter
+//
+//  Bateria de testes de widget que verifica o TMCanvasGraphView, assegurando
+//  que o controlador GraphView de máquinas de Turing sincronize estados e
+//  transições com o provider Riverpod durante interações típicas de edição.
+//  As verificações incluem criação dinâmica de nós, adição de transições e
+//  descarte apropriado do controlador ao término de cada cenário.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/ux_error_handling_test.dart
+++ b/test/widget/presentation/ux_error_handling_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/ux_error_handling_test.dart
-// Objetivo: Garantir a experiência de usuário ao lidar com erros de importação,
-// cobrindo banner inline, diálogo e ações de retry.
-// Cenários cobertos:
-// - Exibição do banner de erro e mensagem detalhada.
-// - Interação com diálogo de erro e botões auxiliares.
-// - Funcionamento do botão de tentar novamente e estado do provider.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  ux_error_handling_test.dart
+//  JFlutter
+//
+//  Extensa suíte de testes de widget dedicada a validar componentes de UX para
+//  tratamento de erros de importação, incluindo banners inline, diálogos e
+//  botões de repetição. Os cenários percorrem diferentes mensagens, fluxos de
+//  tentativa novamente e descarte, garantindo que callbacks sejam disparados e
+//  que o estado visual reaja às interações do usuário em sequências completas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/visualizations_test.dart
+++ b/test/widget/presentation/visualizations_test.dart
@@ -1,13 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/widget/presentation/visualizations_test.dart
-// Objetivo: Reservar infraestrutura para testes de visualizações e goldens,
-// indicando trabalho pendente na fase 3.2.
-// Cenários cobertos:
-// - Registro de teste pendente sinalizando necessidade de configuração.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  visualizations_test.dart
+//  JFlutter
+//
+//  Teste placeholder que documenta a dependência futura de infraestrutura de
+//  visualizações e goldens para a fase 3.2 do projeto. O caso falha
+//  intencionalmente para sinalizar a ausência de renderizadores configurados e
+//  garantir que a lacuna permaneça visível na matriz de testes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
 
 import 'package:flutter_test/flutter_test.dart';
 


### PR DESCRIPTION
## Summary
- padronizei os cabeçalhos de 15 arquivos de testes e widgets com o formato solicitado
- escrevi resumos em português descrevendo a função de cada arquivo e a autoria padronizada

## Testing
- not run (comentários e documentação apenas)


------
https://chatgpt.com/codex/tasks/task_e_68e5400768a4832eb493cad919ef19ae