### PR TITLE
Add error handling widgets for import flows

### DIFF
--- a/lib/presentation/widgets/error_banner.dart
+++ b/lib/presentation/widgets/error_banner.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart' hide ButtonStyle;
+
+import 'retry_button.dart';
+
+/// Inline banner that communicates import or execution failures.
+class ErrorBanner extends StatelessWidget {
+  const ErrorBanner({
+    super.key,
+    required this.message,
+    this.onRetry,
+    this.onDismiss,
+  });
+
+  /// Error message displayed in the banner body.
+  final String message;
+
+  /// Optional callback triggered when the user selects the retry action.
+  final VoidCallback? onRetry;
+
+  /// Optional callback triggered when the user dismisses the banner.
+  final VoidCallback? onDismiss;
+
+  bool get _showActions => onRetry != null || onDismiss != null;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+    final textTheme = theme.textTheme;
+
+    return Material(
+      color: Colors.transparent,
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+        decoration: BoxDecoration(
+          color: colorScheme.errorContainer,
+          borderRadius: BorderRadius.circular(12),
+          border: Border.all(color: colorScheme.error.withOpacity(0.5)),
+        ),
+        child: Row(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Icon(Icons.error, color: colorScheme.error),
+            const SizedBox(width: 12),
+            Expanded(
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text(
+                    message,
+                    style: textTheme.bodyMedium?.copyWith(
+                      color: colorScheme.onErrorContainer,
+                    ),
+                  ),
+                  if (_showActions) ...[
+                    const SizedBox(height: 12),
+                    Wrap(
+                      spacing: 8,
+                      runSpacing: 8,
+                      children: [
+                        if (onRetry != null)
+                          RetryButton(
+                            onPressed: onRetry,
+                            style: ButtonStyle.secondary,
+                          ),
+                        if (onDismiss != null)
+                          TextButton.icon(
+                            onPressed: onDismiss,
+                            icon: const Icon(Icons.close, size: 18),
+                            label: const Text('Dismiss'),
+                          ),
+                      ],
+                    ),
+                  ],
+                ],
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/import_error_dialog.dart
+++ b/lib/presentation/widgets/import_error_dialog.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart' hide ButtonStyle;
+
+import 'retry_button.dart';
+
+/// Dialog used to present detailed information about an import failure.
+class ImportErrorDialog extends StatelessWidget {
+  const ImportErrorDialog({
+    super.key,
+    required this.title,
+    required this.message,
+    required this.details,
+    required this.onRetry,
+    required this.onCancel,
+  });
+
+  /// Short title describing the failure (displayed in the dialog header).
+  final String title;
+
+  /// Friendly explanation displayed at the top of the dialog content.
+  final String message;
+
+  /// Additional technical information intended to help the user resolve the
+  /// issue.
+  final String details;
+
+  /// Callback triggered when the user decides to retry the import.
+  final VoidCallback onRetry;
+
+  /// Callback triggered when the user dismisses the dialog.
+  final VoidCallback onCancel;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final colorScheme = theme.colorScheme;
+
+    return AlertDialog(
+      title: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(Icons.error_outline, color: colorScheme.error),
+          const SizedBox(width: 8),
+          Expanded(
+            child: Text(
+              title,
+              style: theme.textTheme.titleMedium,
+            ),
+          ),
+        ],
+      ),
+      content: Column(
+        mainAxisSize: MainAxisSize.min,
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            message,
+            style: theme.textTheme.bodyMedium,
+          ),
+          const SizedBox(height: 12),
+          Text(
+            details,
+            style: theme.textTheme.bodySmall?.copyWith(
+              color: colorScheme.onSurfaceVariant,
+            ),
+          ),
+        ],
+      ),
+      actions: [
+        TextButton(
+          onPressed: onCancel,
+          child: const Text('Cancel'),
+        ),
+        RetryButton(onPressed: onRetry),
+      ],
+    );
+  }
+}

--- a/lib/presentation/widgets/retry_button.dart
+++ b/lib/presentation/widgets/retry_button.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart' hide ButtonStyle;
+
+/// Visual variants available for [RetryButton].
+enum ButtonStyle {
+  /// High emphasis button used as the primary call to action.
+  primary,
+
+  /// Tonal variant that provides a softer emphasis compared to [primary].
+  secondary,
+
+  /// Outlined button variant that keeps emphasis without filling the background.
+  outline,
+
+  /// Text-only variant with minimal emphasis.
+  text,
+}
+
+/// Button used to trigger retry flows across the application.
+///
+/// The widget centralises the UX expectations validated in
+/// `ux_error_handling_test.dart`, including iconography, disabled and
+/// loading states as well as multiple visual variants.
+class RetryButton extends StatelessWidget {
+  const RetryButton({
+    super.key,
+    this.text = 'Retry',
+    this.onPressed,
+    this.isLoading = false,
+    this.style = ButtonStyle.primary,
+  });
+
+  /// Label displayed inside the button when not loading.
+  final String text;
+
+  /// Callback triggered when the user taps the button.
+  final VoidCallback? onPressed;
+
+  /// Whether the button should present a loading indicator instead of the
+  /// regular icon.
+  final bool isLoading;
+
+  /// Visual style applied to the button.
+  final ButtonStyle style;
+
+  bool get _isDisabled => onPressed == null || isLoading;
+
+  @override
+  Widget build(BuildContext context) {
+    final effectiveOnPressed = _isDisabled ? null : onPressed;
+    final Widget icon = _buildIcon(context);
+    final Text label = Text(isLoading ? 'Retrying...' : text);
+
+    switch (style) {
+      case ButtonStyle.primary:
+        return FilledButton.icon(
+          onPressed: effectiveOnPressed,
+          icon: icon,
+          label: label,
+        );
+      case ButtonStyle.secondary:
+        return FilledButton.tonalIcon(
+          onPressed: effectiveOnPressed,
+          icon: icon,
+          label: label,
+        );
+      case ButtonStyle.outline:
+        return OutlinedButton.icon(
+          onPressed: effectiveOnPressed,
+          icon: icon,
+          label: label,
+        );
+      case ButtonStyle.text:
+        return TextButton.icon(
+          onPressed: effectiveOnPressed,
+          icon: icon,
+          label: label,
+        );
+    }
+  }
+
+  Widget _buildIcon(BuildContext context) {
+    if (!isLoading) {
+      return const Icon(Icons.refresh, size: 18);
+    }
+
+    final colorScheme = Theme.of(context).colorScheme;
+    return SizedBox(
+      width: 16,
+      height: 16,
+      child: CircularProgressIndicator(
+        strokeWidth: 2,
+        valueColor: AlwaysStoppedAnimation<Color>(colorScheme.primary),
+      ),
+    );
+  }
+}

--- a/lib/presentation/widgets/widgets.dart
+++ b/lib/presentation/widgets/widgets.dart
@@ -1,0 +1,3 @@
+export 'error_banner.dart';
+export 'import_error_dialog.dart';
+export 'retry_button.dart';


### PR DESCRIPTION
## Summary
- add a reusable `RetryButton` with loading/disabled behaviour and style variants
- implement `ErrorBanner` and `ImportErrorDialog` that compose the retry control and expose dismiss/cancel flows
- publish the new widgets through a presentation widgets barrel for easy reuse

## Testing
- `flutter test test/widget/presentation/ux_error_handling_test.dart` *(fails: flutter command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e85ff30af0832e85cbce43ed80567a