### PR TITLE
Padronizar cabeçalhos de testes Dart (lote 1)

### DIFF
--- a/test/core/services/simulation_highlight_service_test.dart
+++ b/test/core/services/simulation_highlight_service_test.dart
@@ -1,14 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/core/services/simulation_highlight_service_test.dart
-// Objetivo: Verificar a comunicação do serviço de destaque de simulação com o
-// controlador GraphView.
-// Cenários cobertos:
-// - Emissão de destaques durante a simulação passo a passo.
-// - Limpeza de destaques ao encerrar ou reiniciar.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  simulation_highlight_service_test.dart
+//  JFlutter
+//
+//  Testes que exercitam o SimulationHighlightService, certificando a emissão de
+//  destaques durante a simulação passo a passo e a limpeza adequada por meio do
+//  canal GraphView ao finalizar ou reiniciar execuções no canvas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/simulation_highlight.dart';

--- a/test/integration/io/examples_roundtrip_test.dart
+++ b/test/integration/io/examples_roundtrip_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/examples_roundtrip_test.dart
-// Objetivo: Exercitar round-trips de exemplos canônicos passando por assets,
-// serviços de serialização e exportação.
-// Cenários cobertos:
-// - Conversão de autômatos, gramáticas e MTs entre entidades e arquivos.
-// - Exportação SVG e validação de estruturas serializadas.
-// - Verificação de consistência dos metadados da biblioteca Examples.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  examples_roundtrip_test.dart
+//  JFlutter
+//
+//  Testes de integração que percorrem os exemplos oficiais do projeto, passando
+//  pelos assets, serviços de serialização e exportação para validar round-trips
+//  completos de autômatos, gramáticas e máquinas de Turing, inclusive conferindo
+//  metadados publicados pela biblioteca Examples.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/integration/io/interoperability_roundtrip_test.dart
+++ b/test/integration/io/interoperability_roundtrip_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/integration/io/interoperability_roundtrip_test.dart
-// Objetivo: Validar interoperabilidade entre formatos `.jff`, JSON e SVG,
-// garantindo round-trip sem perda.
-// Cenários cobertos:
-// - Conversões JFLAP↔modelos internos usando parser XML dedicado.
-// - Serialização JSON de autômatos, gramáticas e MTs.
-// - Exportação SVG para visualização preservando elementos-chave.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  interoperability_roundtrip_test.dart
+//  JFlutter
+//
+//  Testes de integração que verificam a interoperabilidade entre os formatos
+//  JFLAP (.jff), JSON e SVG, assegurando round-trip completo dos modelos de
+//  autômatos, gramáticas e máquinas de Turing, com foco em integridade de dados
+//  e preservação visual na exportação.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'dart:convert';

--- a/test/unit/core/algorithms/pda_to_cfg_converter_test.dart
+++ b/test/unit/core/algorithms/pda_to_cfg_converter_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/algorithms/pda_to_cfg_converter_test.dart
-// Objetivo: Verificar a conversão de PDAs para gramáticas livres de contexto,
-// assegurando preservação da linguagem reconhecida.
-// Cenários cobertos:
-// - Construção de produções a partir de transições de empilha/desempilha.
-// - Geração de regras iniciais com estados intermediários e terminais.
-// - Tratamento de autômatos inválidos com feedback de erro estruturado.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  pda_to_cfg_converter_test.dart
+//  JFlutter
+//
+//  Conjunto de testes que confirma a conversão de autômatos de pilha em
+//  gramáticas livres de contexto, cobrindo a derivação de produções a partir
+//  de transições, a montagem de regras iniciais com estados intermediários e a
+//  sinalização de erros quando o autômato de origem é inválido.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/unit/core/cfg/cfg_toolkit_test.dart
+++ b/test/unit/core/cfg/cfg_toolkit_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/cfg/cfg_toolkit_test.dart
-// Objetivo: Validar o toolkit de GLC do JFlutter cobrindo normalizações e
-// verificações estruturais essenciais.
-// Cenários cobertos:
-// - Remoção de produções ε, unitárias e símbolos inúteis.
-// - Conversão para Forma Normal de Chomsky e checagem de validade.
-// - Garantia de preservação da linguagem ao aplicar transformações sucessivas.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  cfg_toolkit_test.dart
+//  JFlutter
+//
+//  Bateria de testes que valida o toolkit de gramáticas livres de contexto,
+//  cobrindo remoção de produções λ e unitárias, eliminação de símbolos inúteis,
+//  conversão para Forma Normal de Chomsky e verificação da preservação da
+//  linguagem após transformações sequenciais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/cfg/cfg_toolkit.dart';

--- a/test/unit/core/pda/pda_simulator_test.dart
+++ b/test/unit/core/pda/pda_simulator_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/pda/pda_simulator_test.dart
-// Objetivo: Avaliar o simulador interno de autômatos de pilha com variações de
-// critérios de aceitação e manipulação de pilha em diferentes linguagens.
-// Cenários cobertos:
-// - Aceitação por estado final e por pilha vazia com símbolos iniciais.
-// - Balanceamento de parênteses e controle de contagem através de push/pop.
-// - Rejeições em entradas inválidas e caminhos não determinísticos.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  pda_simulator_test.dart
+//  JFlutter
+//
+//  Testes que avaliam o simulador de autômatos de pilha, cobrindo aceitação por
+//  estado final e por pilha vazia, manipulação de símbolos iniciais e uso de
+//  operações push/pop para balanceamento de linguagens clássicas, além do
+//  tratamento de rejeições e ramos não determinísticos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/pda_simulator.dart';

--- a/test/unit/core/regex/regex_pipeline_test.dart
+++ b/test/unit/core/regex/regex_pipeline_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/regex/regex_pipeline_test.dart
-// Objetivo: Validar o pipeline Regex→AST→AFN (Thompson) assegurando geração e
-// simulação coerentes com operações do automato.
-// Cenários cobertos:
-// - Construção de AFNs para literais, concatenação, união e estrela de Kleene.
-// - Agrupamentos, operadores opcionais e precedência correta na árvore sintática.
-// - Rejeição de expressões inválidas e propagação de erros do parser.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  regex_pipeline_test.dart
+//  JFlutter
+//
+//  Testes que validam o pipeline de expressões regulares até a construção de
+//  autômatos finitos não determinísticos, avaliando literais, concatenação,
+//  união, estrela de Kleene e operadores opcionais, além de assegurar o
+//  tratamento adequado de entradas inválidas pelo parser.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/algorithm_operations.dart';

--- a/test/unit/core/tm/tm_simulator_test.dart
+++ b/test/unit/core/tm/tm_simulator_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/core/tm/tm_simulator_test.dart
-// Objetivo: Exercitar o simulador interno de máquinas de Turing com cenários
-// determinísticos e não determinísticos, incluindo múltiplas fitas.
-// Cenários cobertos:
-// - Máquinas determinísticas que expandem cadeias unárias e reconhecem padrões.
-// - Construções não determinísticas com ramos concorrentes e rejeição.
-// - Operações multi-fita com movimentação independente e sincronização.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  tm_simulator_test.dart
+//  JFlutter
+//
+//  Testes abrangentes para o simulador de máquinas de Turing, incluindo cenários
+//  determinísticos, alternativas não determinísticas e configurações com múltiplas
+//  fitas, avaliando aceitação, rejeição e comportamento das transições no tempo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/algorithms/tm_simulator.dart';

--- a/test/unit/data/examples_asset_data_source_test.dart
+++ b/test/unit/data/examples_asset_data_source_test.dart
@@ -1,16 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/examples_asset_data_source_test.dart
-// Objetivo: Garantir a integridade das fixtures JSON de "Examples v1" ao
-// validar metadados, estruturas e round-trips necessários para o consumo no
-// aplicativo.
-// Cenários cobertos:
-// - Carregamento de arquivos de exemplo e validação do formato JSON esperado.
-// - Garantia de metadados obrigatórios para categorias, dificuldade e tags.
-// - Verificação de consistência entre metadados declarados e conteúdo serializado.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  examples_asset_data_source_test.dart
+//  JFlutter
+//
+//  Conjunto de testes que inspeciona as fixtures JSON de ExamplesAssetDataSource,
+//  assegurando a presença de metadados obrigatórios, a estrutura esperada para
+//  cada categoria e a coerência entre os arquivos de exemplo e suas descrições
+//  utilizadas pelo aplicativo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:convert';
 import 'dart:io';

--- a/test/unit/data/import_export_validation_test.dart
+++ b/test/unit/data/import_export_validation_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/import_export_validation_test.dart
-// Objetivo: Validar os fluxos de importação e exportação garantindo round-trip
-// consistente entre o modelo interno de AFD e os formatos JFLAP/JSON/SVG.
-// Cenários cobertos:
-// - Reconstrução fiel de autômatos após serialização JFLAP.
-// - Conversão JSON preservando estados, transições e alfabetos.
-// - Exportação SVG com feedback de sucesso e métricas de estrutura.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  import_export_validation_test.dart
+//  JFlutter
+//
+//  Conjunto de testes que valida os fluxos de importação e exportação do
+//  serviço dedicado, garantindo round-trip consistente entre o modelo interno
+//  de autômatos e os formatos JFLAP e JSON, além de verificar a geração de SVG
+//  e o tratamento adequado de cenários de erro.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:vector_math/vector_math_64.dart';

--- a/test/unit/data/services/examples_library_stats_test.dart
+++ b/test/unit/data/services/examples_library_stats_test.dart
@@ -1,14 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/services/examples_library_stats_test.dart
-// Objetivo: Verificar a formatação segura de `ExamplesLibraryStats` garantindo
-// descrições coerentes mesmo com coleções vazias ou parciais.
-// Cenários cobertos:
-// - Representação textual de estatísticas vazias sem lançar exceções.
-// - Agregação de totais e rótulos quando apenas parte dos mapas está preenchida.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  examples_library_stats_test.dart
+//  JFlutter
+//
+//  Testes unitários que verificam a formatação segura de ExamplesLibraryStats,
+//  assegurando descrições consistentes para coleções vazias ou parciais, bem
+//  como a agregação correta de totais, categorias e etiquetas mais frequentes.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';

--- a/test/unit/data/services/import_export_validation_test.dart
+++ b/test/unit/data/services/import_export_validation_test.dart
@@ -1,16 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/services/import_export_validation_test.dart
-// Objetivo: Assegurar que o serviço de validação de importação/exportação
-// identifique inconsistências estruturais e rejeite autômatos inválidos antes
-// da serialização.
-// Cenários cobertos:
-// - Construção de autômato válido com estados e transições consistentes.
-// - Detecção de laços, símbolos ausentes e estados inválidos durante a validação.
-// - Consolidação de relatórios de erro para múltiplas violações.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  import_export_validation_test.dart
+//  JFlutter
+//
+//  Suite de testes que exercita o ImportExportValidationService, garantindo que
+//  autômatos válidos sejam aceitos, que inconsistências estruturais sejam
+//  identificadas antes da serialização e que relatórios de erro agreguem todas
+//  as violações detectadas em diferentes cenários.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/unit/data/settings_repository_impl_test.dart
+++ b/test/unit/data/settings_repository_impl_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/data/settings_repository_impl_test.dart
-// Objetivo: Confirmar que o repositório de configurações elimina chaves
-// legadas relacionadas ao canvas Draw2D ao carregar ou salvar preferências.
-// Cenários cobertos:
-// - Limpeza da flag `settings_use_draw2d_canvas` durante o carregamento das
-//   configurações.
-// - Remoção do mesmo sinalizador ao persistir novas preferências.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  settings_repository_impl_test.dart
+//  JFlutter
+//
+//  Testes que confirmam a limpeza de chaves legadas pelo SharedPreferencesSettingsRepository,
+//  removendo o uso antigo do canvas Draw2D tanto ao carregar quanto ao salvar
+//  preferências e garantindo que o armazenamento permaneça consistente.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/models/settings_model.dart';

--- a/test/unit/presentation/pumping_lemma_game_test.dart
+++ b/test/unit/presentation/pumping_lemma_game_test.dart
@@ -1,15 +1,13 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/presentation/pumping_lemma_game_test.dart
-// Objetivo: Validar o fluxo do modo jogo do lema do bombeamento, garantindo
-// progressão linear e registro de pontuação.
-// Cenários cobertos:
-// - Estado inicial sem desafios e contadores zerados.
-// - Registro de respostas corretas/incorretas com atualização de métricas.
-// - Reinício de jogo e descarte de recursos do provider.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  pumping_lemma_game_test.dart
+//  JFlutter
+//
+//  Testes do modo jogo do lema do bombeamento, garantindo inicialização limpa,
+//  progressão linear pelos desafios, registro de respostas corretas e incorretas
+//  com atualização de pontuação e a liberação adequada de recursos ao reiniciar.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/unit/presentation/transition_label_updates_test.dart
+++ b/test/unit/presentation/transition_label_updates_test.dart
@@ -1,15 +1,14 @@
-// ============================================================================
-// JFlutter - Suite de Testes
-// ----------------------------------------------------------------------------
-// Arquivo: test/unit/presentation/transition_label_updates_test.dart
-// Objetivo: Garantir que provedores de edição atualizem rótulos de transições
-// de forma consistente entre autômatos finitos, PDAs e MTs.
-// Cenários cobertos:
-// - Atualização de rótulo e conjunto de símbolos em autômatos finitos.
-// - Sincronização de campos de pilha em transições de PDA.
-// - Ajustes de leitura, escrita e direção em transições de MT.
-// Autoria: Equipe de Qualidade JFlutter.
-// ============================================================================
+//
+//  transition_label_updates_test.dart
+//  JFlutter
+//
+//  Testes voltados aos providers de edição de transições, assegurando que
+//  autômatos finitos, PDAs e máquinas de Turing recebam atualizações consistentes
+//  de rótulos, símbolos e parâmetros específicos de cada modelo durante as
+//  operações de edição em tempo real.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 


### PR DESCRIPTION
## Summary
- aplicar o cabeçalho padronizado aos primeiros 15 arquivos de teste Dart fora de References
- substituir comentários antigos por resumos em português destacando o propósito de cada suíte

## Testing
- não executado (não solicitado)

------
https://chatgpt.com/codex/tasks/task_e_68e543efdc5c832ea0997a9bccc3fadb