### PR TITLE
Add integration test for automaton simulation

### DIFF
--- a/integration_test/app_simulation_test.dart
+++ b/integration_test/app_simulation_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:jflutter/main.dart' as app;
+import 'package:jflutter/data/data_sources/examples_asset_data_source.dart';
+import 'package:jflutter/presentation/providers/automaton_provider.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+void main() {
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  testWidgets('loads example and runs simulations', (tester) async {
+    SharedPreferences.setMockInitialValues(const {});
+
+    await app.main();
+    await tester.pumpAndSettle();
+
+    final providerScopeFinder = find.byType(ProviderScope);
+    expect(
+      providerScopeFinder,
+      findsOneWidget,
+      reason: 'The root ProviderScope should be available for dependency access.',
+    );
+
+    final container = ProviderScope.containerOf(
+      tester.element(providerScopeFinder),
+      listen: false,
+    );
+
+    final examplesDataSource = ExamplesAssetDataSource();
+    final exampleResult = await examplesDataSource.loadExample('AFD - Termina com A');
+    expect(
+      exampleResult.isSuccess,
+      isTrue,
+      reason: exampleResult.error ?? 'Expected example to load successfully.',
+    );
+
+    final automaton = exampleResult.data?.automaton;
+    expect(automaton, isNotNull, reason: 'The loaded example should contain an automaton.');
+
+    container.read(automatonProvider.notifier).replaceCurrentAutomaton(automaton!);
+    await tester.pumpAndSettle();
+
+    // Open the simulation sheet through the quick action.
+    final simulateAction = find.byTooltip('Simulate').first;
+    await tester.tap(simulateAction);
+    await tester.pumpAndSettle();
+
+    final inputField = find.bySemanticsLabel('Input String');
+    expect(inputField, findsOneWidget);
+
+    Future<void> runSimulation(String input, String expectedLabel) async {
+      await tester.enterText(inputField, input);
+      await tester.pumpAndSettle();
+
+      final simulateButton = find.widgetWithText(ElevatedButton, 'Simulate');
+      expect(simulateButton, findsOneWidget);
+
+      await tester.tap(simulateButton);
+      await tester.pumpAndSettle();
+
+      expect(find.text(expectedLabel), findsOneWidget);
+    }
+
+    await runSimulation('ba', 'Accepted');
+    await runSimulation('bb', 'Rejected');
+  });
+}

--- a/integration_test/driver.dart
+++ b/integration_test/driver.dart
@@ -1,0 +1,3 @@
+import 'package:integration_test/integration_test_driver.dart';
+
+Future<void> main() => integrationDriver();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -86,6 +86,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  integration_test:
+    sdk: flutter
   test: ^1.24.0
   shared_preferences_platform_interface: ^2.4.1
 


### PR DESCRIPTION
## Summary
- add the Flutter integration_test dependency and driver scaffold
- create an end-to-end test that loads an automaton example and verifies accepted and rejected simulation runs

## Testing
- `flutter test integration_test` *(fails: Flutter SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e91e28aa60832ebed2b5991c871cd3