### PR TITLE
fix null handling: address Codex review regressions

### DIFF
--- a/lib/presentation/widgets/export/svg_exporter.dart
+++ b/lib/presentation/widgets/export/svg_exporter.dart
@@ -33,7 +33,7 @@ class SvgExporter {
     }
 
     final decimals = value % 1 == 0 ? 0 : 2;
-    var text = value.toStringAsFixed(decimals);var text = value.toStringAsFixed(decimals == 0 ? 0 : 2);
+    var text = value.toStringAsFixed(decimals);
     if (decimals != 0) {
       text = text.replaceFirst(RegExp(r'0+$'), '');
       if (text.endsWith('.')) {

--- a/lib/presentation/widgets/file_operations_panel.dart
+++ b/lib/presentation/widgets/file_operations_panel.dart
@@ -20,7 +20,7 @@ import '../../core/result.dart';
 import '../../data/services/file_operations_service.dart';
 import 'utils/platform_file_loader.dart';
 import 'error_banner.dart';
-// import 'import_error_dialog.dart'; // does not exist yet (TODO)
+import 'import_error_dialog.dart';
 
 /// Panel for file operations (save/load/export)
 class FileOperationsPanel extends StatefulWidget {


### PR DESCRIPTION
## Summary
- ensure `_formatDimension` uses a single assignment when formatting dimensions
- restore the missing `ImportErrorDialog` import in `FileOperationsPanel`

## Testing
- `flutter analyze` *(fails: Flutter SDK unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f54808e140832ea82789e4fa88f0c3