### PR TITLE
presentation: standardize dart file headers

### DIFF
--- a/lib/presentation/providers/home_navigation_provider.dart
+++ b/lib/presentation/providers/home_navigation_provider.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/home_navigation_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Define o estado de navegação entre os espaços de trabalho principais exibidos na página inicial. Mapeia índices simbólicos para cada módulo de teoria de autômatos disponível na aplicação.
-/// Contexto: Utiliza um StateNotifier simples para permitir que widgets mudem a aba ativa de forma reativa. Centraliza constantes de navegação garantindo consistência entre botões, menus e rotas internas.
-/// Observações: Oferece atalhos legíveis para alternar rapidamente entre editores específicos. Pode ser estendido com novos índices sem impactar consumidores que apenas observam o estado inteiro.
-/// ---------------------------------------------------------------------------
+//
+//  home_navigation_provider.dart
+//  JFlutter
+//
+//  Controla a navegação principal da HomePage utilizando um StateNotifier que
+//  mapeia índices simbólicos para os espaços de trabalho de autômatos,
+//  gramáticas, PDAs, máquinas de Turing, expressões regulares e o jogo do Lema
+//  do Bombeamento, permitindo alternância reativa entre módulos.
+//  Centraliza constantes de índices e expõe helpers de troca para que widgets
+//  mudem o workspace ativo de forma consistente em toda a interface.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 /// Controls navigation between the major workspaces displayed on the home page.

--- a/lib/presentation/providers/pumping_lemma_progress_provider.dart
+++ b/lib/presentation/providers/pumping_lemma_progress_provider.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/providers/pumping_lemma_progress_provider.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Mantém o histórico de desafios e estatísticas do jogo do Lema do Bombeamento. Modela tentativas, replays e pontuação para alimentar os painéis pedagógicos.
-/// Contexto: Implementa um StateNotifier imutável que registra interações relevantes como respostas e reinícios. Facilita a sincronização entre widgets do jogo fornecendo métricas agregadas e logs cronológicos.
-/// Observações: Expõe fábricas de entrada para simplificar a criação de registros e operações de reset. Permite que componentes verifiquem conquistas e progresso sem acessar diretamente fontes externas.
-/// ---------------------------------------------------------------------------
+//
+//  pumping_lemma_progress_provider.dart
+//  JFlutter
+//
+//  Organiza o estado imutável do jogo do Lema do Bombeamento, registrando
+//  desafios disponíveis, tentativas, pontuação e o histórico cronológico de
+//  interações do usuário para alimentar painéis pedagógicos e estatísticas.
+//  Expõe um StateNotifier com fábricas de eventos e operações para iniciar,
+//  reiniciar e acompanhar desafios, garantindo que widgets sincronizem métricas
+//  consistentes sem acessar fontes externas diretamente.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/algorithm_panel.dart
+++ b/lib/presentation/widgets/algorithm_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/algorithm_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Consolida comandos de algoritmos para autômatos finitos como conversões, operações de linguagem e equivalência. Integra entradas de expressão regular, seleção de automatos externos e feedback passo a passo.
-/// Contexto: Utiliza serviços de arquivos para importar modelos adicionais e chama callbacks fornecidos pelos provedores para executar os algoritmos. Apresenta controles agrupados e indicadores de progresso para acompanhar execuções longas.
-/// Observações: Gerencia estado interno de execução incluindo mensagens e etapas registradas pelo AlgorithmOperations. Estrutura modular facilita a ativação seletiva de funcionalidades conforme cada página precisa.
-/// ---------------------------------------------------------------------------
+//
+//  algorithm_panel.dart
+//  JFlutter
+//
+//  Consolida os comandos de algoritmos aplicáveis aos autômatos finitos,
+//  reunindo conversões NFA→DFA, minimização, complementação, operações de
+//  linguagem e transformações com expressões regulares em um painel único.
+//  Controla progresso, feedback textual e carregamento de autômatos externos via
+//  FilePicker, executando callbacks fornecidos pela camada de apresentação para
+//  orquestrar AlgorithmOperations.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import '../../core/models/fsa.dart';

--- a/lib/presentation/widgets/automaton_canvas.dart
+++ b/lib/presentation/widgets/automaton_canvas.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/automaton_canvas.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Redireciona para o canvas unificado baseado em GraphView garantindo interface consistente para importações legadas. Fornece typedef amigável para manter nomenclaturas utilizadas anteriormente no projeto.
-/// Contexto: Funciona como ponto de entrada simplificado permitindo alternar implementações sem atualizar consumidores espalhados. Mantém compatibilidade ao reexportar o widget principal com escopo controlado.
-/// Observações: Estrutura mínima facilita futuras adaptações específicas por plataforma. Documentação clara auxilia desenvolvedores na transição para a nova infraestrutura de canvas.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_canvas.dart
+//  JFlutter
+//
+//  Age como fachada para o canvas unificado baseado em GraphView, mantendo
+//  compatibilidade com importações legadas e permitindo a substituição do
+//  widget principal sem tocar consumidores espalhados pelo projeto.
+//  Reexporta AutomatonGraphViewCanvas com um typedef amigável para preservar
+//  nomenclaturas antigas enquanto concentra futuras personalizações em um único
+//  ponto de entrada.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'automaton_graphview_canvas.dart';
 
 export 'automaton_graphview_canvas.dart' show AutomatonGraphViewCanvas;

--- a/lib/presentation/widgets/automaton_graphview_canvas.dart
+++ b/lib/presentation/widgets/automaton_graphview_canvas.dart
@@ -1,11 +1,17 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/automaton_graphview_canvas.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Implementa canvas interativo baseado em GraphView para edição e visualização de autômatos finitos. Administra ferramentas, destaques de simulação e sincronização com provedores Riverpod garantindo experiência fluida.
-/// Contexto: Coordena controladores internos e externos para manipular nós, transições e overlays de rótulos, além de emitir atualizações para o AutomatonProvider. Incorpora algoritmos de layout e integrações com serviços de destaque para acompanhar execuções.
-/// Observações: Gerencia gestos complexos, estados de arrasto e atualizações diferidas para manter desempenho em autômatos grandes. Estrutura lógica extensível permitindo adicionar novas ferramentas ou interações sem refatorações profundas.
-/// ---------------------------------------------------------------------------
+//
+//  automaton_graphview_canvas.dart
+//  JFlutter
+//
+//  Implementa o canvas interativo baseado em GraphView responsável por editar e
+//  visualizar autômatos nos diferentes modos do aplicativo, coordenando
+//  ferramentas, arrastos de estados, criação de transições e emissão de destaques
+//  durante simulações.
+//  Orquestra controladores especializados para FSA, PDA e TM, integra editores de
+//  rótulos, sobreposições contextuais e sincronização com providers Riverpod para
+//  manter o modelo consistente mesmo em autômatos de grande porte.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'dart:math' as math;
 
 import 'package:collection/collection.dart';

--- a/lib/presentation/widgets/canvas_actions_sheet.dart
+++ b/lib/presentation/widgets/canvas_actions_sheet.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/canvas_actions_sheet.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Exibe folha de ações contextuais para o canvas permitindo criar estados e ajustar enquadramento rapidamente. Aplica feedback háptico e navegação consistente ao interagir com as opções.
-/// Contexto: Foi projetado para ser chamado por gestos no canvas, oferecendo atalhos para adicionar nós, ajustar zoom ao conteúdo e resetar a visão. Utiliza ModalBottomSheet para manter linguagem visual do Material Design.
-/// Observações: Ajusta habilitação de ações conforme a área selecionada evitando duplicidades no grafo. Pode ser estendido com novos itens preservando a estrutura existente de callbacks e feedbacks.
-/// ---------------------------------------------------------------------------
+//
+//  canvas_actions_sheet.dart
+//  JFlutter
+//
+//  Exibe a folha de ações contextuais do canvas de autômatos, oferecendo atalhos
+//  para adicionar estados, ajustar o enquadramento ao conteúdo e redefinir a
+//  visualização com feedback háptico consistente.
+//  Projetado para ser acionado por gestos de contexto, utiliza
+//  showModalBottomSheet para preservar a linguagem Material e habilita opções de
+//  forma dinâmica conforme a posição escolhida no grafo.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 

--- a/lib/presentation/widgets/diagnostics_panel.dart
+++ b/lib/presentation/widgets/diagnostics_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/diagnostics_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Apresenta mensagens de diagnóstico sobre autômatos com ações de atualização e feedback visual. Fornece resumo quando não há problemas e detalha sugestões acionáveis quando disponíveis.
-/// Contexto: Consome instâncias de DiagnosticMessage geradas pelo domínio para auxiliar estudantes na correção de modelos. Estrutura uma lista expansível que evidencia severidade e orienta correções passo a passo.
-/// Observações: Permite incorporar controle de recarregamento opcional com indicador de progresso embutido. Pode ser reutilizado em diferentes páginas mantendo consistência na comunicação de erros e alertas.
-/// ---------------------------------------------------------------------------
+//
+//  diagnostics_panel.dart
+//  JFlutter
+//
+//  Materializa o painel de diagnósticos dos autômatos exibindo mensagens,
+//  severidades e sugestões acionáveis em cartões expansíveis com opção de
+//  recarregar análises.
+//  Consome DiagnosticMessage gerados pelo núcleo para orientar estudantes na
+//  correção de modelos, diferenciando estados sem problemas de listas de alertas
+//  com indicadores visuais claros.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import '../../core/services/diagnostics_service.dart';
 

--- a/lib/presentation/widgets/grammar_editor.dart
+++ b/lib/presentation/widgets/grammar_editor.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/grammar_editor.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Disponibiliza editor completo de gramáticas com suporte a criação, edição e listagem de produções. Integra campos reativos, ações rápidas e validações para facilitar a modelagem de linguagens formais.
-/// Contexto: Conecta-se ao GrammarProvider para refletir alterações de estado e executar comandos como limpar regras ou iniciar conversões. Estrutura layouts responsivos adaptados a telas móveis e desktops mantendo a usabilidade.
-/// Observações: Gerencia controladores de texto e seleção de produções garantindo consistência ao alternar entre modos de edição. Pode ser combinado com painéis de conversão e simulação graças à sua comunicação via Riverpod.
-/// ---------------------------------------------------------------------------
+//
+//  grammar_editor.dart
+//  JFlutter
+//
+//  Disponibiliza o editor completo de gramáticas formais com formulários para
+//  símbolos iniciais, produções e metadados, oferecendo validações rápidas e
+//  ações de limpeza para acelerar a modelagem de linguagens.
+//  Sincroniza-se com o GrammarProvider via Riverpod para refletir atualizações em
+//  tempo real e ajustar layouts responsivos que atendem tanto a telas móveis
+//  quanto desktops.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../../core/models/production.dart';

--- a/lib/presentation/widgets/graphview_canvas_toolbar.dart
+++ b/lib/presentation/widgets/graphview_canvas_toolbar.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/graphview_canvas_toolbar.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Implementa a barra de ferramentas que controla o canvas baseado em GraphView, fornecendo atalhos de edição e navegação. Permite selecionar ferramentas, adicionar elementos e ajustar a visualização do grafo.
-/// Contexto: Comunica-se diretamente com o controlador do canvas para executar ações como desfazer, refit e reset de viewport. Expõe ganchos opcionais para botões de transição, limpeza e mensagens de status adaptando-se a layouts desktop ou mobile.
-/// Observações: Gerencia escuta de alterações do controlador para manter o estado visual atualizado. Pode ser configurada para funcionar como conjunto de toggles quando ferramentas exclusivas precisam permanecer ativas.
-/// ---------------------------------------------------------------------------
+//
+//  graphview_canvas_toolbar.dart
+//  JFlutter
+//
+//  Define a barra de ferramentas que controla o canvas de automatos em GraphView,
+//  disponibilizando comandos de viewport, botões de desfazer/refazer e atalhos
+//  para criação de estados e transições em modos desktop ou mobile.
+//  Observa o controlador do canvas para refletir o estado atual das ações,
+//  permitindo seleção de ferramentas mutuamente exclusivas e ganchos de limpeza,
+//  mensagens de status e fluxos personalizados.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../features/canvas/graphview/base_graphview_canvas_controller.dart';

--- a/lib/presentation/widgets/mobile_navigation.dart
+++ b/lib/presentation/widgets/mobile_navigation.dart
@@ -1,11 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/mobile_navigation.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Fornece barra de navegação inferior otimizada para dispositivos móveis com itens personalizáveis. Ajusta visual e feedback para acomodar múltiplos módulos do aplicativo em telas reduzidas.
-/// Contexto: Recebe lista de NavigationItem que descreve rótulos, ícones e descrições permitindo integração com ferramentas de acessibilidade. Mantém estilo consistente com Material 3 incluindo sombras e SafeArea.
-/// Observações: Destaca item ativo com cor primária e tipografia reforçada melhorando a orientação do usuário. Estrutura flexível facilita adição ou remoção de seções sem alterar o widget principal.
-/// ---------------------------------------------------------------------------
+//
+//  mobile_navigation.dart
+//  JFlutter
+//
+//  Fornece a barra inferior de navegação otimizada para dispositivos móveis,
+//  apresentando itens configuráveis com ícones, rótulos e descrições para
+//  suportar múltiplos módulos do aplicativo em telas compactas.
+//  Aplica estética Material 3 com SafeArea, sombras sutis e destaque do item
+//  ativo, garantindo acessibilidade e facilidade na expansão do menu.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 /// Mobile-optimized bottom navigation widget

--- a/lib/presentation/widgets/pda_simulation_panel.dart
+++ b/lib/presentation/widgets/pda_simulation_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/pda_simulation_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Widget que executa simulações de autômatos de pilha permitindo configurar entrada, símbolo inicial da pilha e modo passo a passo. Exibe resultados, mensagens de erro e traços detalhados para estudo.
-/// Contexto: Trabalha em conjunto com o PDAEditorProvider e serviços de destaque para manter sincronização visual com o canvas. Organiza controles em cartões materiais de fácil leitura adequados a diversos tamanhos de tela.
-/// Observações: Administra controladores de texto e estado local para preservar interações do usuário entre execuções. Invoca o simulador central garantindo que os mesmos modelos do domínio sejam utilizados em toda a aplicação.
-/// ---------------------------------------------------------------------------
+//
+//  pda_simulation_panel.dart
+//  JFlutter
+//
+//  Responsável pela simulação de autômatos de pilha no aplicativo, permitindo
+//  configurar cadeia de entrada, símbolo inicial da pilha, gravação de traço e
+//  visualizar resultados aceitos ou rejeitados com mensagens de erro.
+//  Integra-se ao PDAEditorProvider e ao serviço de destaque para sincronizar o
+//  canvas, administrando controladores e estado local a fim de preservar
+//  interações entre execuções.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pumping_lemma_game.dart
+++ b/lib/presentation/widgets/pumping_lemma_game.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/pumping_lemma_game.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Implementa versão compacta do jogo do Lema do Bombeamento com seleção de desafios e feedback imediato. Sincroniza pontuação e progresso com o provedor dedicado para acompanhar o desempenho do usuário.
-/// Contexto: Utiliza Riverpod para armazenar histórico global enquanto mantém estados locais para fluxo de jogo e seleção de respostas. Apresenta interface baseada em cartões com instruções e resultado ao final de cada rodada.
-/// Observações: Lista conjunto inicial de desafios que pode ser expandido conforme necessário. Cuida da inicialização do provedor ao montar para garantir contagem correta de desafios disponíveis.
-/// ---------------------------------------------------------------------------
+//
+//  pumping_lemma_game.dart
+//  JFlutter
+//
+//  Implementa a experiência interativa do jogo do Lema do Bombeamento,
+//  apresentando desafios guiados, fluxo de perguntas e feedback imediato sobre
+//  regularidade de linguagens em um layout baseado em cartões.
+//  Integra-se ao provider de progresso para registrar pontuações, reinícios e
+//  histórico, enquanto coordena estados locais para seleção de respostas e
+//  avanço entre níveis.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/pumping_lemma_help.dart
+++ b/lib/presentation/widgets/pumping_lemma_help.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/pumping_lemma_help.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Fornece painel de apoio teórico ao jogo do Lema do Bombeamento com abas de teoria, passos e exemplos. Ajuda estudantes a revisar conceitos-chave enquanto experimentam o minigame.
-/// Contexto: Utiliza estrutura de abas controlada localmente para alternar conteúdos estáticos e orientativos. Pode ser renderizado ao lado do jogo principal oferecendo referência rápida em uma interface coesa.
-/// Observações: Mantém estado interno simples apenas para alternância de abas, evitando dependências externas. O conteúdo pode ser expandido com novas seções mantendo a mesma organização visual e pedagógica.
-/// ---------------------------------------------------------------------------
+//
+//  pumping_lemma_help.dart
+//  JFlutter
+//
+//  Constrói o painel de apoio teórico exibido ao lado do jogo do Lema do
+//  Bombeamento, reunindo conteúdos de teoria, passos guiados e exemplos em uma
+//  navegação por abas controlada localmente.
+//  Fornece referências pedagógicas em português e inglês com estilo Material,
+//  permitindo que estudantes alternem rapidamente entre explicações sem depender
+//  de estado global ou serviços adicionais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/simulation_panel.dart
+++ b/lib/presentation/widgets/simulation_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/simulation_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Gerencia interface de simulação para autômatos com controles de entrada, execução e visualização passo a passo. Integra destaque de transições e reprodução automática para auxiliar no entendimento do processo.
-/// Contexto: Utiliza SimulationHighlightService e resultados centralizados para sincronizar canvas e relatórios textuais. Oferece funcionalidades como modo passo a passo, reprodução contínua e exibição de mensagens de aceitação ou rejeição.
-/// Observações: Controla ciclo de vida de controladores e timers garantindo limpeza adequada ao atualizar widgets. Design modular permite adaptar a painel lateral ou seções independentes em páginas diversas.
-/// ---------------------------------------------------------------------------
+//
+//  simulation_panel.dart
+//  JFlutter
+//
+//  Constrói o painel de simulação de autômatos com entrada textual, botões de
+//  execução e modos passo a passo que descrevem cada transição realizada e o
+//  restante da cadeia processada.
+//  Gerencia timers, destaques compartilhados com o canvas e renderização de
+//  resultados aceitos ou rejeitados, permitindo alternar entre reprodução
+//  automática e navegação manual pelas etapas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import '../../core/models/simulation_result.dart';
 import '../../core/models/simulation_step.dart';

--- a/lib/presentation/widgets/tm_algorithm_panel.dart
+++ b/lib/presentation/widgets/tm_algorithm_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/tm_algorithm_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Disponibiliza conjunto de análises para Máquinas de Turing abrangendo decidibilidade, alcançabilidade e métricas de fita. Apresenta resultados estruturados para auxiliar na depuração dos modelos criados.
-/// Contexto: Interage com o TMEditorProvider e algoritmos do domínio para executar inspeções detalhadas sobre estados e transições. Usa seções temáticas que permitem ao usuário focar em aspectos específicos da máquina.
-/// Observações: Mantém estado interno de foco e resultados para evitar recomputações desnecessárias. Pode ser expandido com novos diagnósticos mantendo a mesma experiência visual e organizacional.
-/// ---------------------------------------------------------------------------
+//
+//  tm_algorithm_panel.dart
+//  JFlutter
+//
+//  Disponibiliza o painel de análises para Máquinas de Turing, reunindo botões
+//  para verificações de decidibilidade, alcançabilidade, linguagem, operações de
+//  fita e métricas temporais e espaciais com resultados estruturados.
+//  Conecta-se ao TMEditorProvider e aos AlgorithmOperations para executar
+//  diagnósticos, mantendo estado local de foco e evitando recomputações
+//  desnecessárias entre execuções.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/tm_simulation_panel.dart
+++ b/lib/presentation/widgets/tm_simulation_panel.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/tm_simulation_panel.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Componente de interface que executa simulações de Máquinas de Turing a partir do autômato ativo. Exibe campos de entrada, botões de controle e resultados para orientar o usuário durante a análise.
-/// Contexto: Interage com o TMEditorProvider para obter configurações atuais e utiliza serviços de destaque para sincronizar o canvas. Organiza visualizações como histórico de passos e mensagens de aceitação dentro de um painel responsivo.
-/// Observações: Gerencia ciclo de vida de controladores locais e limpa realces quando desmontado para evitar estados residuais. Pode ser embutido em páginas maiores compartilhando a instância de SimulationHighlightService entre widgets.
-/// ---------------------------------------------------------------------------
+//
+//  tm_simulation_panel.dart
+//  JFlutter
+//
+//  Realiza a simulação de Máquinas de Turing para o autômato ativo, oferecendo
+//  campos de entrada, controles de execução e apresentação de resultados com
+//  histórico de passos e mensagens de aceitação.
+//  Dialoga com o TMEditorProvider e com o SimulationHighlightService para manter
+//  sincronização com o canvas, limpando controladores e destaques conforme o
+//  ciclo de vida do widget.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 

--- a/lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
@@ -1,11 +1,17 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/trace_viewers/base_trace_viewer.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Fornece componente base para visualização de traços reutilizado por FA, PDA e TM. Gerencia colapso de listas longas, seleção de passos e integração opcional com destaques do canvas.
-/// Contexto: Recebe um SimulationResult genérico e um construtor de linhas para especializações, garantindo comportamento comum entre diferentes automatos. Administra estado interno para dobragem e seleção respeitando as necessidades de acessibilidade.
-/// Observações: Emite eventos para SimulationHighlightService quando habilitado, permitindo sincronização imediata com visualizações gráficas. Flexível o bastante para suportar novos tipos de traço sem alteração estrutural significativa.
-/// ---------------------------------------------------------------------------
+//
+//  base_trace_viewer.dart
+//  JFlutter
+//
+//  Provê widget base reutilizado pelos visualizadores de traços de FA, PDA e
+//  TM, tratando colapso de listas extensas, seleção de passos e integração
+//  opcional com o SimulationHighlightService para sincronizar destaques no
+//  canvas.
+//  Aceita um SimulationResult genérico e um builder de linhas especializado,
+//  garantindo comportamento consistente e acessível para qualquer algoritmo que
+//  produza sequências de passos.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../../core/models/simulation_result.dart';

--- a/lib/presentation/widgets/trace_viewers/fa_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/fa_trace_viewer.dart
@@ -1,11 +1,15 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/trace_viewers/fa_trace_viewer.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Apresenta traços de simulação de autômatos finitos detalhando estado corrente, entrada restante e transição utilizada. Utiliza convenções como ε para cadeia vazia reforçando terminologia de teoria de autômatos.
-/// Contexto: Se baseia no BaseTraceViewer para renderização padronizada e suporta personalização de linhas de passo. É utilizado por painéis de simulação para oferecer visão cronológica de execuções.
-/// Observações: Opera diretamente com SimulationResult genérico tornando-se compatível com DFAs, NFAs e execuções passo a passo. Pode ser estendido para incluir metadados adicionais sem romper a API existente.
-/// ---------------------------------------------------------------------------
+//
+//  fa_trace_viewer.dart
+//  JFlutter
+//
+//  Exibe os traços de simulação de autômatos finitos reutilizando o
+//  BaseTraceViewer para mostrar estado atual, entrada restante e transições
+//  consumidas, utilizando convenções clássicas como ε para indicar cadeia vazia.
+//  Funciona com resultados de DFAs e NFAs de forma uniforme, fornecendo uma
+//  visualização cronológica que pode ser estendida com metadados adicionais.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../../core/models/simulation_result.dart';

--- a/lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
@@ -1,11 +1,17 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/trace_viewers/pda_trace_viewer.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Exibe traços de simulações de autômatos de pilha destacando estado atual, entrada remanescente e conteúdo da pilha. Converte resultados específicos do simulador em formato comum para reutilizar a infraestrutura de visualização.
-/// Contexto: Trabalha com SimulationHighlightService para sincronizar destaques no canvas e com BaseTraceViewer para renderização consistente. Usa convenções como λ para entradas vazias reforçando conceitos teóricos na interface.
-/// Observações: Simplifica tratamento de resultados aceitos ou rejeitados mantendo mensagens claras. Pode ser integrado a diferentes painéis que necessitem apresentar passo a passo de execuções PDA.
-/// ---------------------------------------------------------------------------
+//
+//  pda_trace_viewer.dart
+//  JFlutter
+//
+//  Apresenta os traços de simulação de autômatos de pilha traduzindo os dados
+//  retornados pelo PDASimulator em SimulationResult genérico para reutilizar o
+//  BaseTraceViewer, com destaque para entrada remanescente, conteúdo da pilha e
+//  transições utilizadas.
+//  Harmoniza mensagens de aceitação e rejeição, integra-se ao serviço de
+//  destaque do canvas e reforça convenções teóricas como λ para representar
+//  cadeia vazia e pilhas descarregadas.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../../core/algorithms/pda_simulator.dart';

--- a/lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
+++ b/lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
@@ -1,11 +1,16 @@
-/// ---------------------------------------------------------------------------
-/// Projeto: JFlutter
-/// Arquivo: lib/presentation/widgets/trace_viewers/tm_trace_viewer.dart
-/// Autoria: Equipe de Engenharia JFlutter
-/// Descrição: Responsável por exibir traços de simulação de Máquinas de Turing em formato legível, destacando passos, fita e transições utilizadas. Normaliza o resultado para reutilizar componentes compartilhados de visualização.
-/// Contexto: Converte resultados específicos do simulador de TM em SimulationResult genérico para consumo pelo BaseTraceViewer. Permite integração com serviços de destaque para sincronização com o canvas correspondente.
-/// Observações: Realiza tratamento especial para cenários de timeout, laço infinito e rejeição garantindo mensagens adequadas. Pode ser reutilizado em qualquer página que precise apresentar execuções de TM de maneira consistente.
-/// ---------------------------------------------------------------------------
+//
+//  tm_trace_viewer.dart
+//  JFlutter
+//
+//  Renderiza os traços de simulação de Máquinas de Turing convertendo o
+//  resultado especializado do simulador em um SimulationResult genérico para o
+//  BaseTraceViewer, com suporte a destaques de fita, transições e estados.
+//  Normaliza mensagens de erro para diferenciar rejeições, timeouts e laços
+//  infinitos, oferecendo uma apresentação consistente reaproveitável em qualquer
+//  tela que consuma execuções de TM.
+//
+//  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import '../../../core/algorithms/tm_simulator.dart';


### PR DESCRIPTION
## Summary
- add the mandated header block to the remaining presentation providers tied to the home navigation and Pumping Lemma progress flows
- document responsibilities in Portuguese across the presentation widgets (canvas, simulations, diagnostics, trace viewers) using the required author format

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e545b7ea54832ea1c2b0ba55b46325