### PR TITLE
Handle absolute keystore paths in signing script

### DIFF
--- a/android/scripts/create_key_properties.sh
+++ b/android/scripts/create_key_properties.sh
@@ -38,6 +38,12 @@ keyPassword=${JFLUTTER_KEY_PASSWORD}
 EOF2
 
 echo "Created ${KEY_PROPERTIES_FILE}"
-if [[ ! -f "${ANDROID_DIR}/${STORE_FILE_PATH}" ]]; then
-  echo "Warning: Keystore file '${STORE_FILE_PATH}' does not exist relative to android/." >&2
+if [[ ${STORE_FILE_PATH} =~ ^/ || ${STORE_FILE_PATH} =~ ^[A-Za-z]:[\\/] ]]; then
+  if [[ ! -f "${STORE_FILE_PATH}" ]]; then
+    echo "Warning: Keystore file '${STORE_FILE_PATH}' does not exist at the specified absolute path." >&2
+  fi
+else
+  if [[ ! -f "${ANDROID_DIR}/${STORE_FILE_PATH}" ]]; then
+    echo "Warning: Keystore file '${STORE_FILE_PATH}' does not exist relative to android/." >&2
+  fi
 fi


### PR DESCRIPTION
## Summary
- detect absolute keystore paths when validating the generated key.properties file
- check keystore existence using the appropriate absolute or android-relative path and adjust warnings

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e85e8c2f54832e9d3a0967a21b6548