### PR TITLE
Improve mobile navigation semantics

### DIFF
--- a/lib/presentation/widgets/mobile_navigation.dart
+++ b/lib/presentation/widgets/mobile_navigation.dart
@@ -75,32 +75,42 @@ class MobileNavigation extends StatelessWidget {
         ? colorScheme.primary
         : colorScheme.onSurface.withValues(alpha: 0.6);
 
-    return InkWell(
-      onTap: onTap,
-      borderRadius: BorderRadius.circular(12),
-      child: Container(
-        padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(
-              item.icon,
-              color: color,
-              size: 18, // Smaller icons for better fit
+    return FocusableActionDetector(
+      descendantsAreFocusable: false,
+      child: Semantics(
+        button: true,
+        selected: isSelected,
+        hint: item.description,
+        onTap: onTap,
+        child: InkWell(
+          onTap: onTap,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.symmetric(vertical: 6, horizontal: 2),
+            child: Column(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  item.icon,
+                  color: color,
+                  size: 18, // Smaller icons for better fit
+                ),
+                const SizedBox(height: 2),
+                Text(
+                  item.label,
+                  style: Theme.of(context).textTheme.labelSmall?.copyWith(
+                    color: color,
+                    fontWeight:
+                        isSelected ? FontWeight.w600 : FontWeight.normal,
+                    fontSize: 9, // Even smaller text
+                  ),
+                  textAlign: TextAlign.center,
+                  maxLines: 1,
+                  overflow: TextOverflow.ellipsis,
+                ),
+              ],
             ),
-            const SizedBox(height: 2),
-            Text(
-              item.label,
-              style: Theme.of(context).textTheme.labelSmall?.copyWith(
-                color: color,
-                fontWeight: isSelected ? FontWeight.w600 : FontWeight.normal,
-                fontSize: 9, // Even smaller text
-              ),
-              textAlign: TextAlign.center,
-              maxLines: 1,
-              overflow: TextOverflow.ellipsis,
-            ),
-          ],
+          ),
         ),
       ),
     );

--- a/test/widget/presentation/mobile_navigation_semantics_test.dart
+++ b/test/widget/presentation/mobile_navigation_semantics_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:jflutter/presentation/widgets/mobile_navigation.dart';
+
+void main() {
+  testWidgets('navigation item exposes description semantics and selection state', (tester) async {
+    final semantics = SemanticsTester(tester);
+    addTearDown(semantics.dispose);
+
+    const items = [
+      NavigationItem(
+        label: 'Home',
+        icon: Icons.home,
+        description: 'Navigate to the home dashboard',
+      ),
+      NavigationItem(
+        label: 'Settings',
+        icon: Icons.settings,
+        description: 'Open configuration settings',
+      ),
+    ];
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          bottomNavigationBar: MobileNavigation(
+            currentIndex: 1,
+            onTap: (_) {},
+            items: items,
+          ),
+        ),
+      ),
+    );
+
+    await tester.pump();
+
+    final nodes = semantics.nodesWith(
+      hint: items[1].description,
+    );
+
+    expect(nodes, hasLength(1));
+
+    final node = nodes.single;
+    expect(node.hasFlag(SemanticsFlag.isSelected), isTrue);
+    expect(node.hasAction(SemanticsAction.tap), isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- wrap each mobile navigation tile with focus and semantics metadata
- surface navigation descriptions as hints while marking the selected item
- add a widget test that validates the semantics hint, selection flag, and tap action

## Testing
- Not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68f643969160832eb103372a4a16c1e6