### PR TITLE
Enable web file operations in panels

### DIFF
--- a/lib/presentation/widgets/utils/platform_file_loader.dart
+++ b/lib/presentation/widgets/utils/platform_file_loader.dart
@@ -1,0 +1,55 @@
+import 'package:file_picker/file_picker.dart';
+
+import '../../../core/models/fsa.dart';
+import '../../../core/models/grammar.dart';
+import '../../../core/result.dart';
+import '../../../data/services/file_operations_service.dart';
+
+const _kUnreadableFileMessage =
+    'Selected file did not contain readable data.';
+
+String? _normalizedPath(String? path) {
+  if (path == null) {
+    return null;
+  }
+
+  final trimmed = path.trim();
+  return trimmed.isEmpty ? null : trimmed;
+}
+
+/// Loads an automaton from the provided [PlatformFile], preferring in-memory
+/// bytes when available to support web targets where no physical path exists.
+Future<Result<FSA>> loadAutomatonFromPlatformFile(
+  FileOperationsService service,
+  PlatformFile file,
+) async {
+  if (file.bytes != null) {
+    return service.loadAutomatonFromBytes(file.bytes!);
+  }
+
+  final normalizedPath = _normalizedPath(file.path);
+  if (normalizedPath != null) {
+    return service.loadAutomatonFromJFLAP(normalizedPath);
+  }
+
+  return const Failure<FSA>(_kUnreadableFileMessage);
+}
+
+/// Loads a grammar from the provided [PlatformFile], preferring in-memory
+/// bytes when available to support web targets where no physical path exists.
+Future<Result<Grammar>> loadGrammarFromPlatformFile(
+  FileOperationsService service,
+  PlatformFile file,
+) async {
+  if (file.bytes != null) {
+    return service.loadGrammarFromBytes(file.bytes!);
+  }
+
+  final normalizedPath = _normalizedPath(file.path);
+  if (normalizedPath != null) {
+    return service.loadGrammarFromJFLAP(normalizedPath);
+  }
+
+  return const Failure<Grammar>(_kUnreadableFileMessage);
+}
+

--- a/test/presentation/widgets/utils/platform_file_loader_test.dart
+++ b/test/presentation/widgets/utils/platform_file_loader_test.dart
@@ -1,0 +1,210 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:vector_math/vector_math_64.dart';
+
+import 'package:jflutter/core/models/fsa.dart';
+import 'package:jflutter/core/models/fsa_transition.dart';
+import 'package:jflutter/core/models/grammar.dart';
+import 'package:jflutter/core/models/production.dart';
+import 'package:jflutter/core/models/state.dart' as automaton_state;
+import 'package:jflutter/core/result.dart';
+import 'package:jflutter/data/services/file_operations_service.dart';
+import 'package:jflutter/presentation/widgets/utils/platform_file_loader.dart';
+
+void main() {
+  group('loadAutomatonFromPlatformFile', () {
+    late _RecordingFileOperationsService service;
+    late FSA fsa;
+
+    setUp(() {
+      final state = automaton_state.State(
+        id: 'q0',
+        label: 'q0',
+        position: Vector2.zero(),
+        isInitial: true,
+        isAccepting: false,
+      );
+      fsa = FSA(
+        id: 'a1',
+        name: 'Automaton',
+        states: {state},
+        transitions: <FSATransition>{},
+        alphabet: <String>{},
+        initialState: state,
+        acceptingStates: <automaton_state.State>{},
+        created: DateTime(2023),
+        modified: DateTime(2023),
+        bounds: const math.Rectangle(0, 0, 100, 100),
+        zoomLevel: 1,
+        panOffset: Vector2.zero(),
+      );
+
+      service = _RecordingFileOperationsService(automaton: fsa);
+    });
+
+    test('prefers bytes when available', () async {
+      final file = PlatformFile(
+        name: 'automaton.jff',
+        size: 4,
+        bytes: Uint8List.fromList([1, 2, 3, 4]),
+      );
+
+      final result = await loadAutomatonFromPlatformFile(service, file);
+
+      expect(result, isA<Success<FSA>>());
+      expect(service.bytesCalls, 1);
+      expect(service.pathCalls, 0);
+    });
+
+    test('falls back to path when bytes are missing', () async {
+      final file = PlatformFile(
+        name: 'automaton.jff',
+        size: 0,
+        path: '/tmp/automaton.jff',
+      );
+
+      final result = await loadAutomatonFromPlatformFile(service, file);
+
+      expect(result, isA<Success<FSA>>());
+      expect(service.bytesCalls, 0);
+      expect(service.pathCalls, 1);
+    });
+
+    test('returns failure when neither bytes nor path are provided', () async {
+      final file = PlatformFile(
+        name: 'automaton.jff',
+        size: 0,
+      );
+
+      final result = await loadAutomatonFromPlatformFile(service, file);
+
+      expect(result, isA<Failure<FSA>>());
+      expect(service.bytesCalls, 0);
+      expect(service.pathCalls, 0);
+    });
+  });
+
+  group('loadGrammarFromPlatformFile', () {
+    late _RecordingFileOperationsService service;
+    late Grammar grammar;
+
+    setUp(() {
+      grammar = Grammar(
+        id: 'g1',
+        name: 'Grammar',
+        terminals: {'a'},
+        nonterminals: {'S'},
+        startSymbol: 'S',
+        productions: {
+          Production(
+            id: 'p0',
+            leftSide: const ['S'],
+            rightSide: const ['a'],
+            order: 0,
+          ),
+        },
+        type: GrammarType.contextFree,
+        created: DateTime(2023),
+        modified: DateTime(2023),
+      );
+
+      service = _RecordingFileOperationsService(grammar: grammar);
+    });
+
+    test('prefers bytes when available', () async {
+      final file = PlatformFile(
+        name: 'grammar.cfg',
+        size: 2,
+        bytes: Uint8List.fromList([1, 2]),
+      );
+
+      final result = await loadGrammarFromPlatformFile(service, file);
+
+      expect(result, isA<Success<Grammar>>());
+      expect(service.grammarBytesCalls, 1);
+      expect(service.grammarPathCalls, 0);
+    });
+
+    test('falls back to path when bytes are missing', () async {
+      final file = PlatformFile(
+        name: 'grammar.cfg',
+        size: 0,
+        path: '/tmp/grammar.cfg',
+      );
+
+      final result = await loadGrammarFromPlatformFile(service, file);
+
+      expect(result, isA<Success<Grammar>>());
+      expect(service.grammarBytesCalls, 0);
+      expect(service.grammarPathCalls, 1);
+    });
+
+    test('returns failure when neither bytes nor path are provided', () async {
+      final file = PlatformFile(
+        name: 'grammar.cfg',
+        size: 0,
+      );
+
+      final result = await loadGrammarFromPlatformFile(service, file);
+
+      expect(result, isA<Failure<Grammar>>());
+      expect(service.grammarBytesCalls, 0);
+      expect(service.grammarPathCalls, 0);
+    });
+  });
+}
+
+class _RecordingFileOperationsService extends FileOperationsService {
+  _RecordingFileOperationsService({
+    FSA? automaton,
+    Grammar? grammar,
+  })  : _automaton = automaton,
+        _grammar = grammar;
+
+  final FSA? _automaton;
+  final Grammar? _grammar;
+
+  int bytesCalls = 0;
+  int pathCalls = 0;
+  int grammarBytesCalls = 0;
+  int grammarPathCalls = 0;
+
+  @override
+  Future<Result<FSA>> loadAutomatonFromBytes(Uint8List bytes) async {
+    bytesCalls += 1;
+    if (_automaton != null) {
+      return Success(_automaton!);
+    }
+    return const Failure('No automaton configured');
+  }
+
+  @override
+  Future<Result<FSA>> loadAutomatonFromJFLAP(String filePath) async {
+    pathCalls += 1;
+    if (_automaton != null) {
+      return Success(_automaton!);
+    }
+    return const Failure('No automaton configured');
+  }
+
+  @override
+  Future<Result<Grammar>> loadGrammarFromBytes(Uint8List bytes) async {
+    grammarBytesCalls += 1;
+    if (_grammar != null) {
+      return Success(_grammar!);
+    }
+    return const Failure('No grammar configured');
+  }
+
+  @override
+  Future<Result<Grammar>> loadGrammarFromJFLAP(String filePath) async {
+    grammarPathCalls += 1;
+    if (_grammar != null) {
+      return Success(_grammar!);
+    }
+    return const Failure('No grammar configured');
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared platform file loader to prioritize in-memory data and inject file services into the panels
- enable FileOperationsPanel and AlgorithmPanel to support web download flows and web-friendly messaging
- implement web download handling inside FileOperationsService for XML/SVG exports and cover the loaders with widget-level unit tests

## Testing
- `flutter test test/presentation/widgets/utils/platform_file_loader_test.dart` *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e91a1a7fdc832eb219025c3948888e