### PR TITLE
Normalize header template spacing

### DIFF
--- a/lib/presentation/widgets/automaton_canvas_tool.dart
+++ b/lib/presentation/widgets/automaton_canvas_tool.dart
@@ -9,6 +9,7 @@
 //  tipos de interação.
 //
 //  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/foundation.dart';
 
 /// Editing tools supported by the automaton canvas.

--- a/lib/presentation/widgets/mobile_automaton_controls.dart
+++ b/lib/presentation/widgets/mobile_automaton_controls.dart
@@ -10,6 +10,7 @@
 //  da página hospedeira.
 //
 //  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 
 import 'automaton_canvas_tool.dart';

--- a/lib/presentation/widgets/tm_canvas_graphview.dart
+++ b/lib/presentation/widgets/tm_canvas_graphview.dart
@@ -9,6 +9,7 @@
 //  ferramentas e habilita formulários inline para operações de fita.
 //
 //  Thales Matheus Mendonça Santos - October 2025
+//
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 


### PR DESCRIPTION
## Summary
- insert the missing blank comment separator after the author line in three widget headers to match the repository template

## Testing
- python - <<'PY' ...
- dart format lib

------
https://chatgpt.com/codex/tasks/task_e_68e54ba86f5c832e962da2cf73a76953