### PR TITLE
Add spacer after GraphView test headers

### DIFF
--- a/test/widget/presentation/automaton_graphview_canvas_test.dart
+++ b/test/widget/presentation/automaton_graphview_canvas_test.dart
@@ -10,6 +10,7 @@
 //  autômato.
 //
 //  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'dart:math' as math;
 

--- a/test/widget/presentation/graphview_canvas_toolbar_test.dart
+++ b/test/widget/presentation/graphview_canvas_toolbar_test.dart
@@ -9,6 +9,7 @@
 //  apenas quando fornecidos, mantendo o contrato da interface responsiva.
 //
 //  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/widget/presentation/graphview_label_field_editor_test.dart
+++ b/test/widget/presentation/graphview_label_field_editor_test.dart
@@ -9,6 +9,7 @@
 //  contrato do componente.
 //
 //  Thales Matheus Mendonça Santos - October 2025
+//
 
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';


### PR DESCRIPTION
## Summary
- add spacer comment after the author header in the GraphView widget test files to keep the header formatting consistent

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e54c062954832e8b5ab13b592adfb4