### PR TITLE
Update palindrome PDA example validation

### DIFF
--- a/jflutter_js/examples/apda_palindrome.json
+++ b/jflutter_js/examples/apda_palindrome.json
@@ -16,21 +16,36 @@
     {
       "id": "q1",
       "name": "q1",
-      "x": 300.0,
+      "x": 320.0,
+      "y": 200.0,
+      "isInitial": false,
+      "isFinal": false
+    },
+    {
+      "id": "q2",
+      "name": "q2",
+      "x": 520.0,
       "y": 200.0,
       "isInitial": false,
       "isFinal": true
     }
   ],
   "transitions": {
-    "q0|a|Z": ["q0|aZ"],
-    "q0|b|Z": ["q0|bZ"],
-    "q0|a|a": ["q0|aa"],
-    "q0|b|b": ["q0|bb"],
-    "q0||Z": ["q1|Z"]
+    "q0|a|Z": ["q0|aZ", "q1|Z"],
+    "q0|b|Z": ["q0|bZ", "q1|Z"],
+    "q0|a|a": ["q0|aa", "q1|a"],
+    "q0|a|b": ["q0|ab", "q1|b"],
+    "q0|b|a": ["q0|ba", "q1|a"],
+    "q0|b|b": ["q0|bb", "q1|b"],
+    "q0||a": ["q1|a"],
+    "q0||b": ["q1|b"],
+    "q0||Z": ["q1|Z"],
+    "q1|a|a": ["q1|"],
+    "q1|b|b": ["q1|"],
+    "q1||Z": ["q2|Z"]
   },
   "initialId": "q0",
   "initialStack": ["Z"],
-  "finalStates": ["q1"],
-  "description": "Autômato de pilha que reconhece palíndromos usando pilha para verificar simetria"
+  "finalStates": ["q2"],
+  "description": "Autômato de pilha não determinístico que empilha a primeira metade da palavra e desempilha a segunda para reconhecer palíndromos"
 }

--- a/lib/data/data_sources/examples_asset_data_source.dart
+++ b/lib/data/data_sources/examples_asset_data_source.dart
@@ -89,8 +89,8 @@ class ExamplesAssetDataSource {
       subcategory: 'Stack Verification',
       difficulty: DifficultyLevel.hard,
       description:
-          'Autômato de pilha que reconhece palíndromos. Usa pilha para verificar simetria.',
-      tags: ['pda', 'palindrome', 'stack', 'verification'],
+          'Autômato de pilha não determinístico que empilha a primeira metade da palavra e desempilha a segunda para validar palíndromos.',
+      tags: ['pda', 'palindrome', 'stack', 'non-deterministic', 'mirroring'],
       estimatedComplexity: ComplexityLevel.high,
     ),
 

--- a/test/unit/data/examples_asset_data_source_test.dart
+++ b/test/unit/data/examples_asset_data_source_test.dart
@@ -10,12 +10,39 @@
 //  Thales Matheus Mendonça Santos - October 2025
 //
 
+import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:jflutter/core/repositories/automaton_repository.dart';
 import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';
+
+class _PdaTransition {
+  const _PdaTransition({
+    required this.toState,
+    required this.inputSymbol,
+    required this.requiredStackTop,
+    required this.stackReplacement,
+  });
+
+  final String toState;
+  final String inputSymbol;
+  final String requiredStackTop;
+  final String stackReplacement;
+}
+
+class _PdaConfiguration {
+  const _PdaConfiguration({
+    required this.state,
+    required this.index,
+    required this.stack,
+  });
+
+  final String state;
+  final int index;
+  final List<String> stack;
+}
 
 void main() {
   group('ExamplesAssetDataSource JSON validation', () {
@@ -103,6 +130,156 @@ void main() {
 
       expect(result.isSuccess, isTrue);
       expect(result.data, isNull);
+    });
+
+    bool runPda(Map<String, dynamic> json, String input) {
+      final transitionsRaw = json['transitions'];
+      expect(transitionsRaw, isA<Map<String, dynamic>>());
+
+      final transitions = <String, List<_PdaTransition>>{};
+      (transitionsRaw as Map<String, dynamic>).forEach((key, value) {
+        final parts = key.split('|');
+        expect(
+          parts.length,
+          3,
+          reason:
+              'Transition key "$key" must follow the pattern estado|símbolo|topoDaPilha.',
+        );
+
+        final fromState = parts[0];
+        final inputSymbol = parts[1];
+        final requiredStackTop = parts[2];
+
+        final targets = value is List ? value : [value];
+        final parsedTargets = targets.map((dynamic target) {
+          final targetString = target.toString();
+          final targetParts = targetString.split('|');
+          expect(
+            targetParts.length,
+            2,
+            reason:
+                'Transition target "$targetString" must follow the pattern estado|substituicaoPilha.',
+          );
+
+          final stackReplacement =
+              targetParts.length > 1 ? targetParts[1] : '';
+
+          return _PdaTransition(
+            toState: targetParts[0],
+            inputSymbol: inputSymbol,
+            requiredStackTop: requiredStackTop,
+            stackReplacement: stackReplacement,
+          );
+        }).toList();
+
+        transitions.putIfAbsent(fromState, () => []).addAll(parsedTargets);
+      });
+
+      final initialState = json['initialId'] as String;
+      final finalStates = Set<String>.from(
+        (json['finalStates'] as List).map((e) => e.toString()),
+      );
+      final initialStack = (json['initialStack'] as List)
+          .map((e) => e.toString())
+          .toList();
+
+      final queue = ListQueue<_PdaConfiguration>();
+      queue.add(
+        _PdaConfiguration(
+          state: initialState,
+          index: 0,
+          stack: List<String>.from(initialStack),
+        ),
+      );
+
+      final visited = <String>{};
+
+      bool isEpsilon(String symbol) => symbol.isEmpty || symbol == 'λ';
+
+      while (queue.isNotEmpty) {
+        final config = queue.removeFirst();
+        final signature =
+            '${config.state}|${config.index}|${config.stack.join(',')}';
+        if (!visited.add(signature)) {
+          continue;
+        }
+
+        if (config.index == input.length &&
+            finalStates.contains(config.state)) {
+          return true;
+        }
+
+        final available = transitions[config.state];
+        if (available == null) {
+          continue;
+        }
+
+        for (final transition in available) {
+          final nextStack = List<String>.from(config.stack);
+
+          if (transition.requiredStackTop.isNotEmpty) {
+            if (nextStack.isEmpty ||
+                nextStack.last != transition.requiredStackTop) {
+              continue;
+            }
+            nextStack.removeLast();
+          }
+
+          final consumesEpsilon = isEpsilon(transition.inputSymbol);
+
+          if (!consumesEpsilon) {
+            if (config.index >= input.length) {
+              continue;
+            }
+            final currentSymbol = input[config.index];
+            if (currentSymbol != transition.inputSymbol) {
+              continue;
+            }
+          }
+
+          final replacement = transition.stackReplacement;
+          if (replacement.isNotEmpty) {
+            for (var i = replacement.length - 1; i >= 0; i--) {
+              nextStack.add(replacement[i]);
+            }
+          }
+
+          final nextIndex = consumesEpsilon ? config.index : config.index + 1;
+
+          queue.add(
+            _PdaConfiguration(
+              state: transition.toState,
+              index: nextIndex,
+              stack: nextStack,
+            ),
+          );
+        }
+      }
+
+      return false;
+    }
+
+    test('APD palindrome example accepts palindromes and rejects non-palindromes', () {
+      final json = loadExample('apda_palindrome.json');
+
+      const accepted = ['','a','b','aa','bb','aba','bab','abba','baab','abbba'];
+      const rejected = ['ab','ba','abb','aab','ababa','abbabb'];
+
+      for (final word in accepted) {
+        expect(
+          runPda(json, word),
+          isTrue,
+          reason: 'Expected palindrome "$word" to be accepted.',
+        );
+      }
+
+      for (final word in rejected) {
+        expect(
+          runPda(json, word),
+          isFalse,
+          reason: 'Expected non-palindrome "$word" to be rejected.',
+        );
+      }
     });
 
     test('Validates TM example structure', () {


### PR DESCRIPTION
## Summary
- expand the APD palindrome example with explicit push/pop transitions so the second half of the word is validated via stack popping
- refresh the example metadata description and tags to reflect the non-deterministic palindrome verification strategy
- add a PDA simulation test that loads the asset and checks acceptance for palindromes while rejecting non-palindromes

## Testing
- flutter test test/unit/data/examples_asset_data_source_test.dart *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e85f074878832e874611b0bf15d7b8