### PR TITLE
Implement production error handling widgets

### DIFF
--- a/lib/presentation/widgets/error_banner.dart
+++ b/lib/presentation/widgets/error_banner.dart
@@ -1,83 +1,238 @@
-import 'package:flutter/material.dart' hide ButtonStyle;
+import 'package:flutter/material.dart';
 
 import 'retry_button.dart';
 
-/// Inline banner that communicates import or execution failures.
-class ErrorBanner extends StatelessWidget {
-  const ErrorBanner({
-    super.key,
-    required this.message,
-    this.onRetry,
-    this.onDismiss,
+/// Severity levels supported by [ErrorBanner].
+enum ErrorSeverity {
+  /// Critical failure that requires immediate attention.
+  error,
+
+  /// Recoverable issue that should be addressed soon.
+  warning,
+
+  /// Informational notice that does not block the workflow.
+  info,
+}
+
+class _SeverityVisuals {
+  const _SeverityVisuals({
+    required this.background,
+    required this.foreground,
+    required this.border,
+    required this.icon,
+    required this.semanticsLabel,
   });
 
-  /// Error message displayed in the banner body.
+  final Color background;
+  final Color foreground;
+  final Color border;
+  final IconData icon;
+  final String semanticsLabel;
+}
+
+const Map<ErrorSeverity, _SeverityVisuals> _severityVisuals = {
+  ErrorSeverity.error: _SeverityVisuals(
+    background: Color(0xFFFFEBEE),
+    foreground: Color(0xFFC62828),
+    border: Color(0xFFB71C1C),
+    icon: Icons.error_outline,
+    semanticsLabel: 'Error banner',
+  ),
+  ErrorSeverity.warning: _SeverityVisuals(
+    background: Color(0xFFFFF3E0),
+    foreground: Color(0xFFE65100),
+    border: Color(0xFFEF6C00),
+    icon: Icons.warning_amber_rounded,
+    semanticsLabel: 'Warning banner',
+  ),
+  ErrorSeverity.info: _SeverityVisuals(
+    background: Color(0xFFE3F2FD),
+    foreground: Color(0xFF1976D2),
+    border: Color(0xFF1565C0),
+    icon: Icons.info_outline,
+    semanticsLabel: 'Info banner',
+  ),
+};
+
+/// Inline banner that communicates recoverable issues without hiding content.
+class ErrorBanner extends StatelessWidget {
+  ErrorBanner({
+    super.key,
+    required this.message,
+    required ErrorSeverity severity,
+    bool? showRetryButton,
+    this.showDismissButton = true,
+    this.onRetry,
+    this.onDismiss,
+    this.icon,
+  })  : assert(message.trim().isNotEmpty, 'message must not be empty'),
+        severity = severity,
+        showRetryButton = showRetryButton ?? (severity != ErrorSeverity.info),
+        assert(
+          !showRetryButton || onRetry != null,
+          'onRetry must be provided when showRetryButton is true',
+        ),
+        assert(
+          !showDismissButton || onDismiss != null,
+          'onDismiss must be provided when showDismissButton is true',
+        );
+
+  /// Text communicated to the user about the failure.
   final String message;
 
-  /// Optional callback triggered when the user selects the retry action.
+  /// Determines the colour palette and icon.
+  final ErrorSeverity severity;
+
+  /// Whether to render the retry action.
+  final bool showRetryButton;
+
+  /// Whether to render the dismiss action.
+  final bool showDismissButton;
+
+  /// Invoked when the retry action is pressed.
   final VoidCallback? onRetry;
 
-  /// Optional callback triggered when the user dismisses the banner.
+  /// Invoked when the dismiss action is pressed.
   final VoidCallback? onDismiss;
 
-  bool get _showActions => onRetry != null || onDismiss != null;
+  /// Optional icon override.
+  final IconData? icon;
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
-    final textTheme = theme.textTheme;
+    final visuals = _severityVisuals[severity]!;
 
-    return Material(
-      color: Colors.transparent,
-      child: Container(
-        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
-        decoration: BoxDecoration(
-          color: colorScheme.errorContainer,
-          borderRadius: BorderRadius.circular(12),
-          border: Border.all(color: colorScheme.error.withOpacity(0.5)),
-        ),
-        child: Row(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Icon(Icons.error, color: colorScheme.error),
-            const SizedBox(width: 12),
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text(
-                    message,
-                    style: textTheme.bodyMedium?.copyWith(
-                      color: colorScheme.onErrorContainer,
-                    ),
+    return Semantics(
+      container: true,
+      label: visuals.semanticsLabel,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          final isCompact = constraints.maxWidth < 600;
+          final padding = EdgeInsets.symmetric(
+            horizontal: isCompact ? 12 : 16,
+            vertical: isCompact ? 12 : 16,
+          );
+
+          final Widget content = isCompact
+              ? _buildVerticalContent(context, visuals, padding)
+              : _buildHorizontalContent(context, visuals, padding);
+
+          return DecoratedBox(
+            decoration: BoxDecoration(
+              color: visuals.background,
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: visuals.border),
+            ),
+            child: content,
+          );
+        },
+      ),
+    );
+  }
+
+  Widget _buildHorizontalContent(
+    BuildContext context,
+    _SeverityVisuals visuals,
+    EdgeInsets padding,
+  ) {
+    return Padding(
+      padding: padding,
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          Icon(icon ?? visuals.icon, color: visuals.foreground),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Text(
+              message,
+              style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                    color: visuals.foreground,
                   ),
-                  if (_showActions) ...[
-                    const SizedBox(height: 12),
-                    Wrap(
-                      spacing: 8,
-                      runSpacing: 8,
-                      children: [
-                        if (onRetry != null)
-                          RetryButton(
-                            onPressed: onRetry,
-                            style: ButtonStyle.secondary,
-                          ),
-                        if (onDismiss != null)
-                          TextButton.icon(
-                            onPressed: onDismiss,
-                            icon: const Icon(Icons.close, size: 18),
-                            label: const Text('Dismiss'),
-                          ),
-                      ],
-                    ),
-                  ],
-                ],
+            ),
+          ),
+          if (showRetryButton || showDismissButton)
+            const SizedBox(width: 12),
+          if (showRetryButton || showDismissButton)
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              crossAxisAlignment: WrapCrossAlignment.center,
+              children: [
+                if (showRetryButton)
+                  RetryButton(
+                    onPressed: onRetry!,
+                    label: 'Retry',
+                  ),
+                if (showDismissButton)
+                  _DismissButton(onDismiss: onDismiss!),
+              ],
+            ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildVerticalContent(
+    BuildContext context,
+    _SeverityVisuals visuals,
+    EdgeInsets padding,
+  ) {
+    return Padding(
+      padding: padding,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Icon(icon ?? visuals.icon, color: visuals.foreground),
+              const SizedBox(width: 12),
+              Expanded(
+                child: Text(
+                  message,
+                  style: Theme.of(context).textTheme.bodyMedium?.copyWith(
+                        color: visuals.foreground,
+                      ),
+                ),
               ),
+            ],
+          ),
+          if (showRetryButton || showDismissButton) ...[
+            const SizedBox(height: 12),
+            Wrap(
+              spacing: 8,
+              runSpacing: 8,
+              children: [
+                if (showRetryButton)
+                  RetryButton(
+                    onPressed: onRetry!,
+                    label: 'Retry',
+                  ),
+                if (showDismissButton)
+                  _DismissButton(onDismiss: onDismiss!),
+              ],
             ),
           ],
-        ),
+        ],
+      ),
+    );
+  }
+}
+
+class _DismissButton extends StatelessWidget {
+  const _DismissButton({required this.onDismiss});
+
+  final VoidCallback onDismiss;
+
+  @override
+  Widget build(BuildContext context) {
+    return Semantics(
+      label: 'Dismiss message',
+      button: true,
+      child: TextButton.icon(
+        onPressed: onDismiss,
+        icon: const Icon(Icons.close, size: 18),
+        label: const Text('Dismiss'),
       ),
     );
   }

--- a/lib/presentation/widgets/import_error_dialog.dart
+++ b/lib/presentation/widgets/import_error_dialog.dart
@@ -1,76 +1,263 @@
-import 'package:flutter/material.dart' hide ButtonStyle;
+import 'package:flutter/material.dart';
 
 import 'retry_button.dart';
 
-/// Dialog used to present detailed information about an import failure.
+/// Types of import errors surfaced by [ImportErrorDialog].
+enum ImportErrorType {
+  malformedJFF,
+  invalidJSON,
+  unsupportedVersion,
+  corruptedData,
+  invalidAutomaton,
+}
+
+class _ErrorDialogVisuals {
+  const _ErrorDialogVisuals({
+    required this.title,
+    required this.icon,
+    required this.color,
+  });
+
+  final String title;
+  final IconData icon;
+  final Color color;
+}
+
+const Map<ImportErrorType, _ErrorDialogVisuals> _dialogVisuals = {
+  ImportErrorType.malformedJFF: _ErrorDialogVisuals(
+    title: 'Malformed JFLAP File',
+    icon: Icons.topic_outlined,
+    color: Color(0xFFC62828),
+  ),
+  ImportErrorType.invalidJSON: _ErrorDialogVisuals(
+    title: 'Invalid JSON Structure',
+    icon: Icons.code_off,
+    color: Color(0xFFE65100),
+  ),
+  ImportErrorType.unsupportedVersion: _ErrorDialogVisuals(
+    title: 'Unsupported File Version',
+    icon: Icons.update_disabled,
+    color: Color(0xFF1565C0),
+  ),
+  ImportErrorType.corruptedData: _ErrorDialogVisuals(
+    title: 'Corrupted Data Detected',
+    icon: Icons.bug_report_outlined,
+    color: Color(0xFFD84315),
+  ),
+  ImportErrorType.invalidAutomaton: _ErrorDialogVisuals(
+    title: 'Invalid Automaton Definition',
+    icon: Icons.device_hub,
+    color: Color(0xFF6A1B9A),
+  ),
+};
+
+/// Dialog explaining why an import failed and how the user can recover.
 class ImportErrorDialog extends StatelessWidget {
   const ImportErrorDialog({
     super.key,
-    required this.title,
-    required this.message,
-    required this.details,
+    required this.fileName,
+    required this.errorType,
+    required this.detailedMessage,
+    this.technicalDetails,
+    this.showTechnicalDetails = false,
     required this.onRetry,
     required this.onCancel,
-  });
+  })  : assert(fileName != '', 'fileName must not be empty'),
+        assert(detailedMessage.trim().isNotEmpty,
+            'detailedMessage must not be empty');
 
-  /// Short title describing the failure (displayed in the dialog header).
-  final String title;
+  /// Name of the file the user attempted to import.
+  final String fileName;
 
-  /// Friendly explanation displayed at the top of the dialog content.
-  final String message;
+  /// Categorisation of the failure.
+  final ImportErrorType errorType;
 
-  /// Additional technical information intended to help the user resolve the
-  /// issue.
-  final String details;
+  /// Friendly explanation of the failure.
+  final String detailedMessage;
 
-  /// Callback triggered when the user decides to retry the import.
+  /// Optional technical stack trace or parser message.
+  final String? technicalDetails;
+
+  /// Whether the details section starts expanded.
+  final bool showTechnicalDetails;
+
+  /// Invoked when the user elects to retry the import.
   final VoidCallback onRetry;
 
-  /// Callback triggered when the user dismisses the dialog.
+  /// Invoked when the user cancels the flow.
   final VoidCallback onCancel;
+
+  bool get _hasTechnicalDetails =>
+      technicalDetails != null && technicalDetails!.trim().isNotEmpty;
+
+  @override
+  Widget build(BuildContext context) {
+    final visuals = _dialogVisuals[errorType]!;
+    final theme = Theme.of(context);
+
+    return Semantics(
+      namesRoute: true,
+      label: 'Import error dialog',
+      child: AlertDialog(
+        clipBehavior: Clip.antiAlias,
+        insetPadding: const EdgeInsets.symmetric(horizontal: 24, vertical: 24),
+        titlePadding: const EdgeInsets.fromLTRB(24, 24, 24, 16),
+        contentPadding: const EdgeInsets.fromLTRB(24, 0, 24, 0),
+        actionsPadding: const EdgeInsets.fromLTRB(24, 12, 24, 20),
+        title: _DialogTitle(visuals: visuals),
+        content: ConstrainedBox(
+          constraints: const BoxConstraints(maxWidth: 500),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              _FileChip(fileName: fileName, color: visuals.color),
+              const SizedBox(height: 16),
+              Text(
+                detailedMessage,
+                style: theme.textTheme.bodyMedium,
+              ),
+              if (_hasTechnicalDetails) ...[
+                const SizedBox(height: 16),
+                _TechnicalDetailsSection(
+                  details: technicalDetails!,
+                  initiallyExpanded: showTechnicalDetails,
+                ),
+              ],
+            ],
+          ),
+        ),
+        actions: [
+          Semantics(
+            label: 'Cancel import',
+            button: true,
+            child: TextButton(
+              onPressed: onCancel,
+              child: const Text('Cancel'),
+            ),
+          ),
+          RetryButton(onPressed: onRetry),
+        ],
+      ),
+    );
+  }
+}
+
+class _DialogTitle extends StatelessWidget {
+  const _DialogTitle({required this.visuals});
+
+  final _ErrorDialogVisuals visuals;
 
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
-    final colorScheme = theme.colorScheme;
 
-    return AlertDialog(
-      title: Row(
-        crossAxisAlignment: CrossAxisAlignment.center,
-        children: [
-          Icon(Icons.error_outline, color: colorScheme.error),
-          const SizedBox(width: 8),
-          Expanded(
-            child: Text(
-              title,
-              style: theme.textTheme.titleMedium,
+    return Row(
+      crossAxisAlignment: CrossAxisAlignment.center,
+      children: [
+        Icon(visuals.icon, size: 48, color: visuals.color),
+        const SizedBox(width: 12),
+        Expanded(
+          child: Text(
+            visuals.title,
+            style: theme.textTheme.headlineSmall?.copyWith(
+              color: visuals.color,
+              fontWeight: FontWeight.w600,
             ),
           ),
-        ],
-      ),
-      content: Column(
-        mainAxisSize: MainAxisSize.min,
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Text(
-            message,
-            style: theme.textTheme.bodyMedium,
-          ),
-          const SizedBox(height: 12),
-          Text(
-            details,
-            style: theme.textTheme.bodySmall?.copyWith(
-              color: colorScheme.onSurfaceVariant,
-            ),
-          ),
-        ],
-      ),
-      actions: [
-        TextButton(
-          onPressed: onCancel,
-          child: const Text('Cancel'),
         ),
-        RetryButton(onPressed: onRetry),
+      ],
+    );
+  }
+}
+
+class _FileChip extends StatelessWidget {
+  const _FileChip({required this.fileName, required this.color});
+
+  final String fileName;
+  final Color color;
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withOpacity(0.08),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(color: color.withOpacity(0.4)),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(Icons.insert_drive_file_outlined, size: 20, color: color),
+          const SizedBox(width: 8),
+          Flexible(
+            child: Text(
+              fileName,
+              style: Theme.of(context)
+                  .textTheme
+                  .bodyMedium
+                  ?.copyWith(color: color),
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _TechnicalDetailsSection extends StatefulWidget {
+  const _TechnicalDetailsSection({
+    required this.details,
+    required this.initiallyExpanded,
+  });
+
+  final String details;
+  final bool initiallyExpanded;
+
+  @override
+  State<_TechnicalDetailsSection> createState() =>
+      _TechnicalDetailsSectionState();
+}
+
+class _TechnicalDetailsSectionState extends State<_TechnicalDetailsSection> {
+  late bool _expanded = widget.initiallyExpanded;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final borderColor = theme.colorScheme.outlineVariant;
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        TextButton.icon(
+          onPressed: () => setState(() => _expanded = !_expanded),
+          icon: Icon(_expanded ? Icons.expand_less : Icons.expand_more),
+          label: Text(_expanded ? 'Hide technical details' : 'View technical details'),
+        ),
+        AnimatedCrossFade(
+          firstChild: const SizedBox.shrink(),
+          secondChild: Container(
+            width: double.infinity,
+            padding: const EdgeInsets.all(12),
+            decoration: BoxDecoration(
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: borderColor),
+              color: theme.colorScheme.surfaceVariant,
+            ),
+            child: SingleChildScrollView(
+              child: Text(
+                widget.details,
+                style: theme.textTheme.bodySmall,
+              ),
+            ),
+          ),
+          crossFadeState:
+              _expanded ? CrossFadeState.showSecond : CrossFadeState.showFirst,
+          duration: const Duration(milliseconds: 200),
+        ),
       ],
     );
   }


### PR DESCRIPTION
## Summary
- implement the ErrorBanner widget with severity-driven visuals, responsive layouting, and accessibility hooks per the UI contract
- add an ImportErrorDialog that surfaces file metadata, recovery actions, and optional technical detail expansion
- replace RetryButton with the contract-compliant action control and update the UX error handling test suite to use the real widgets

## Testing
- flutter test test/widget/presentation/ux_error_handling_test.dart *(not run: `flutter` command unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e91a20c90c832e9039aa633da86bc1