### PR TITLE
Add import error dialog to file operations panel

### DIFF
--- a/lib/presentation/widgets/file_operations_panel.dart
+++ b/lib/presentation/widgets/file_operations_panel.dart
@@ -20,7 +20,7 @@ import '../../core/result.dart';
 import '../../data/services/file_operations_service.dart';
 import 'utils/platform_file_loader.dart';
 import 'error_banner.dart';
-// import 'import_error_dialog.dart'; // does not exist yet (TODO)
+import 'import_error_dialog.dart';
 
 /// Panel for file operations (save/load/export)
 class FileOperationsPanel extends StatefulWidget {


### PR DESCRIPTION
## Summary
- replace the commented placeholder import in `FileOperationsPanel` with the actual `import_error_dialog.dart` module so the dialog can be resolved

## Testing
- dart format lib/presentation/widgets/file_operations_panel.dart *(fails: `dart` command not available in container)*
- flutter test test/widget/presentation/ux_error_handling_test.dart *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68f6439fb390832e9e68506bca96a776