### PR TITLE
core: add headers to algorithms files

### DIFF
--- a/lib/core/algorithms/algorithm_operations.dart
+++ b/lib/core/algorithms/algorithm_operations.dart
@@ -1,3 +1,16 @@
+//
+//  algorithm_operations.dart
+//  JFlutter
+//
+//  Reúne pontos de entrada de alto nível para os algoritmos de conversão,
+//  análise e simulação do projeto, encapsulando chamadas para conversores de
+//  autômatos, avaliadores de gramáticas, simuladores assíncronos e rotinas do
+//  lema do bombeamento. Fornece tratamento de erros uniforme e tempos limite
+//  configuráveis para cada operação, permitindo que a camada de apresentação
+//  invoque funcionalidades complexas com uma interface coesa.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/pda.dart';
 import '../models/tm.dart';

--- a/lib/core/algorithms/automata/fa_algorithms.dart
+++ b/lib/core/algorithms/automata/fa_algorithms.dart
@@ -1,3 +1,16 @@
+//
+//  fa_algorithms.dart
+//  JFlutter
+//
+//  Oferece uma fachada simplificada para algoritmos relacionados a autômatos
+//  finitos determinísticos e não determinísticos, expondo conversão NFA→DFA,
+//  minimização com rastreamento de passos, operações de linguagem e verificações
+//  de propriedades como finitude e equivalência. Centraliza dependências de
+//  módulos especializados para que camadas superiores acessem rotinas robustas
+//  com chamadas diretas e documentadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../models/fsa.dart';
 import '../../result.dart';
 import '../dfa_minimizer.dart';

--- a/lib/core/algorithms/automata/fa_simulator.dart
+++ b/lib/core/algorithms/automata/fa_simulator.dart
@@ -1,3 +1,15 @@
+//
+//  fa_simulator.dart
+//  JFlutter
+//
+//  Disponibiliza uma fachada específica para simulação de autômatos finitos,
+//  escolhendo dinamicamente entre execuções determinísticas e não
+//  determinísticas fornecidas por `AutomatonSimulator`. Simplifica o acesso a
+//  resultados completos de simulação e à verificação booleana de aceitação,
+//  respeitando configurações de passo a passo e limites de tempo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../models/fsa.dart';
 import '../../models/simulation_result.dart';
 import '../../result.dart';

--- a/lib/core/algorithms/automaton_simulator.dart
+++ b/lib/core/algorithms/automaton_simulator.dart
@@ -1,3 +1,16 @@
+//
+//  automaton_simulator.dart
+//  JFlutter
+//
+//  Implementa o motor central de simulação para autômatos finitos, cobrindo
+//  execuções determinísticas e não determinísticas com suporte a rastreamento
+//  passo a passo. Realiza validações estruturais, controla tempo limite,
+//  compila listas de etapas e produz resultados ricos que incluem estatísticas
+//  de execução. Serve como base para fachadas de nível superior no domínio de
+//  autômatos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/state.dart';
 import '../models/fsa_transition.dart';

--- a/lib/core/algorithms/cfg/cfg_toolkit.dart
+++ b/lib/core/algorithms/cfg/cfg_toolkit.dart
@@ -1,3 +1,15 @@
+//
+//  cfg_toolkit.dart
+//  JFlutter
+//
+//  Agrupa utilitários para manipulação de gramáticas livres de contexto,
+//  oferecendo redução estrutural, conversão para Forma Normal de Chomsky e
+//  verificações rápidas dessa normalização. Reaproveita operações privadas para
+//  eliminar produções lambda e unitárias, além de remover símbolos inúteis,
+//  produzindo gramáticas equivalentes mais enxutas para análises subsequentes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../models/grammar.dart';
 import '../../models/production.dart';
 import '../../result.dart';

--- a/lib/core/algorithms/cfg/cyk_parser.dart
+++ b/lib/core/algorithms/cfg/cyk_parser.dart
@@ -1,3 +1,15 @@
+//
+//  cyk_parser.dart
+//  JFlutter
+//
+//  Implementa o algoritmo CYK para gramáticas em Forma Normal de Chomsky,
+//  incluindo a preparação da gramática em CNF, construção de tabela dinâmica e
+//  reconstrução opcional da derivação. Trata o caso da palavra vazia, registra
+//  apontadores de retrocesso e retorna resultados estruturados com árvore de
+//  derivação quando a sentença é aceita.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../../models/grammar.dart';
 import '../../models/production.dart';
 import '../../result.dart';

--- a/lib/core/algorithms/common/throttling.dart
+++ b/lib/core/algorithms/common/throttling.dart
@@ -1,3 +1,15 @@
+//
+//  throttling.dart
+//  JFlutter
+//
+//  Define utilitários de controle de frequência para rotinas ligadas à UI,
+//  incluindo agendamento sincronizado com frames Flutter, debounce, throttle e
+//  processamento em lotes. Complementa com heurística de orçamento temporal para
+//  estimar iterações viáveis, permitindo que algoritmos intensivos mantenham a
+//  fluidez da interface.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:async';
 import 'dart:math' as math;
 import 'package:flutter/scheduler.dart';

--- a/lib/core/algorithms/dfa_completer.dart
+++ b/lib/core/algorithms/dfa_completer.dart
@@ -1,3 +1,14 @@
+//
+//  dfa_completer.dart
+//  JFlutter
+//
+//  Fornece rotina para completar autômatos finitos determinísticos, garantindo
+//  transições definidas para todo símbolo do alfabeto a partir de cada estado.
+//  Cria estado armadilha quando necessário e copia metadados relevantes, mantendo
+//  coerência visual e temporal ao gerar um DFA plenamente definido.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 import '../models/fsa.dart';
 import '../models/state.dart';

--- a/lib/core/algorithms/dfa_minimizer.dart
+++ b/lib/core/algorithms/dfa_minimizer.dart
@@ -1,3 +1,15 @@
+//
+//  dfa_minimizer.dart
+//  JFlutter
+//
+//  Reúne a implementação completa da minimização de autômatos finitos
+//  determinísticos via algoritmo de Hopcroft, incluindo validações, remoção de
+//  estados inalcançáveis e reconstrução geométrica para preservar metadados.
+//  Fornece operações auxiliares para tratar símbolos epsilon e gerar respostas
+//  encapsuladas em objetos `Result` com mensagens claras de erro.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 import '../models/fsa.dart';
 import '../models/state.dart';

--- a/lib/core/algorithms/dfa_operations.dart
+++ b/lib/core/algorithms/dfa_operations.dart
@@ -1,3 +1,15 @@
+//
+//  dfa_operations.dart
+//  JFlutter
+//
+//  Consolida operações de alto nível sobre autômatos determinísticos, cobrindo
+//  complementação, construções de produto para união/interseção/diferença e
+//  fechamentos por prefixos e sufixos. Inclui validações detalhadas, normaliza
+//  alfabetos via completude e delega determinização quando necessário para
+//  preservar corretude formal dos resultados retornados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:collection';
 
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/core/algorithms/equivalence_checker.dart
+++ b/lib/core/algorithms/equivalence_checker.dart
@@ -1,3 +1,15 @@
+//
+//  equivalence_checker.dart
+//  JFlutter
+//
+//  Implementa verificação de equivalência entre dois autômatos finitos,
+//  normalizando alfabetos, convertendo NFAs para DFAs e completando transições
+//  antes de percorrer o produto cartesiano. Utiliza busca em largura para
+//  detectar divergências de aceitação e retorna rapidamente quando linguagens
+//  diferem.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/state.dart';
 import 'dfa_completer.dart';

--- a/lib/core/algorithms/fa_to_regex_converter.dart
+++ b/lib/core/algorithms/fa_to_regex_converter.dart
@@ -1,3 +1,15 @@
+//
+//  fa_to_regex_converter.dart
+//  JFlutter
+//
+//  Implementa o método de eliminação de estados para converter autômatos
+//  finitos em expressões regulares equivalentes. Normaliza a estrutura para
+//  possuir estados iniciais e finais únicos, valida integridade do autômato e
+//  aplica manipulações iterativas de transições para gerar a expressão
+//  resultante encapsulada em `Result`.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:vector_math/vector_math_64.dart';
 import '../models/fsa.dart';
 import '../models/state.dart';

--- a/lib/core/algorithms/fsa_to_grammar_converter.dart
+++ b/lib/core/algorithms/fsa_to_grammar_converter.dart
@@ -1,3 +1,14 @@
+//
+//  fsa_to_grammar_converter.dart
+//  JFlutter
+//
+//  Responsável por transformar autômatos finitos em gramáticas regulares,
+//  atribuindo não terminais a estados, gerando produções rotuladas pelas
+//  transições e adicionando regras lambda para estados de aceitação. Retorna
+//  objeto `Grammar` pronto para consumo em módulos de análise e conversão.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/fsa.dart';
 import '../models/grammar.dart';
 import '../models/production.dart';

--- a/lib/core/algorithms/grammar_analyzer.dart
+++ b/lib/core/algorithms/grammar_analyzer.dart
@@ -1,3 +1,15 @@
+//
+//  grammar_analyzer.dart
+//  JFlutter
+//
+//  Oferece rotinas avançadas para analisar e transformar gramáticas, incluindo
+//  remoção de recursão à esquerda, fatoração à esquerda e construção de
+//  relatórios ricos com notas, derivações e conflitos. Estruturas auxiliares
+//  encapsulam tabelas LL(1) e resultados tipados, permitindo futuras extensões
+//  de análise.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/grammar.dart';
 import '../models/production.dart';
 import '../result.dart';

--- a/lib/core/algorithms/grammar_parser.dart
+++ b/lib/core/algorithms/grammar_parser.dart
@@ -1,3 +1,14 @@
+//
+//  grammar_parser.dart
+//  JFlutter
+//
+//  Coordena estratégias de parsing para gramáticas livres de contexto, incluindo
+//  heurísticas rápidas para gramáticas de Dyck, reconhecimento geral via Earley
+//  e derivação com análise recursiva. Realiza validações de entrada, seleciona
+//  abordagens conforme dicas e encapsula resultados ricos em `ParseResult`.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import '../models/grammar.dart';
 import '../models/production.dart';
 import '../models/parse_table.dart';


### PR DESCRIPTION
## Summary
- add the standardized project header comments to the algorithm-focused Dart sources
- document each file's responsibilities within the new headers for clarity

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e5400768a4832eb493cad919ef19ae