### PR TITLE
Padroniza cabeçalhos dos testes com autoria padrão

### DIFF
--- a/test/core/services/simulation_highlight_service_test.dart
+++ b/test/core/services/simulation_highlight_service_test.dart
@@ -1,14 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/core/services/simulation_highlight_service_test.dart
-// Objetivo: Verificar a comunicação do serviço de destaque de simulação com o
-// controlador GraphView.
-// Cenários cobertos:
-// - Emissão de destaques durante a simulação passo a passo.
-// - Limpeza de destaques ao encerrar ou reiniciar.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  simulation_highlight_service_test.dart
+//  JFlutter
+//
+//  Conjunto de testes dedicado ao serviço de destaques de simulação, validando
+//  a coordenação com o GraphViewHighlightController para emitir, atualizar e
+//  limpar destaques durante execuções passo a passo e reinicializações de
+//  simulações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';

--- a/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_automaton_mapper_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_automaton_mapper_test.dart
-// Objetivo: Validar o mapeamento de autômatos para modelos GraphView usados no
-// canvas.
-// Cenários cobertos:
-// - Conversão de estados e transições em nós e arestas com posição.
-// - Tratamento de loops, transições múltiplas e estados iniciais/aceitadores.
-// - Atualização de dados ao sincronizar com GraphViewAutomatonMapper.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_automaton_mapper_test.dart
+//  JFlutter
+//
+//  Este arquivo reúne testes que asseguram a tradução de autômatos finitos em
+//  estruturas de nós e arestas compreendidas pelo GraphView, cobrindo cenários
+//  com estados iniciais, finais, transições múltiplas e sincronizações
+//  subsequentes do mapper com o canvas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_controller_test.dart
@@ -9,7 +9,7 @@
 //  estado gráfico sincronizado.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/test/features/canvas/graphview/graphview_canvas_models_test.dart
+++ b/test/features/canvas/graphview/graphview_canvas_models_test.dart
@@ -8,7 +8,7 @@
 //  entre símbolos de pilha e indicadores de transições λ.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:jflutter/features/canvas/graphview/graphview_canvas_models.dart';

--- a/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_pda_canvas_controller_test.dart
-// Objetivo: Validar o controlador GraphView específico de PDA, assegurando
-// sincronização com o provider e manipulação da pilha.
-// Cenários cobertos:
-// - Construção de grafos a partir de PDAs com transições de push/pop.
-// - Seleção e atualização de transições refletidas no editor.
-// - Descarte adequado do controlador após o uso.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_pda_canvas_controller_test.dart
+//  JFlutter
+//
+//  Este arquivo agrupa testes que garantem o comportamento do controlador de
+//  canvas para PDAs no GraphView, verificando a criação de grafos com transições
+//  push/pop, a integração com provedores e serviços simulados, além do descarte
+//  apropriado de recursos após o uso.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/features/canvas/graphview/graphview_pda_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_pda_mapper_test.dart
@@ -8,7 +8,7 @@
 //  e a atualização do grafo resultante ao sincronizar múltiplas transições.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'dart:math' as math;
 
 import 'package:test/test.dart';

--- a/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_canvas_controller_test.dart
@@ -9,7 +9,7 @@
 //  recursos associados ao controlador.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/test/features/canvas/graphview/graphview_tm_mapper_test.dart
+++ b/test/features/canvas/graphview/graphview_tm_mapper_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/features/canvas/graphview/graphview_tm_mapper_test.dart
-// Objetivo: Validar mapeamento de máquinas de Turing para estruturas GraphView
-// utilizadas no canvas.
-// Cenários cobertos:
-// - Conversão de estados, transições e direções de fita em modelos visuais.
-// - Suporte a múltiplas fitas e símbolos de leitura/escrita.
-// - Ajuste de nós e controle de curvas em representações gráficas.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  graphview_tm_mapper_test.dart
+//  JFlutter
+//
+//  Este conjunto de testes garante que máquinas de Turing sejam convertidas em
+//  estruturas do GraphView com estados, transições, direções de fita e múltiplas
+//  fitas corretamente interpretadas para o canvas, incluindo ajustes de curvas e
+//  posicionamento para manter a legibilidade visual.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/integration/io/examples_roundtrip_test.dart
+++ b/test/integration/io/examples_roundtrip_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/examples_roundtrip_test.dart
-// Objetivo: Exercitar round-trips de exemplos canônicos passando por assets,
-// serviços de serialização e exportação.
-// Cenários cobertos:
-// - Conversão de autômatos, gramáticas e MTs entre entidades e arquivos.
-// - Exportação SVG e validação de estruturas serializadas.
-// - Verificação de consistência dos metadados da biblioteca Examples.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  examples_roundtrip_test.dart
+//  JFlutter
+//
+//  Esta suíte de integração valida o fluxo completo de ida e volta dos exemplos
+//  embarcados, atravessando carregamento de assets, serialização, exportação e
+//  leitura de arquivos para garantir consistência entre entidades, metadados e
+//  representações gráficas em SVG.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/integration/io/interoperability_roundtrip_test.dart
+++ b/test/integration/io/interoperability_roundtrip_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/interoperability_roundtrip_test.dart
-// Objetivo: Validar interoperabilidade entre formatos `.jff`, JSON e SVG,
-// garantindo round-trip sem perda.
-// Cenários cobertos:
-// - Conversões JFLAP↔modelos internos usando parser XML dedicado.
-// - Serialização JSON de autômatos, gramáticas e MTs.
-// - Exportação SVG para visualização preservando elementos-chave.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  interoperability_roundtrip_test.dart
+//  JFlutter
+//
+//  Os testes aqui descritos asseguram a interoperabilidade entre arquivos JFLAP
+//  (`.jff`), representações JSON e exportações SVG, cobrindo conversões de ida e
+//  volta para autômatos, gramáticas e máquinas de Turing sem perda de
+//  informações ou metadados relevantes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/widget/presentation/mobile_automaton_controls_test.dart
+++ b/test/widget/presentation/mobile_automaton_controls_test.dart
@@ -10,7 +10,7 @@
 //  configurações.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/test/widget/presentation/pda_canvas_graphview_test.dart
+++ b/test/widget/presentation/pda_canvas_graphview_test.dart
@@ -9,7 +9,7 @@
 //  descarte correto de recursos após cada execução.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/test/widget/presentation/tm_canvas_graphview_test.dart
+++ b/test/widget/presentation/tm_canvas_graphview_test.dart
@@ -9,7 +9,7 @@
 //  descarte apropriado do controlador ao término de cada cenário.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';

--- a/test/widget/presentation/ux_error_handling_test.dart
+++ b/test/widget/presentation/ux_error_handling_test.dart
@@ -9,7 +9,7 @@
 //  que o estado visual reaja às interações do usuário em sequências completas.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 void main() {

--- a/test/widget/presentation/visualizations_test.dart
+++ b/test/widget/presentation/visualizations_test.dart
@@ -8,7 +8,7 @@
 //  garantir que a lacuna permaneça visível na matriz de testes.
 //
 //  Thales Matheus Mendonça Santos - October 2025
-
+//
 import 'package:flutter_test/flutter_test.dart';
 
 // Placeholder failing widget/golden tests para Phase 3.2 T010.


### PR DESCRIPTION
## Summary
- Atualiza os testes do GraphView para usar o novo cabeçalho padronizado com resumo em português e autoria de Thales Matheus Mendonça Santos.
- Acompanha o mesmo padrão nos testes de integração e widgets relacionados para manter consistência em toda a suíte.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e543efdc5c832ea0997a9bccc3fadb