### PR TITLE
Document NFA→DFA state guard

### DIFF
--- a/lib/core/algorithms/nfa_to_dfa_converter.dart
+++ b/lib/core/algorithms/nfa_to_dfa_converter.dart
@@ -198,7 +198,10 @@ class NFAToDFAConverter {
 
     // Process each state set
     int stateCounter = 1;
-    const int maxStates = 1000; // Performance safeguard
+    // Keep this hard ceiling in sync with docs/reference-deviations.md.
+    // Mobile profiles start thrashing well before the theoretical 2^n bound;
+    // clamping at 1 000 states prevents OOM freezes during subset expansion.
+    const int maxStates = 1000;
     while (queue.isNotEmpty) {
       final currentStateKey = queue.removeAt(0);
       if (processed.contains(currentStateKey)) continue;


### PR DESCRIPTION
## Summary
- document the fixed 1 000-state ceiling in the NFA→DFA converter and note its divergence from the Python reference
- clarify how the guard manifests for consumers and why it remains hard-coded to protect mobile devices
- add an inline comment in the converter to keep the source and documentation aligned

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68e85ebeb340832e9a6892384da452fd