### PR TITLE
Improve file operations panel error handling

### DIFF
--- a/lib/presentation/widgets/file_operations_panel.dart
+++ b/lib/presentation/widgets/file_operations_panel.dart
@@ -19,6 +19,8 @@ import '../../core/models/grammar.dart';
 import '../../core/result.dart';
 import '../../data/services/file_operations_service.dart';
 import 'utils/platform_file_loader.dart';
+import 'error_banner.dart';
+import 'import_error_dialog.dart';
 
 /// Panel for file operations (save/load/export)
 class FileOperationsPanel extends StatefulWidget {
@@ -41,9 +43,23 @@ class FileOperationsPanel extends StatefulWidget {
   State<FileOperationsPanel> createState() => _FileOperationsPanelState();
 }
 
+class _PanelFeedback {
+  const _PanelFeedback({
+    required this.message,
+    required this.severity,
+    this.canRetry = false,
+  });
+
+  final String message;
+  final ErrorSeverity severity;
+  final bool canRetry;
+}
+
 class _FileOperationsPanelState extends State<FileOperationsPanel> {
   late final FileOperationsService _fileService;
   bool _isLoading = false;
+  _PanelFeedback? _feedback;
+  Future<void> Function()? _pendingRetry;
 
   @override
   void initState() {
@@ -59,6 +75,17 @@ class _FileOperationsPanelState extends State<FileOperationsPanel> {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
+            if (_feedback != null) ...[
+              ErrorBanner(
+                message: _feedback!.message,
+                severity: _feedback!.severity,
+                showRetryButton: _feedback!.canRetry && !_isLoading,
+                onRetry:
+                    _feedback!.canRetry && !_isLoading ? _retryLastOperation : null,
+                onDismiss: _dismissFeedback,
+              ),
+              const SizedBox(height: 16),
+            ],
             Text(
               'File Operations',
               style: Theme.of(context).textTheme.titleLarge,
@@ -189,11 +216,18 @@ class _FileOperationsPanelState extends State<FileOperationsPanel> {
             : 'Automaton saved successfully';
         _showSuccessMessage(successMessage);
       } else {
-        _showErrorMessage('Failed to save automaton: ${saveResult.error}');
+        _showErrorMessage(
+          'Failed to save automaton: ${saveResult.error}',
+          retryOperation: _saveAutomatonAsJFLAP,
+        );
       }
     } catch (e) {
-      _showErrorMessage('Error saving automaton: $e');
+      _showErrorMessage(
+        'Error saving automaton: $e',
+        retryOperation: _saveAutomatonAsJFLAP,
+      );
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }
@@ -220,12 +254,22 @@ class _FileOperationsPanelState extends State<FileOperationsPanel> {
           widget.onAutomatonLoaded?.call(loadResult.data!);
           _showSuccessMessage('Automaton loaded successfully');
         } else {
-          _showErrorMessage('Failed to load automaton: ${loadResult.error}');
+          await _handleImportFailure(
+            fileName: file.name,
+            errorMessage: loadResult.error ?? 'Unknown error',
+            retryOperation: _loadAutomatonFromJFLAP,
+          );
         }
       }
-    } catch (e) {
-      _showErrorMessage('Error loading automaton: $e');
+    } catch (e, stackTrace) {
+      await _handleImportFailure(
+        fileName: 'Automaton',
+        errorMessage: 'Error loading automaton: $e',
+        retryOperation: _loadAutomatonFromJFLAP,
+        stackTrace: stackTrace,
+      );
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }
@@ -268,11 +312,16 @@ class _FileOperationsPanelState extends State<FileOperationsPanel> {
       } else {
         _showErrorMessage(
           'Failed to export automaton: ${exportResult.error}',
+          retryOperation: _exportAutomatonAsSVG,
         );
       }
     } catch (e) {
-      _showErrorMessage('Error exporting automaton: $e');
+      _showErrorMessage(
+        'Error exporting automaton: $e',
+        retryOperation: _exportAutomatonAsSVG,
+      );
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }
@@ -317,11 +366,18 @@ class _FileOperationsPanelState extends State<FileOperationsPanel> {
             : 'Grammar saved successfully';
         _showSuccessMessage(successMessage);
       } else {
-        _showErrorMessage('Failed to save grammar: ${saveResult.error}');
+        _showErrorMessage(
+          'Failed to save grammar: ${saveResult.error}',
+          retryOperation: _saveGrammarAsJFLAP,
+        );
       }
     } catch (e) {
-      _showErrorMessage('Error saving grammar: $e');
+      _showErrorMessage(
+        'Error saving grammar: $e',
+        retryOperation: _saveGrammarAsJFLAP,
+      );
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }
@@ -348,25 +404,199 @@ class _FileOperationsPanelState extends State<FileOperationsPanel> {
           widget.onGrammarLoaded?.call(loadResult.data!);
           _showSuccessMessage('Grammar loaded successfully');
         } else {
-          _showErrorMessage('Failed to load grammar: ${loadResult.error}');
+          await _handleImportFailure(
+            fileName: file.name,
+            errorMessage: loadResult.error ?? 'Unknown error',
+            retryOperation: _loadGrammarFromJFLAP,
+          );
         }
       }
-    } catch (e) {
-      _showErrorMessage('Error loading grammar: $e');
+    } catch (e, stackTrace) {
+      await _handleImportFailure(
+        fileName: 'Grammar',
+        errorMessage: 'Error loading grammar: $e',
+        retryOperation: _loadGrammarFromJFLAP,
+        stackTrace: stackTrace,
+      );
     } finally {
+      if (!mounted) return;
       setState(() => _isLoading = false);
     }
   }
 
-  void _showSuccessMessage(String message) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message), backgroundColor: Colors.green),
+  Future<void> _handleImportFailure({
+    required String fileName,
+    required String errorMessage,
+    required Future<void> Function() retryOperation,
+    StackTrace? stackTrace,
+  }) async {
+    final trimmedMessage = errorMessage.trim();
+    final isCritical = _isCriticalImportError(trimmedMessage);
+
+    if (isCritical) {
+      await _showImportErrorDialog(
+        fileName: fileName,
+        errorMessage: trimmedMessage,
+        retryOperation: retryOperation,
+        stackTrace: stackTrace,
+      );
+    } else {
+      _showErrorMessage(
+        trimmedMessage,
+        retryOperation: retryOperation,
+      );
+    }
+  }
+
+  Future<void> _showImportErrorDialog({
+    required String fileName,
+    required String errorMessage,
+    required Future<void> Function() retryOperation,
+    StackTrace? stackTrace,
+  }) async {
+    _pendingRetry = retryOperation;
+
+    final errorType = _resolveImportErrorType(errorMessage);
+    final friendlyMessage = _friendlyMessageFor(errorType);
+    final technicalDetails = _composeTechnicalDetails(errorMessage, stackTrace);
+
+    if (!mounted) return;
+
+    setState(() {
+      _isLoading = false;
+      _feedback = null;
+    });
+
+    await showDialog<void>(
+      context: context,
+      builder: (dialogContext) {
+        return ImportErrorDialog(
+          fileName: fileName,
+          errorType: errorType,
+          detailedMessage: friendlyMessage,
+          technicalDetails: technicalDetails,
+          showTechnicalDetails: technicalDetails != null,
+          onRetry: () {
+            Navigator.of(dialogContext).pop();
+            _retryLastOperation();
+          },
+          onCancel: () {
+            Navigator.of(dialogContext).pop();
+            _dismissFeedback();
+          },
+        );
+      },
     );
   }
 
-  void _showErrorMessage(String message) {
-    ScaffoldMessenger.of(context).showSnackBar(
-      SnackBar(content: Text(message), backgroundColor: Colors.red),
-    );
+  String? _composeTechnicalDetails(String message, StackTrace? stackTrace) {
+    if (message.isEmpty && stackTrace == null) {
+      return null;
+    }
+
+    if (stackTrace == null) {
+      return message;
+    }
+
+    final buffer = StringBuffer(message);
+    buffer
+      ..writeln()
+      ..writeln(stackTrace.toString());
+    return buffer.toString();
+  }
+
+  ImportErrorType _resolveImportErrorType(String message) {
+    final normalized = message.toLowerCase();
+
+    if (normalized.contains('xml') || normalized.contains('parse')) {
+      return ImportErrorType.malformedJFF;
+    }
+    if (normalized.contains('json')) {
+      return ImportErrorType.invalidJSON;
+    }
+    if (normalized.contains('version')) {
+      return ImportErrorType.unsupportedVersion;
+    }
+    if (normalized.contains('corrupt') ||
+        normalized.contains('unreadable') ||
+        normalized.contains('selected file did not contain readable data')) {
+      return ImportErrorType.corruptedData;
+    }
+    return ImportErrorType.invalidAutomaton;
+  }
+
+  String _friendlyMessageFor(ImportErrorType type) {
+    switch (type) {
+      case ImportErrorType.malformedJFF:
+        return 'The selected JFLAP file could not be parsed. Please verify the file integrity and try again.';
+      case ImportErrorType.invalidJSON:
+        return 'The import contains JSON sections that are invalid. Fix the JSON structure and retry.';
+      case ImportErrorType.unsupportedVersion:
+        return 'This file targets a newer JFLAP schema version. Export it again using a compatible version and retry.';
+      case ImportErrorType.corruptedData:
+        return 'The file appears to be corrupted or unreadable. Restore a valid backup before importing again.';
+      case ImportErrorType.invalidAutomaton:
+        return 'The automaton definition is inconsistent. Review the transitions and states before retrying the import.';
+    }
+  }
+
+  bool _isCriticalImportError(String message) {
+    final normalized = message.toLowerCase();
+    return normalized.contains('xml') ||
+        normalized.contains('parse') ||
+        normalized.contains('malformed') ||
+        normalized.contains('invalid json') ||
+        normalized.contains('corrupt') ||
+        normalized.contains('unreadable');
+  }
+
+  void _showSuccessMessage(String message) {
+    if (!mounted) return;
+
+    setState(() {
+      _feedback = _PanelFeedback(
+        message: message,
+        severity: ErrorSeverity.info,
+      );
+    });
+    _pendingRetry = null;
+  }
+
+  void _showErrorMessage(
+    String message, {
+    Future<void> Function()? retryOperation,
+  }) {
+    if (!mounted) return;
+
+    setState(() {
+      _feedback = _PanelFeedback(
+        message: message,
+        severity: ErrorSeverity.error,
+        canRetry: retryOperation != null,
+      );
+    });
+    _pendingRetry = retryOperation;
+  }
+
+  void _retryLastOperation() {
+    final retryOperation = _pendingRetry;
+    if (retryOperation == null || _isLoading) {
+      return;
+    }
+
+    setState(() {
+      _feedback = null;
+    });
+
+    retryOperation();
+  }
+
+  void _dismissFeedback() {
+    if (!mounted) return;
+
+    setState(() {
+      _feedback = null;
+    });
+    _pendingRetry = null;
   }
 }

--- a/specs/003-ui-improvement-taskforce/quickstart.md
+++ b/specs/003-ui-improvement-taskforce/quickstart.md
@@ -161,28 +161,28 @@ flutter run -d chrome
 
 ### ✅ Section 4: Error Handling Widgets
 
-#### 4.1 ErrorBanner - Import Error
-- [ ] Attempt to import invalid file: `invalid_automaton.jff`
-- [ ] Verify ErrorBanner appears:
+#### 4.1 File Operations Panel - Recoverable Failure
+- [ ] Trigger a recoverable error (ex.: export automaton to read-only path)
+- [ ] Verify inline ErrorBanner appears inside the panel:
   - Red background (#FFEBEE)
   - Error icon (left)
-  - Message: "Import failed: malformed JFLAP file"
-  - Retry button (right)
-  - Dismiss button (X icon, far right)
-- [ ] Verify banner inline (above canvas or in panel)
-- [ ] Verify user context preserved (stays on same screen)
+  - Message explaining the failure (no modal shown)
+  - Retry button (uses global RetryButton styling)
+  - Dismiss button (X icon)
+- [ ] Tap "Retry" and confirm the operation is attempted again
+- [ ] After success, verify the banner flips to informational blue with the success copy
 
-#### 4.2 ImportErrorDialog
-- [ ] Tap "Retry" on error banner
-- [ ] Verify ImportErrorDialog appears:
+#### 4.2 ImportErrorDialog - Critical Failure
+- [ ] Attempt to import malformed file: `invalid_automaton.jff`
+- [ ] Verify ImportErrorDialog opens immediately (no inline banner):
   - Modal (blocks background)
-  - Title: "Import Error"
-  - Filename shown
-  - Detailed message
-  - Cancel and Retry buttons
+  - Title contextualised to the failure type
+  - Filename shown in chip
+  - Detailed recovery guidance + technical details toggle
+  - Cancel and Retry buttons wired to RetryButton styling
 - [ ] Tap outside dialog (verify not dismissible)
-- [ ] Tap Cancel
-- [ ] Verify dialog closes, returns to previous state
+- [ ] Tap Cancel → dialog closes and panel clears retry state
+- [ ] Re-open and tap Retry → dialog closes, picker reopens, and success banner is rendered after a valid file
 
 #### 4.3 RetryButton States
 - [ ] Find standalone RetryButton (if any, or use in banner)


### PR DESCRIPTION
## Summary
- display inline ErrorBanner feedback and surface ImportErrorDialog for critical failures within the file operations panel while reusing RetryButton callbacks
- extend the UX error handling widget tests with fake file picker/service flows covering recoverable exports and critical imports
- refresh the UI improvement taskforce quickstart to document the new banner-versus-dialog behaviour and retry expectations