### PR TITLE
Lock down key.properties permissions

### DIFF
--- a/android/scripts/create_key_properties.sh
+++ b/android/scripts/create_key_properties.sh
@@ -37,6 +37,11 @@ keyAlias=${JFLUTTER_KEY_ALIAS}
 keyPassword=${JFLUTTER_KEY_PASSWORD}
 EOF2
 
+# Lock down permissions to preserve signing credentials.
+if ! chmod 600 "${KEY_PROPERTIES_FILE}" 2>/dev/null; then
+  echo "Warning: Unable to restrict permissions on ${KEY_PROPERTIES_FILE}; ensure credentials remain protected on this platform." >&2
+fi
+
 echo "Created ${KEY_PROPERTIES_FILE}"
 if [[ ${STORE_FILE_PATH} =~ ^/ || ${STORE_FILE_PATH} =~ ^[A-Za-z]:[\\/] ]]; then
   if [[ ! -f "${STORE_FILE_PATH}" ]]; then


### PR DESCRIPTION
## Summary
- ensure the generated android/key.properties file has restrictive permissions
- warn users when chmod is unsupported so the script completes gracefully
- document that the permissions lock protects signing credentials

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e91a285834832ea42172d7963ddc23