### PR TITLE
Add GraphView history limits and cache eviction

### DIFF
--- a/docs/canvas_bridge.md
+++ b/docs/canvas_bridge.md
@@ -30,3 +30,9 @@ The `GraphViewCanvasToolbar` widget centralises viewport actions, undo/redo, and
 ## Data Round-Tripping
 
 When the user edits the canvas, the controller merges the Graph snapshot into the existing automaton template and republishes it through `AutomatonProvider`. This keeps inspector panels, persistence layers, and simulators aligned with the visual representation while avoiding manual diff logic.【F:lib/features/canvas/graphview/graphview_canvas_controller.dart†L188-L219】【F:lib/presentation/providers/automaton_provider.dart†L25-L219】
+
+## History & Cache Management
+
+`BaseGraphViewCanvasController` now enforces configurable undo/redo history limits (default: 20 snapshots) and compresses each `GraphViewAutomatonSnapshot` using gzip before storing it in memory, keeping long editing sessions lighter without affecting replay accuracy.【F:lib/features/canvas/graphview/base_graphview_canvas_controller.dart†L58-L109】【F:lib/features/canvas/graphview/base_graphview_canvas_controller.dart†L253-L566】 Controllers expose the `historyLimit` parameter so editors with heavier workflows can raise or lower retention as needed, and the new tests assert that older entries are discarded as expected.【F:lib/features/canvas/graphview/graphview_canvas_controller.dart†L35-L50】【F:test/features/canvas/graphview/graphview_canvas_controller_test.dart†L418-L446】
+
+To avoid runaway memory usage on large automatons, the same controller exposes a `cacheEvictionThreshold` (default: 250 items). When the active snapshot exceeds that count, the node/edge caches and GraphView instances are cleared and rebuilt on demand, and the same eviction happens on `dispose` to release resources deterministically.【F:lib/features/canvas/graphview/base_graphview_canvas_controller.dart†L99-L217】【F:lib/features/canvas/graphview/base_graphview_canvas_controller.dart†L342-L588】【F:test/features/canvas/graphview/graphview_canvas_controller_test.dart†L432-L519】

--- a/lib/features/canvas/graphview/graphview_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_canvas_controller.dart
@@ -37,11 +37,16 @@ class GraphViewCanvasController
     Graph? graph,
     GraphViewController? viewController,
     TransformationController? transformationController,
+    int historyLimit = BaseGraphViewCanvasController.kDefaultHistoryLimit,
+    int cacheEvictionThreshold =
+        BaseGraphViewCanvasController.kDefaultCacheEvictionThreshold,
   }) : super(
          notifier: automatonProvider,
-         graph: graph,
-         viewController: viewController,
-         transformationController: transformationController,
+          graph: graph,
+          viewController: viewController,
+          transformationController: transformationController,
+          historyLimit: historyLimit,
+          cacheEvictionThreshold: cacheEvictionThreshold,
        );
 
   AutomatonProvider get _provider => notifier;

--- a/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_pda_canvas_controller.dart
@@ -38,11 +38,16 @@ class GraphViewPdaCanvasController
     Graph? graph,
     GraphViewController? viewController,
     TransformationController? transformationController,
+    int historyLimit = BaseGraphViewCanvasController.kDefaultHistoryLimit,
+    int cacheEvictionThreshold =
+        BaseGraphViewCanvasController.kDefaultCacheEvictionThreshold,
   }) : super(
           notifier: editorNotifier,
           graph: graph,
           viewController: viewController,
           transformationController: transformationController,
+          historyLimit: historyLimit,
+          cacheEvictionThreshold: cacheEvictionThreshold,
         );
 
   PDAEditorNotifier get _notifier => notifier;

--- a/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
+++ b/lib/features/canvas/graphview/graphview_tm_canvas_controller.dart
@@ -41,12 +41,17 @@ class GraphViewTmCanvasController
     Graph? graph,
     GraphViewController? viewController,
     TransformationController? transformationController,
+    int historyLimit = BaseGraphViewCanvasController.kDefaultHistoryLimit,
+    int cacheEvictionThreshold =
+        BaseGraphViewCanvasController.kDefaultCacheEvictionThreshold,
   }) : super(
-         notifier: editorNotifier,
-         graph: graph,
-         viewController: viewController,
-         transformationController: transformationController,
-       );
+          notifier: editorNotifier,
+          graph: graph,
+          viewController: viewController,
+          transformationController: transformationController,
+          historyLimit: historyLimit,
+          cacheEvictionThreshold: cacheEvictionThreshold,
+        );
 
   TMEditorNotifier get _notifier => notifier;
 


### PR DESCRIPTION
## Summary
- enforce configurable undo/redo caps in BaseGraphViewCanvasController and compress stored snapshots
- add cache eviction thresholds and dispose-time cleanup for GraphView controllers
- extend widget tests and docs to cover the new history and cache parameters

## Testing
- flutter test test/features/canvas/graphview/graphview_canvas_controller_test.dart *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68e85f923c00832eb1de1a6faad8ef97