### PR TITLE
Add standardized headers to core domain modules

### DIFF
--- a/lib/core/algorithms.dart
+++ b/lib/core/algorithms.dart
@@ -1,3 +1,15 @@
+//
+//  algorithms.dart
+//  JFlutter
+//
+//  Agrupa em um único ponto todas as operações algorítmicas disponíveis no
+//  núcleo, indo de simuladores a conversores e minimizadores utilizados pelas
+//  funcionalidades principais. Simplifica os imports para camadas externas que
+//  precisam acessar a suíte completa de algoritmos formais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 // Re-export all algorithm operations
 export 'algorithms/algorithm_operations.dart';
 export 'algorithms/automaton_simulator.dart';

--- a/lib/core/algorithms/grammar_parser_simple_recursive.dart
+++ b/lib/core/algorithms/grammar_parser_simple_recursive.dart
@@ -1,3 +1,15 @@
+//
+//  grammar_parser_simple_recursive.dart
+//  JFlutter
+//
+//  Fornece um analisador sintático recursivo simples para gramáticas livres de
+//  contexto, validando entradas e produzindo derivações passo a passo quando a
+//  palavra pertence à linguagem. Complementa outros parsers ao oferecer uma
+//  opção mais direta para testes e demonstrações.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import '../models/grammar.dart';
 import '../models/production.dart';
 import '../result.dart' as jflutter_result;

--- a/lib/core/algorithms/grammar_to_fsa_converter.dart
+++ b/lib/core/algorithms/grammar_to_fsa_converter.dart
@@ -1,3 +1,15 @@
+//
+//  grammar_to_fsa_converter.dart
+//  JFlutter
+//
+//  Converte gramáticas lineares à direita em autômatos finitos equivalentes,
+//  validando restrições das produções e gerando estados com posicionamento
+//  calculado. Cria transições consistentes, estados finais quando necessário e
+//  retorna resultados padronizados com mensagens de erro amigáveis.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import 'dart:math' as math;
 
 import 'package:vector_math/vector_math_64.dart';

--- a/lib/core/algorithms/pumping_lemma_game.dart
+++ b/lib/core/algorithms/pumping_lemma_game.dart
@@ -1,3 +1,16 @@
+//
+//  pumping_lemma_game.dart
+//  JFlutter
+//
+//  Implementa o jogo interativo do lema do bombeamento para linguagens
+//  regulares, cuidando de validações, geração de desafios e acompanhamento de
+//  tentativas dos usuários. Coordena cálculos de comprimento de bombeamento,
+//  simulações de cadeias e pontuação para guiar a experiência educativa no
+//  aplicativo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import '../models/fsa.dart';
 import '../models/state.dart';
 import '../models/pumping_lemma_game.dart' as models;

--- a/lib/core/algorithms/regex_to_nfa_converter.dart
+++ b/lib/core/algorithms/regex_to_nfa_converter.dart
@@ -1,3 +1,15 @@
+//
+//  regex_to_nfa_converter.dart
+//  JFlutter
+//
+//  Converte expressões regulares em autômatos finitos não determinísticos
+//  aplicando construções de Thompson, validações e geração de identificadores
+//  únicos. Expõe utilitários para analisar a expressão, criar estados e
+//  transições e relatar erros detalhados quando a entrada é inválida.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import 'dart:math' as math;
 import 'package:vector_math/vector_math_64.dart';
 import '../models/fsa.dart';

--- a/lib/core/algorithms/tm_simulator.dart
+++ b/lib/core/algorithms/tm_simulator.dart
@@ -1,3 +1,15 @@
+//
+//  tm_simulator.dart
+//  JFlutter
+//
+//  Entrega a lógica de simulação para máquinas de Turing determinísticas e não
+//  determinísticas, abrangendo validações, execução passo a passo e métricas de
+//  análise. Gerencia configurações exploradas, movimentação de fita e detecção
+//  de condições de aceitação ou rejeição.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import '../models/fsa_transition.dart';
 import '../models/simulation_step.dart';
 import '../models/state.dart';

--- a/lib/core/automaton.dart
+++ b/lib/core/automaton.dart
@@ -1,2 +1,14 @@
+//
+//  automaton.dart
+//  JFlutter
+//
+//  Oferece uma fachada mínima que reexporta o modelo de autômato central,
+//  permitindo que módulos externos criem e manipulem autômatos sem navegar pela
+//  estrutura detalhada de arquivos. Ajuda a manter o encapsulamento da camada
+//  de modelos do núcleo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 // Re-export the automaton model
 export 'models/automaton.dart';

--- a/lib/core/entities/automaton_entity.dart
+++ b/lib/core/entities/automaton_entity.dart
@@ -1,3 +1,15 @@
+//
+//  automaton_entity.dart
+//  JFlutter
+//
+//  Define a entidade de domínio que representa autômatos no núcleo, descrevendo
+//  estados, transições, alfabeto e metadados utilizados em operações
+//  persistentes e de simulação. Inclui estruturas auxiliares como estados e
+//  enumeradores de tipos para garantir consistência entre camadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 /// Core domain entity representing an automaton
 /// This is the central business entity that all other layers depend on
 class AutomatonEntity {

--- a/lib/core/entities/turing_machine_entity.dart
+++ b/lib/core/entities/turing_machine_entity.dart
@@ -1,3 +1,15 @@
+//
+//  turing_machine_entity.dart
+//  JFlutter
+//
+//  Modela a entidade de domínio para máquinas de Turing, abrangendo alfabetos,
+//  estados, transições e atributos de aceitação necessários para análises
+//  formais. Fornece coleções e utilidades de acesso que sustentam simuladores e
+//  repositórios especializados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 /// Core domain entity representing a Turing machine
 class TuringMachineEntity {
   final String id;

--- a/lib/core/equivalence_checking.dart
+++ b/lib/core/equivalence_checking.dart
@@ -1,2 +1,14 @@
+//
+//  equivalence_checking.dart
+//  JFlutter
+//
+//  Reúne as exportações das rotinas de verificação de equivalência entre
+//  autômatos, permitindo importar simuladores e comparadores a partir de um
+//  único ponto da camada de domínio. Atua como fachada leve para os módulos que
+//  testam se construções distintas reconhecem o mesmo conjunto de palavras.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 // Re-export equivalence checking algorithms
 export 'algorithms/automaton_simulator.dart';

--- a/lib/core/grammar.dart
+++ b/lib/core/grammar.dart
@@ -1,3 +1,15 @@
+//
+//  grammar.dart
+//  JFlutter
+//
+//  Centraliza as exportações relacionadas a gramáticas formais, reunindo
+//  modelos, conversores e analisadores necessários para manipular GLCs dentro
+//  do núcleo da aplicação. Facilita o consumo desses componentes pelas camadas
+//  superiores sem depender de caminhos internos detalhados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 // Re-export grammar-related models and algorithms
 export 'models/grammar.dart';
 export 'algorithms/grammar_parser.dart';

--- a/lib/core/regex.dart
+++ b/lib/core/regex.dart
@@ -1,3 +1,15 @@
+//
+//  regex.dart
+//  JFlutter
+//
+//  Reúne utilidades de expressões regulares ao exportar conversores e o
+//  pipeline de análise responsável por transformá-las em autômatos
+//  equivalentes. Viabiliza que widgets e serviços consumam essas operações com
+//  um único import sem acoplamento adicional.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 // Re-export regex-related algorithms
 export 'algorithms/regex_to_nfa_converter.dart';
 export 'algorithms/fa_to_regex_converter.dart';

--- a/lib/core/repositories/automaton_repository.dart
+++ b/lib/core/repositories/automaton_repository.dart
@@ -1,3 +1,15 @@
+//
+//  automaton_repository.dart
+//  JFlutter
+//
+//  Declara contratos de repositório responsáveis por persistir autômatos,
+//  executar algoritmos formais e distribuir exemplos utilizados pela aplicação.
+//  Estrutura também interfaces de layout e entidades auxiliares que orientam
+//  implementações concretas nas camadas de dados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import '../entities/automaton_entity.dart';
 import '../result.dart';
 import '../models/simulation_result.dart';

--- a/lib/core/repositories/settings_repository.dart
+++ b/lib/core/repositories/settings_repository.dart
@@ -1,3 +1,15 @@
+//
+//  settings_repository.dart
+//  JFlutter
+//
+//  Define a interface de acesso às configurações salvas do usuário,
+//  padronizando como preferências são carregadas e persistidas entre sessões.
+//  Serve como ponto de extensão para provedores concretos de armazenamento
+//  local ou remoto.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 import '../models/settings_model.dart';
 
 /// Repository contract for persisting and retrieving user settings.

--- a/lib/core/run.dart
+++ b/lib/core/run.dart
@@ -1,3 +1,15 @@
+//
+//  run.dart
+//  JFlutter
+//
+//  Disponibiliza reexportações focadas em execução e simulação de autômatos,
+//  PDAs e máquinas de Turing para que consumidores externos acionem rotinas de
+//  processamento sem conhecer a organização interna. Funciona como atalho
+//  semântico para cenários de execução unificada no app.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
+
 // Re-export simulation and running algorithms
 export 'algorithms/automaton_simulator.dart';
 export 'algorithms/pda_simulator.dart';


### PR DESCRIPTION
## Summary
- add the required project header block to core export entrypoints
- document domain entities and repository contracts with the standardized metadata
- describe major algorithm implementations with the mandated Portuguese summaries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e543efdc5c832ea0997a9bccc3fadb